### PR TITLE
Reuse TOI for MPD resends

### DIFF
--- a/src/mbstf/Curl.hh
+++ b/src/mbstf/Curl.hh
@@ -28,10 +28,12 @@ MBSTF_NAMESPACE_START
 
 class Curl {
 public:
+    using date_time_type = std::chrono::system_clock::time_point;
+
     Curl();
     ~Curl();
 
-    long get(const std::string& url, std::chrono::milliseconds timeout);
+    long get(const std::string& url, std::chrono::milliseconds timeout, const std::optional<date_time_type> &last_modified = std::nullopt, const std::optional<std::string> &etag = std::nullopt);
     std::vector<unsigned char> &getData();
     const std::vector<unsigned char> &getData() const;
     const std::string &getEtag() const;
@@ -44,6 +46,7 @@ public:
     Curl &setUserAgent(const std::string &user_agent);
 
 private:
+    long __get(const std::string& url, std::chrono::milliseconds timeout, const std::map<std::string,std::string> &request_headers);
     bool extractProtocolAndStatusCode(std::string_view &status_line);
     void processHeaderLine(std::string_view &header_line);
     static size_t headerCallback(char* buffer, size_t size, size_t numberOfItems, void* userData);

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -150,14 +150,14 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
 	    ogs_error("Next Ingest Item: %s", err.what());
 	}
 
-	if(next_ingest_items.second.empty()) break;
+	if (next_ingest_items.second.empty()) break;
 
 	auto fetch_time = next_ingest_items.first; // Get fetch_time using .first
 
 	std::list<PullObjectIngester::IngestItem> urls;
 
         std::list<std::shared_ptr<PullObjectIngester>> &ingesters = controller->getPullObjectIngesters();
-	while(ingesters.size() < next_ingest_items.second.size()) {
+	while (ingesters.size() < next_ingest_items.second.size()) {
 	    controller->addPullObjectIngester(new PullObjectIngester(controller->objectStore(), *controller, urls));
 	}
 
@@ -171,10 +171,10 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
 
         // Add the URLs to the PullObjectIngester instances
         for (auto ingester_it = ingesters.begin(); ingester_it!= ingesters.end(); ++ingester_it) {
-            if(next_ingest_items.second.empty()) break;
+            if (next_ingest_items.second.empty()) break;
             auto ingest_item = next_ingest_items.second.front();
             next_ingest_items.second.pop_front();  // remove the item
-	    ingest_item.deadline(std::nullopt);
+	    //ingest_item.deadline(std::nullopt);
             ingest_item.deadline(std::chrono::system_clock::now() + controller->manifestHandler()->getDefaultDeadline());
             if (!(*ingester_it)->fetch(ingest_item)) {
                 ogs_debug("Failed to fetch item: %s", ingest_item.url().c_str());

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -34,7 +34,6 @@
 #include "PushObjectIngester.hh"
 #include "SubscriptionService.hh"
 #include "ObjectListPackager.hh"
-#include "DASHManifestHandler.hh"
 
 #include "ObjectStreamingController.hh"
 
@@ -110,16 +109,6 @@ void ObjectStreamingController::processEvent(Event &event, SubscriptionService &
 	    } else {
 		std::unique_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
                 manifestHandler(std::move(manifest_handler));
-                /*
-                const ObjectStore::Metadata &metadata = objectStore().getMetadata(objectId);
-                try {
-                    manifestHandler()->validateManifest(object, object_data, metadata);
-                }  catch (std::exception &ex) {
-                    ogs_info("InVALID Manifest Validation: %s", ex.what());
-                    unsetObjectListPackager();
-                    return;
-                }
-                */
                 if (!packager()) {
                     setObjectListPackager();
                 }
@@ -138,27 +127,17 @@ void ObjectStreamingController::processEvent(Event &event, SubscriptionService &
     }
     ObjectManifestController::processEvent(event, event_service);
 }
-/*
-std::string ObjectStreamingController::generateUUID() {
-    uuid_t uuid;
-    uuid_generate_random(uuid);
-    char uuid_str[37];
-    uuid_unparse(uuid, uuid_str);
-    return std::string(uuid_str);
-}
-
-std::string ObjectStreamingController::nextObjectId()
-{
-    return generateUUID();
-}
-*/
 
 const std::optional<std::string> &ObjectStreamingController::getObjectDistributionBaseUrl() const {
     return distributionSession().objectDistributionBaseUrl();
 }
 
 namespace {
-static const struct init { init() {ControllerFactory::registerController(new ControllerConstructor<ObjectStreamingController>);};} g_init;
+static const struct init {
+    init() {
+        ControllerFactory::registerController(new ControllerConstructor<ObjectStreamingController>);
+    };
+} g_init;
 }
 
 static void validate_distribution_session(DistributionSession &distributionSession)
@@ -174,11 +153,6 @@ static bool check_if_object_added_is_manifest(std::string &objectId, ObjectStore
         metadata.keepAfterSend(true);
         return true;
     }
-    /*
-    if (metadata.mediaType() == "application/dash+xml" ){
-	 return true;
-
-    } */
     return false;
 
 }

--- a/src/mbstf/common.cc
+++ b/src/mbstf/common.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <spdlog/spdlog.h>
 #include "ogs-core.h"
 
 int __mbstf_log_domain;
@@ -24,6 +25,7 @@ int __mbstf_log_domain;
 void initialise_logging(void)
 {
     ogs_log_install_domain(&__mbstf_log_domain, "MBSTF", ogs_core()->log.level);
+    //spdlog::set_level(spdlog::level::debug);
 }
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -34,9 +34,10 @@ fiveg_api_release = get_option('fiveg_api_release')
 
 fs = import('fs')
 
-boost_dep = dependency('boost')
-uuid_dep = dependency('uuid')
-libmpdpp_dep = dependency('mpd++', fallback: ['libmpdpp', 'libmpdpp_dep'])
+boost_dep = dependency('boost', required: true)
+uuid_dep = dependency('uuid', required: true)
+zlib_dep = dependency('zlib', required: true)
+libmpdpp_dep = dependency('mpd++', fallback: ['libmpdpp'])
 
 test_source_subscriber_subscription = files('''
   SubscriptionService.cc

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -32,6 +32,12 @@ std::string trim_slashes(const std::string &path)
     return path.substr(start, end - start);
 }
 
+std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime)
+{
+    return std::format("%b, %d %b %Y %T GMT", datetime);
+}
+
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -18,6 +18,7 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <chrono>
 #include <string>
 
 #include "common.hh"
@@ -25,6 +26,8 @@
 MBSTF_NAMESPACE_START
 
 std::string trim_slashes(const std::string &path);
+
+std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 
 MBSTF_NAMESPACE_STOP
 

--- a/subprojects/libmpdpp.wrap
+++ b/subprojects/libmpdpp.wrap
@@ -3,3 +3,5 @@ directory=libmpdpp
 url=https://github.com/bbc/libmpdpp.git
 revision=main
 
+[provide]
+mpd++ = libmpdpp_dep


### PR DESCRIPTION
Uses the new LibFlute::Transmitter::FileDescription objects to track resends of the MPD.