### PR TITLE
Add cause to ProblemDetail in error responses

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-mbs-transport-function', 'c', 'cpp', 
-    version : '1.0.0',
+    version : '1.1.0',
     license : '5G-MAG Public',
     meson_version : '>= 1.4.0',
     default_options : [

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -242,8 +242,8 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                                                      "Error while populating MBSTF Distribution Session");
                                     return true;
                                 } catch (std::exception &err) {
-                                    ogs_error("Error while populating MBSTF Distribution Session: %s", err.what());
-                                    char *error = ogs_msprintf("Bad request: %s", err.what());
+                                    char *error = ogs_msprintf("Error while populating MBSTF Distribution Session: %s", err.what());
+                                    ogs_error("%s", error);
                                     ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message,
                                                                            app_meta, api, "Bad Request", error));
                                     ogs_free(error);

--- a/src/mbstf/NfServer.hh
+++ b/src/mbstf/NfServer.hh
@@ -25,6 +25,7 @@
 
 #include "common.hh"
 #include "openapi/model/CJson.hh"
+#include "openapi/model/ProblemCause.hh"
 
 using fiveg_mag_reftools::CJson;
 
@@ -106,6 +107,15 @@ public:
                           const std::optional<std::map<std::string,std::string> > &invalid_params = std::nullopt,
                           const std::optional<std::string> &problem_type = std::nullopt);
 
+    static bool sendError(Open5GSSBIStream &stream, const fiveg_mag_reftools::ProblemCause &cause, size_t number_of_components,
+                          const Open5GSSBIMessage &message, const AppMetadata &app,
+                          const std::optional<InterfaceMetadata> &interface = std::nullopt,
+                          const std::optional<std::string> &title = std::nullopt,
+                          const std::optional<std::string> &detail = std::nullopt,
+                          const std::optional<CJson> &problem_detail_json = std::nullopt,
+                          const std::optional<std::map<std::string,std::string> > &invalid_params = std::nullopt,
+                          const std::optional<std::string> &problem_type = std::nullopt);
+
     static std::shared_ptr<Open5GSSBIResponse> newResponse(const std::optional<std::string> &location,
                                                            const std::optional<std::string> &content_type,
                                                            const std::optional<time_type> &last_modified,
@@ -117,6 +127,17 @@ public:
     static std::shared_ptr<Open5GSSBIResponse> populateResponse(std::shared_ptr<Open5GSSBIResponse> &response, const std::string &content, int status);
 
     static std::map<std::string, std::string> makeInvalidParams(const std::string &param, const std::string &reason);
+
+private:
+    static bool __sendError(Open5GSSBIStream &stream, int status, const std::optional<fiveg_mag_reftools::ProblemCause> &cause,
+                            size_t number_of_components,
+                            const Open5GSSBIMessage &message, const AppMetadata &app,
+                            const std::optional<InterfaceMetadata> &interface = std::nullopt,
+                            const std::optional<std::string> &title = std::nullopt,
+                            const std::optional<std::string> &detail = std::nullopt,
+                            const std::optional<CJson> &problem_detail_json = std::nullopt,
+                            const std::optional<std::map<std::string,std::string> > &invalid_params = std::nullopt,
+                            const std::optional<std::string> &problem_type = std::nullopt);
 };
 
 MBSTF_NAMESPACE_STOP


### PR DESCRIPTION
This PR uses the new *ProblemCause* objects, defined in the C++ templates in [rt-common-shared](https://github.com/5G-MAG/rt-common-shared) to populate the *cause* field in the *ProblemDetail* JSON object.

This modifies error responses from the MBSTF to include an appropriate *cause* entry from TS 29.500 Table 5.2.7.2-1, and use the associated HTTP status code (also from Table 5.2.7.2-1).

The version of the MBSTF is also bumped to 1.1.0 because this changes the previous API responses.