### PR TITLE
Feature: Status Subscriptions and Notifications

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-mbs-transport-function', 'c', 'cpp', 
-    version : '1.1.0',
+    version : '1.2.0',
     license : '5G-MAG Public',
     meson_version : '>= 1.4.0',
     default_options : [

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -46,7 +46,7 @@ Context::Context()
     ,servers()
     ,cacheControl({60, 60})
     ,totalMaxBitRateSoftLimit(100)
-    ,consecutiveIngestFailuresBeforeAbort(5)
+    ,consecutiveIngestFailuresBeforeDeactivate(5)
 {
 }
 
@@ -114,16 +114,16 @@ bool Context::parseConfig()
                     } else {
                         throw std::out_of_range("Bad configuration node at mbstf.totalMaxBitRateSoftLimit");
                     }
-                } else if (mbstf_key == "consecutiveIngestFailuresBeforeAbort") {
+                } else if (mbstf_key == "consecutiveIngestFailuresBeforeDeactivate") {
                     if (mbstf_iter.type() == YAML_MAPPING_NODE) {
                         std::string num_val(mbstf_iter.value());
                         size_t idx = 0;
-                        consecutiveIngestFailuresBeforeAbort = std::stoi(num_val, &idx);
+                        consecutiveIngestFailuresBeforeDeactivate = std::stoi(num_val, &idx);
                         if (idx != num_val.size()) {
-                            throw std::out_of_range("Bad configuration value at mbstf.consecutiveIngestFailuresBeforeAbort");
+                            throw std::out_of_range("Bad configuration value at mbstf.consecutiveIngestFailuresBeforeDeactivate");
                         }
                     } else {
-                        throw std::out_of_range("Bad configuration node at mbstf.consecutiveIngestFailuresBeforeAbort");
+                        throw std::out_of_range("Bad configuration node at mbstf.consecutiveIngestFailuresBeforeDeactivate");
                     }
                 } else {
                     ogs_warn("Unknown key `mbstf.%s` in configuration", mbstf_key.c_str());

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -46,6 +46,7 @@ Context::Context()
     ,servers()
     ,cacheControl({60, 60})
     ,totalMaxBitRateSoftLimit(100)
+    ,consecutiveIngestFailuresBeforeAbort(5)
 {
 }
 
@@ -112,6 +113,17 @@ bool Context::parseConfig()
                         }
                     } else {
                         throw std::out_of_range("Bad configuration node at mbstf.totalMaxBitRateSoftLimit");
+                    }
+                } else if (mbstf_key == "consecutiveIngestFailuresBeforeAbort") {
+                    if (mbstf_iter.type() == YAML_MAPPING_NODE) {
+                        std::string num_val(mbstf_iter.value());
+                        size_t idx = 0;
+                        consecutiveIngestFailuresBeforeAbort = std::stoi(num_val, &idx);
+                        if (idx != num_val.size()) {
+                            throw std::out_of_range("Bad configuration value at mbstf.consecutiveIngestFailuresBeforeAbort");
+                        }
+                    } else {
+                        throw std::out_of_range("Bad configuration node at mbstf.consecutiveIngestFailuresBeforeAbort");
                     }
                 } else {
                     ogs_warn("Unknown key `mbstf.%s` in configuration", mbstf_key.c_str());

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -70,7 +70,7 @@ public:
         unsigned int defaultObjectMaxAge; // Use if not given by push/pull resource Cache-Control.
     } cacheControl;
     int totalMaxBitRateSoftLimit; // total maximum bit rate this MBSTF ought to asked to handle
-    int consecutiveIngestFailuresBeforeAbort; // The number of consecutive ingest failures allowed before the session aborts
+    int consecutiveIngestFailuresBeforeDeactivate; // The number of consecutive ingest failures allowed before the session aborts
 
 private:
     void parseCacheControl(Open5GSYamlIter &iter);

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -70,6 +70,7 @@ public:
         unsigned int defaultObjectMaxAge; // Use if not given by push/pull resource Cache-Control.
     } cacheControl;
     int totalMaxBitRateSoftLimit; // total maximum bit rate this MBSTF ought to asked to handle
+    int consecutiveIngestFailuresBeforeAbort; // The number of consecutive ingest failures allowed before the session aborts
 
 private:
     void parseCacheControl(Open5GSYamlIter &iter);

--- a/src/mbstf/Controller.cc
+++ b/src/mbstf/Controller.cc
@@ -17,7 +17,7 @@
 MBSTF_NAMESPACE_START
 
 Controller::Controller(DistributionSession &distributionSession)
-    :m_distributionSession(distributionSession)
+    :SubscriptionService(), m_distributionSession(distributionSession)
 {
 }
 

--- a/src/mbstf/Controller.hh
+++ b/src/mbstf/Controller.hh
@@ -13,12 +13,13 @@
  */
 
 #include "common.hh"
+#include "SubscriptionService.hh"
 
 MBSTF_NAMESPACE_START
 
 class DistributionSession;
 
-class Controller { // : public SubscriptionService {
+class Controller : public SubscriptionService {
 public:
     Controller() = delete;
     Controller(DistributionSession &distributionSession);

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -34,7 +34,11 @@
 #include "Context.hh"
 #include "Controller.hh"
 #include "ControllerFactory.hh"
+#include "DistributionSessionEvents.hh"
+#include "DistributionSessionNotificationEvent.hh"
+#include "DistributionSessionSubscription.hh"
 #include "hash.hh"
+#include "LocalEvents.hh"
 #include "MBSTFNetworkFunction.hh"
 #include "ModelParamsException.hh"
 #include "NfServer.hh"
@@ -48,10 +52,14 @@
 #include "Open5GSYamlDocument.hh"
 #include "Open5GSNetworkFunction.hh"
 #include "openapi/model/CreateReqData.h"
+#include "openapi/model/CreateRspData.h"
 #include "openapi/model/DistSession.h"
+#include "openapi/model/DistSessionEventReportList.h"
 #include "openapi/model/DistSessionState.h"
 #include "openapi/model/ObjDistributionData.h"
 #include "openapi/model/ObjAcquisitionMethod.h"
+#include "openapi/model/StatusSubscribeReqData.h"
+#include "openapi/model/StatusSubscribeRspData.h"
 #include "openapi/model/TunnelAddress.h"
 
 #include "openapi/api/IndividualMBSDistributionSessionApi-info.h"
@@ -64,13 +72,18 @@ using fiveg_mag_reftools::CJson;
 using fiveg_mag_reftools::ModelException;
 using fiveg_mag_reftools::ProblemCause;
 using reftools::mbstf::CreateReqData;
+using reftools::mbstf::CreateRspData;
 using reftools::mbstf::DistSession;
 using reftools::mbstf::DistSessionState;
+using reftools::mbstf::DistSessionEventReportList;
+using reftools::mbstf::DistSessionSubscription;
 using reftools::mbstf::IpAddr;
 using reftools::mbstf::ObjDistributionData;
 using reftools::mbstf::UpTrafficFlowInfo;
 using reftools::mbstf::ObjAcquisitionMethod;
 using reftools::mbstf::ObjDistributionOperatingMode;
+using reftools::mbstf::StatusSubscribeReqData;
+using reftools::mbstf::StatusSubscribeRspData;
 using reftools::mbstf::TunnelAddress;
 
 MBSTF_NAMESPACE_START
@@ -92,9 +105,16 @@ static void send_model_params_error(const ModelParamsException &err, Open5GSSBIS
 /**** public: ****/
 
 DistributionSession::DistributionSession(CJson &json, bool as_request)
-    :m_createReqData(std::make_shared<CreateReqData>(json, as_request))
+    :m_createReqData(new CreateReqData(json, as_request))
+    //,m_generated
+    //,m_lastUsed
+    //,m_hash
+    //,m_distributionSessionId
     ,m_controller()
-    //,m_eventSubscriptions()
+    ,m_eventSubscriptions()
+    ,m_currentStateFunction()
+    ,m_eventTimestamps()
+    ,m_subscriptionLocation()
 {
 
     std::shared_ptr<DistSession> distSession = m_createReqData->getDistSession();
@@ -108,12 +128,31 @@ DistributionSession::DistributionSession(CJson &json, bool as_request)
 
 DistributionSession::~DistributionSession()
 {
-    // TODO: if session is in ACTIVE state then send SESSION_DEACTIVED event to any event subscribers that are listening for it.
+    if (!m_eventTimestamps.sessionDeactivated) {
+        _registerEvent(DistributionSessionEvents::SESSION_DEACTIVATED);
+    }
 }
 
-CJson DistributionSession::json(bool as_request = false) const
+CJson DistributionSession::json(bool as_request, bool include_subscription_location) const
 {
-    return m_createReqData->toJSON(as_request);
+    if (as_request) {
+        /* Return original request object as JSON */
+        return m_createReqData->toJSON(as_request);
+    }
+    /* Create new response object from DistSession */
+    std::shared_ptr<DistSession> dist_session(new DistSession(*m_createReqData->getDistSession()));
+    if (include_subscription_location) {
+        /* We need to add the subscription location URI if an original subscription was present */
+        auto &opt_subsc = dist_session->getDistSessionSubscription();
+        if (opt_subsc) {
+            std::shared_ptr<DistSessionSubscription> new_subsc(new DistSessionSubscription(*opt_subsc.value()));
+            new_subsc->setDistSessionSubscUri(m_subscriptionLocation);
+            dist_session->setDistSessionSubscription(new_subsc);
+        }
+    }
+    CreateRspData response{};
+    response.setDistSession(dist_session);
+    return response.toJSON(as_request);
 }
 
 const std::shared_ptr<DistributionSession> &DistributionSession::find(const std::string &id)
@@ -175,161 +214,15 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                 if (ptr_resource0) {
                     std::string resource0(ptr_resource0);
                     if (resource0 == "dist-sessions") {
+                        /* starts with .../dist-sessions... */
                         std::string method(message.method());
                         const char *ptr_resource1 = message.resourceComponent(1);
-                        if (method == OGS_SBI_HTTP_METHOD_POST) {
-                            ogs_debug("POST response: status = %i", message.resStatus());
-                            if (ptr_resource1) {
-                                const char *ptr_resource2 = message.resourceComponent(2);
-                                if (ptr_resource2) {
-                                    std::string subresource(ptr_resource2);
-                                    if (subresource == "subscriptions") {
-                                        /* .../dist-sessions/{distSessionRef}/subscriptions */
-                                        /* TODO: Implement create subscription operation */
-                                        ogs_error("Attempt to use Distribution Session notifications");
-                                        ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_NOT_IMPLEMENTED,
-                                                                       3, message, app_meta, api,
-                                                                       "Not Implemented", "Subscriptions not implemented yet"));
-                                        return true;
-                                    } else {
-                                        std::ostringstream err;
-                                        err << "Distribution Session [" << ptr_resource1 << "] sub resource [" << subresource
-                                            << "] is not understood for POST method";
-                                        ogs_error("%s", err.str().c_str());
-                                        ogs_assert(true == NfServer::sendError(stream,
-                                                                        ProblemCause::RESOURCE_URI_STRUCTURE_NOT_FOUND,
-                                                                        3, message, app_meta, api, std::nullopt, err.str()));
-                                        return true;
-                                    }
-                                } else {
-                                    ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED,
-                                                                        2, message, app_meta, api, "Method not allowed",
-                                                                        "Cannot POST to individual Distribution Sessions"));
-                                    return true;
-                                }
-                            } else {
-                                ogs_debug("In MBSTF Distribution session");
-                                std::shared_ptr<DistributionSession> distributionSession;
-                                ogs_debug("Request body: %s", request.content());
-                                //ogs_debug("Request " OGS_SBI_CONTENT_TYPE ": %s", request.headerValue(OGS_SBI_CONTENT_TYPE, std::string()).c_str());
-                                if (request.headerValue(OGS_SBI_CONTENT_TYPE, std::string()) != "application/json") {
-                                    ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT,
-                                                                       1, message, app_meta, api, "Unsupported Media Type",
-                                                                       "Expected content type: application/json"));
-                                    return true;
-                                }
-
-                                CJson distSession(CJson::Null);
-                                try {
-                                    distSession = CJson::parse(request.content());
-                                } catch (ModelException &ex) {
-                                    send_model_error(ex, stream, 1, message, app_meta, api, "Bad Request",
-                                                     "Unable to parse MBSTF Distribution Session as JSON");
-                                    return true;
-                                } catch (std::exception &ex) {
-                                    static const char *err = "Unable to parse MBSTF Distribution Session as JSON.";
-                                    ogs_error("%s", err);
-                                    ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message,
-                                                                        app_meta, api, "Bad MBSTF Distribution Session", err));
-                                    return true;
-                                }
-
-                                {
-                                    std::string txt(distSession.serialise());
-                                    ogs_debug("Request Parsed JSON: %s", txt.c_str());
-                                }
-
-                                try {
-                                    distributionSession.reset(new DistributionSession(distSession, true));
-                                } catch (ModelException &err) {
-                                    send_model_error(err, stream, 1, message, app_meta, api, "Bad Request",
-                                                     "Error while populating MBSTF Distribution Session");
-                                    return true;
-                                } catch (std::exception &err) {
-                                    char *error = ogs_msprintf("Error while populating MBSTF Distribution Session: %s", err.what());
-                                    ogs_error("%s", error);
-                                    ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message,
-                                                                           app_meta, api, "Bad Request", error));
-                                    ogs_free(error);
-                                    return true;
-                                }
-
-                                try {
-
-                                    distributionSession->m_controller.reset(ControllerFactory::makeController(*distributionSession));
-                                    if(!distributionSession->m_controller) {
-                                        const std::string &mode = distributionSession->getObjectDistributionOperatingMode();
-                                        char *error = ogs_msprintf("No handler found for objDistributionOperatingMode [%s]",
-                                                                   mode.c_str());
-                                        ogs_error("%s", error);
-                                        ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_NOT_IMPLEMENTED, 1,
-                                                                               message, app_meta, api, "Not Implemented", error));
-                                        ogs_free(error);
-                                        return true;
-                                    }
-                                } catch (ModelException &err) {
-                                    send_model_error(err, stream, 1, message, app_meta, api, "Bad Request",
-                                                     "Error while populating MBSTF Distribution Session");
-                                } catch (std::exception &err) {
-                                    ogs_error("Error while populating MBSTF Distribution Session: %s", err.what());
-                                    char *error = ogs_msprintf("Invalid ObjDistributionData parameters [%s]", err.what());
-                                    ogs_error("%s", error);
-                                    ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message,
-                                                                           app_meta, api, "Invalid ObjDistributionData parameters",
-                                                                           error));
-                                    ogs_free(error);
-                                    return true;
-                                }
-
-                                distributionSession->_transitionTo(distributionSession->getState().getValue());
-                                
-
-                                App::self().context()->addDistributionSession(distributionSession);
-
-                                // TODO: Subscribe to Events from the Controller - to be forwarded to DistributionSessionSubscriptions
-
-                                CJson createdReqData_json(distributionSession->json(false));
-                                std::string body(createdReqData_json.serialise());
-                                ogs_debug("Response Parsed JSON: %s", body.c_str());
-                                std::ostringstream location;
-                                location << request.uri() << "/" << distributionSession->distributionSessionId();
-                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(location.str(),
-                                                                                        body.empty()?nullptr:"application/json",
-                                                                                        distributionSession->generated(),
-                                                                                        distributionSession->hash().c_str(),
-                                                                                        App::self().context()->cacheControl.distMaxAge,
-                                                                                        std::nullopt/*nullptr*/, api, app_meta));
-                                ogs_assert(response);
-                                NfServer::populateResponse(response, body, OGS_SBI_HTTP_STATUS_CREATED);
-                                ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
-                                return true;
-                            }
-                        } else if (method == OGS_SBI_HTTP_METHOD_GET) {
-                            if (!ptr_resource1) {
-                                std::ostringstream err;
-                                err << "Invalid method for resource [" << message.uri() << "]";
-                                ogs_error("%s", err.str().c_str());
-                                ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED, 1,
-                                                                       message, app_meta, api, "Method Not Allowed", err.str()));
-                                return true;
-                            }
+                        if (ptr_resource1) {
+                            /* starts with .../dist-sessions/{distSessionId}... */
                             std::string dist_session_id(ptr_resource1);
+                            std::shared_ptr<DistributionSession> dist_session;
                             try {
-                                int response_code = OGS_SBI_HTTP_STATUS_OK;
-
-                                std::shared_ptr<DistributionSession> distSess = DistributionSession::find(dist_session_id);
-                                CJson createdReqData_json(distSess->json(false));
-                                std::string body(createdReqData_json.serialise());
-                                ogs_debug("Generated JSON: %s", body.c_str());
-                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::string(request.uri()),
-                                                        body.empty()?nullptr:"application/json",
-                                                        distSess->generated(),
-                                                        distSess->hash().c_str(),
-                                                        App::self().context()->cacheControl.distMaxAge,
-                                                        std::nullopt/*nullptr*/, api, app_meta));
-                                ogs_assert(response);
-                                NfServer::populateResponse(response, body, response_code);
-                                ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                                dist_session = DistributionSession::find(dist_session_id);
                             } catch (const std::out_of_range &e) {
                                 std::ostringstream err;
                                 err << "MBSTF Distribution Session [" << dist_session_id << "] does not exist.";
@@ -338,177 +231,148 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                                 static const std::string param("{sessionId}");
                                 std::ostringstream reason;
                                 reason << "Invalid MBSTF Distribution Session identifier [" << dist_session_id << "]";
-                                std::map<std::string, std::string> invalid_params(
-                                                                            NfServer::makeInvalidParams(param, reason.str()));
+                                std::map<std::string, std::string> invalid_params(NfServer::makeInvalidParams(param, reason.str()));
 
                                 ogs_assert(true == NfServer::sendError(stream, ProblemCause::SUBSCRIPTION_NOT_FOUND, 2, message,
-                                                                        app_meta, api, "MBSTF Distribution Session not found",
-                                                                        err.str(), std::nullopt, invalid_params));
-                            }
-                            return true;
-                        } else if (method == OGS_SBI_HTTP_METHOD_DELETE) {
-                            if (ptr_resource1 && !message.resourceComponent(2)) {
-                                std::string dist_session_id(ptr_resource1);
-                                try {
-                                    App::self().context()->deleteDistributionSession(dist_session_id);
-                                    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt,
-                                                                std::nullopt, std::nullopt, 0, std::nullopt, api, app_meta));
-                                    NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
-                                    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
-                                } catch (const std::out_of_range &e) {
-                                    std::ostringstream err;
-                                    err << "MBSTF Distribution Session [" << dist_session_id << "] does not exist.";
-                                    ogs_error("%s", err.str().c_str());
-
-                                    static const std::string param("{sessionId}");
-                                    std::ostringstream reason;
-                                    reason << "Invalid MBSTF Distribution Session identifier [" << dist_session_id << "]";
-                                    std::map<std::string, std::string> invalid_params(NfServer::makeInvalidParams(param,
-                                                                 reason.str()));
-
-                                    ogs_assert(true == NfServer::sendError(stream, ProblemCause::SUBSCRIPTION_NOT_FOUND, 2, message,
-                                                            app_meta, api, "MBSTF Distribution Session not found", err.str(),
-                                                            std::nullopt, invalid_params));
-                                }
-                            } else {
-                                ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED, 2,
-                                                            message, app_meta, api, "Method Not Allowed",
-                                                            "The DELETE method is not allowed for this path"));
-                            }
-                            return true;
-                        } else if (method == OGS_SBI_HTTP_METHOD_PATCH) {
-                            if (!ptr_resource1) {
-                                static const char *err = "MBSTF Distribution Session update operation without distSessionId";
-                                ogs_error("%s", err);
-                                static const std::string param("{sessionId}");
-                                std::map<std::string, std::string> invalid_params(NfServer::makeInvalidParams(param,
-                                                            "Missing MBSTF Distribution Session identifier"));
-                                ogs_assert(true == NfServer::sendError(stream, ProblemCause::SUBSCRIPTION_NOT_FOUND, 1, message,
-                                                            app_meta, api, "MBSTF Distribution Session not found", err,
-                                                            std::nullopt, invalid_params));
+                                                                    app_meta, api, "MBSTF Distribution Session not found",
+                                                                    err.str(), std::nullopt, invalid_params));
                                 return true;
                             }
-                            std::string dist_session_id(ptr_resource1);
-                            std::shared_ptr<DistributionSession> distSess{};
-                            try {
-                                distSess = DistributionSession::find(dist_session_id);
-                            } catch (const std::out_of_range &e) {
-                                std::ostringstream err;
-                                err << "MBSTF Distribution Session [" << dist_session_id << "] does not exist.";
-                                ogs_error("%s", err.str().c_str());
 
-                                static const std::string param("{sessionId}");
-                                std::ostringstream reason;
-                                reason << "Invalid MBSTF Distribution Session identifier [" << dist_session_id << "]";
-                                std::map<std::string, std::string> invalid_params(
-                                                                            NfServer::makeInvalidParams(param, reason.str()));
-
-                                ogs_assert(true == NfServer::sendError(stream, ProblemCause::SUBSCRIPTION_NOT_FOUND, 2, message,
-                                                                        app_meta, api, "MBSTF Distribution Session not found",
-                                                                        err.str(), std::nullopt, invalid_params));
-                                return true;
-                            }
                             const char *ptr_resource2 = message.resourceComponent(2);
                             if (ptr_resource2) {
-                                std::ostringstream err;
-                                err << "MBSTF Distribution Session [" << dist_session_id << "] sub resource [" << ptr_resource2 << "] not understood for PATCH method.";
-                                ogs_error("%s", err.str().c_str());
-                                ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_API, 3, message,
-                                                            app_meta, api, "MBSTF Distribution Session invalid sub resource",
-                                                            err.str()));
-                                return true;
-                            }
-
-                            /* check MIME type */
-                            std::string content_type(message.contentType());
-                            if (content_type != OGS_SBI_CONTENT_PATCH_TYPE) {
-                                std::ostringstream err;
-                                err << "Content-Type [" << message.contentType() << "] unknown for PATCH method, expecting " OGS_SBI_CONTENT_PATCH_TYPE;
-                                ogs_error("%s", err.str().c_str());
-                                ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 2, message,
-                                                            app_meta, api, "MBSTF Distribution Session patch bad MIME type",
-                                                            err.str()));
-                                return true;
-                            }
-
-                            /* parse body */
-                            CJson json(CJson::newNull());
-                            try {
-                                json = CJson::parse(request.content());
-                            } catch (ModelException &err) {
-                                send_model_error(err, stream, 2, message, app_meta, api, "Message body is not valid JSON",
-                                                       "MBSTF Distribution Session patch not valid JSON");
-                                return true;
-                            }
-
-                            /* Apply patch */
-                            auto oldDistSess = distSess->distributionSessionReqData();
-                            std::shared_ptr<reftools::mbstf::CreateReqData> newDistSess{};
-                            try {
-                                newDistSess.reset(oldDistSess->newWithJSONPatches(json));
-                            } catch (ModelException &err) {
-                                send_model_error(err, stream, 2, message, app_meta, api, "Unable to apply JSON Patch",
-                                                         "MBSTF Distribution Session patch failed to apply");
-                                return true;
-                            }
-
-                            /* New state is valid, replace old DistSession */
-                            try {
-                                distSess->distributionSessionReqData(newDistSess);
-                            } catch (ModelParamsException &ex) {
-                                ogs_error("%s", ex.what());
-                                send_model_params_error(ex, stream, 2, message, app_meta, api, "Invalid JSON Patch",
-                                                        "MBSTF Distribution Session patch");
-                                return true;
-                            }
-                            json = distSess->json(false);
-                            std::string body(json.serialise());
-                            ogs_debug("Generated JSON: %s", body.c_str());
-                            std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::string(request.uri()),
-                                                        body.empty()?nullptr:"application/json",
-                                                        distSess->generated(),
-                                                        distSess->hash().c_str(),
-                                                        App::self().context()->cacheControl.distMaxAge,
-                                                        std::nullopt, api, app_meta));
-                            ogs_assert(response);
-                            NfServer::populateResponse(response, body, OGS_SBI_HTTP_STATUS_OK);
-                            ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
-                            return true;
-                        } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
-                            if (ptr_resource1) {
-                                const char *ptr_resource2 = message.resourceComponent(2);
-                                if (ptr_resource2) {
-                                    std::string resource2(ptr_resource2);
-                                    if (resource2 == "subscriptions") {
-                                        std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, /*OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_DELETE ", " */ OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
-                                        NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
-                                        ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                                std::string subresource(ptr_resource2);
+                                if (subresource == "subscriptions") {
+                                    /* starts with .../dist-sessions/{distSessionId}/subscriptions... */
+                                    const char *ptr_resource3 = message.resourceComponent(3);
+                                    if (ptr_resource3) {
+                                        /* starts with .../dist-sessions/{distSessionId}/subscriptions/{subscriptionId}... */
+                                        std::string subscription_id(ptr_resource3);
+                                        const DistributionSessionSubscription *dist_sess_subsc = nullptr;
+                                        try {
+                                            dist_sess_subsc = &dist_session->getSubscription(subscription_id);
+                                        } catch (std::out_of_range &ex) {
+                                            std::ostringstream err;
+                                            err << "Distribution Session Subscription [" << subscription_id << "] not found: "
+                                                << ex.what();
+                                            ogs_error("%s", err.str().c_str());
+                                            std::map<std::string, std::string> invalid_params(
+                                                                    NfServer::makeInvalidParams("{subscriptionId}", ex.what()));
+                                            ogs_assert(true == NfServer::sendError(stream,
+                                                                        ProblemCause::SUBSCRIPTION_NOT_FOUND, 4, message,
+                                                                        app_meta, api,
+                                                                        "MBSTF Distribution Session Subscription not found",
+                                                                        err.str(), std::nullopt, invalid_params));
+                                            return true;
+                                        }
+                                        const char *ptr_resource4 = message.resourceComponent(4);
+                                        if (ptr_resource4) {
+                                            /* starts .../dist-sessions/{distSessionRef}/subscriptions/{subscriptionId}/... */
+                                            std::ostringstream err;
+                                            err << "Distribution Session [" << dist_session_id << "] subscription ["
+                                                << subscription_id << "] sub-resource [" << ptr_resource4
+                                                << "] not understood";
+                                            ogs_error("%s", err.str().c_str());
+                                            ogs_assert(true == NfServer::sendError(stream,
+                                                                        ProblemCause::RESOURCE_URI_STRUCTURE_NOT_FOUND,
+                                                                        5, message, app_meta, api, std::nullopt, err.str()));
+                                        } else {
+                                            /* is .../dist-sessions/{distSessionRef}/subscriptions/{subscriptionId} */
+                                            /* DELETE and PATCH methods allowed by TS 29.581 */
+                                            /* We add OPTIONS for RESTful introspection */
+                                            if (method == OGS_SBI_HTTP_METHOD_DELETE) {
+                                                dist_session->_apiSubscriptionDelete(*dist_sess_subsc, stream, message, request, api, app_meta);
+                                            } else if (method == OGS_SBI_HTTP_METHOD_PATCH) {
+                                                dist_session->_apiSubscriptionPatch(*dist_sess_subsc, stream, message, request, api, app_meta);
+                                            } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
+                                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, /*OGS_SBI_HTTP_METHOD_PATCH ", " OGS_SBI_HTTP_METHOD_DELETE ", " */ OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
+                                                NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
+                                                ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                                            } else {
+                                                std::ostringstream err;
+                                                err << "Distribution Session [" << dist_session_id << "] subscription ["
+                                                    << subscription_id << "] method [" << method
+                                                    << "] not allowed for this resource";
+                                                ogs_error("%s", err.str().c_str());
+                                                ogs_assert(true == NfServer::sendError(stream,
+                                                                        OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED,
+                                                                        4, message, app_meta, api, std::nullopt, err.str()));
+                                            }
+                                        }
                                     } else {
-                                        ogs_assert(true == NfServer::sendError(stream,
-                                                            ProblemCause::RESOURCE_URI_STRUCTURE_NOT_FOUND, 3, message,
-                                                            app_meta, api, "Not found", "Resource path not known"));
+                                        /* is .../dist-sessions/{distSessionRef}/subscriptions */
+                                        /* POST method allowed by TS 29.581 */
+                                        /* We add OPTIONS for RESTful introspection */
+                                        if (method == OGS_SBI_HTTP_METHOD_POST) {
+                                            dist_session->_apiSubscriptionCreate(stream, message, request, api, app_meta);
+
+                                        } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
+                                            std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
+                                            NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
+                                            ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                                        } else {
+                                            std::ostringstream err;
+                                            err << "Distribution Session [" << dist_session_id << "] subscriptions: method ["
+                                                << method << "] not allowed for this resource";
+                                            ogs_error("%s", err.str().c_str());
+                                            ogs_assert(true == NfServer::sendError(stream,
+                                                                        OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED,
+                                                                        3, message, app_meta, api, std::nullopt, err.str()));
+                                        }
                                     }
                                 } else {
-                                    /* .../dist-sessions/{distSessionRef} */
-                                    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, OGS_SBI_HTTP_METHOD_GET ", " OGS_SBI_HTTP_METHOD_DELETE ", " OGS_SBI_HTTP_METHOD_PATCH ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
-                                    NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
-                                    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                                    /* is .../dist-sessions/{distSessionRef}/??? */
+                                    std::string err = std::format("Distribution Session [{}] sub-resource [{}] is not understood",
+                                                                  dist_session_id, subresource);
+                                    ogs_error("%s", err.c_str());
+                                    ogs_assert(true == NfServer::sendError(stream, ProblemCause::RESOURCE_URI_STRUCTURE_NOT_FOUND,
+                                                                        3, message, app_meta, api, std::nullopt, err));
                                 }
                             } else {
-                                /* .../dist-sessions */
-                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
+                                /* is .../dist-sessions/{distSessionRef} */
+                                /* GET, PATCH and DELETE methods are allowed by TS 29.581 */
+                                /* We add OPTIONS for RESTful introspection */
+                                if (method == OGS_SBI_HTTP_METHOD_GET) {
+                                    dist_session->_apiSessionGet(stream, message, request, api, app_meta);
+                                } else if (method == OGS_SBI_HTTP_METHOD_PATCH) {
+                                    dist_session->_apiSessionPatch(stream, message, request, api, app_meta);
+                                } else if (method == OGS_SBI_HTTP_METHOD_DELETE) {
+                                    dist_session->_apiSessionDelete(stream, message, request, api, app_meta);
+                                } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
+                                    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(
+                                                    std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0,
+                                                    OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
+                                    NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
+                                    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                                } else {
+                                    std::ostringstream err;
+                                    err << "Distribution Session [" << ptr_resource1 << "], method [" << method
+                                        << "] is not allowed for a Distribution Session"; 
+                                    ogs_error("%s", err.str().c_str());
+                                    ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED,
+                                                                        2, message, app_meta, api, std::nullopt, err.str()));
+                                }
+                            }
+                        } else {
+                            /* is .../dist-sessions */
+                            /* POST method allowed by TS 29.581 */
+                            /* We also include OPTIONS method for RESTful introspection */
+                            if (method == OGS_SBI_HTTP_METHOD_POST) {
+                                DistributionSession::_apiSessionCreate(stream, message, request, api, app_meta);
+                            } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
+                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(
+                                                    std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, 
+                                                    OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
                                 NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
                                 ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+                            } else {
+                                std::ostringstream err;
+                                err << "Distribution Session [" << ptr_resource1 << "], method [" << method
+                                    << "] is not allowed for a Distribution Session";
+                                ogs_error("%s", err.str().c_str());
+                                ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED,
+                                                                          2, message, app_meta, api, std::nullopt, err.str()));
                             }
-                            return true;
-                        } else {
-                            std::ostringstream err;
-
-                            err << "Invalid method [" << message.method() << "] for " << request.uri();
-                            ogs_error("%s", err.str().c_str());
-                            ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED, 1, message,
-                                                                    app_meta, api, "Method Not Allowed", err.str()));
-                            return true;
                         }
                     } else {
                         std::ostringstream err;
@@ -516,7 +380,6 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                         ogs_error("%s", err.str().c_str());
                         ogs_assert(true == NfServer::sendError(stream, ProblemCause::RESOURCE_URI_STRUCTURE_NOT_FOUND, 1, message,
                                                             app_meta, api, "Bad request", err.str()));
-                        return true;
                     }
                 } else {
                     static const char *err = "Missing resource name from URL path";
@@ -525,6 +388,21 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                                                 std::nullopt, "Missing resource name", err));
                 }
             } /* else: should not be reachable unless we've forgotten to implement a whole, recognised, API service name */
+            return true;
+        }
+    case OGS_EVENT_SBI_CLIENT:
+        {
+            for (auto &[dist_sess_id, dist_sess] : App::self().context()->distributionSessions) {
+                for (auto &[subsc_id, subsc] : dist_sess->m_eventSubscriptions) {
+                    if (subsc.processClientResponse(event)) return true;
+                }
+            }
+        }
+    case LocalEvents::SEND_NOTIFICATION:
+        {
+            DistributionSessionNotificationEvent dist_event(event);
+            const auto &subsc = dist_event.distributionSessionSubscription();
+            subsc.sendNotifications();
             return true;
         }
     default:
@@ -757,6 +635,44 @@ const std::optional<std::string> &DistributionSession::objectDistributionBaseUrl
     }
 }
 
+const std::string &DistributionSession::addSubscription(const std::shared_ptr<DistSessionSubscription> &dist_session_susbc)
+{
+    DistributionSessionSubscription subsc(weak_from_this(), dist_session_susbc);
+    auto it = m_eventSubscriptions.emplace(subsc.subscriptionId(), std::move(subsc)).first;
+    return it->first;
+}
+
+const std::string &DistributionSession::addSubscription(CJson &json, bool as_request)
+{
+    std::shared_ptr<StatusSubscribeReqData> subsc_req(new StatusSubscribeReqData(json, as_request));
+    return addSubscription(subsc_req->getSubscription());
+}
+
+const DistributionSessionSubscription &DistributionSession::getSubscription(const std::string &subscription_id) const
+{
+    auto it = m_eventSubscriptions.find(subscription_id);
+    if (it == m_eventSubscriptions.end()) throw std::out_of_range("No such DistSession subscription Id");
+    return it->second;
+}
+
+void DistributionSession::updateSubscription(const std::string &subscription_id, CJson &json, bool as_request)
+{
+    auto it = m_eventSubscriptions.find(subscription_id);
+    if (it == m_eventSubscriptions.end()) {
+        throw std::range_error("No such subscription");
+    }
+    it->second.update(json, as_request);
+}
+
+void DistributionSession::removeSubscription(const std::string &subscription_id)
+{
+    auto it = m_eventSubscriptions.find(subscription_id);
+    if (it == m_eventSubscriptions.end()) {
+        throw std::range_error("No such subscription");
+    }
+    m_eventSubscriptions.erase(it);
+}
+
 DistributionSession &DistributionSession::distributionSessionReqData(const std::shared_ptr<CreateReqData> &new_create_req_data)
 {
     ModelParamsException ex("Invalid DistSession change", "CreateReqData", std::string(), ProblemCause::INVALID_MSG_FORMAT);
@@ -854,6 +770,7 @@ void DistributionSession::_inactiveState(const DistributionSession::Action &acti
     case Action::INIT_STATE:
         ogs_debug("DistributionSession(%p) entering INACTIVE state", this);
         m_controller->establishInactiveInputs();
+        _registerEvent(DistributionSessionEvents::SESSION_DEACTIVATED);
         /* if we are not at the desired state, transition to the next */
         if (getState().getValue() != DistSessionState::VAL_INACTIVE) _changeState(&DistributionSession::_establishedState);
         break;
@@ -885,6 +802,7 @@ void DistributionSession::_establishedState(const DistributionSession::Action &a
     case Action::INIT_STATE:
         ogs_debug("DistributionSession(%p) entering ESTABLISHED state", this);
         m_controller->establishActiveInputs();
+        _registerEvent(DistributionSessionEvents::DATA_INGEST_SESSION_ESTABLISHED);
         if (getState().getValue() != DistSessionState::VAL_ESTABLISHED) _changeState(&DistributionSession::_activeState);
         break;
     case Action::STATE_TRANSITION:
@@ -919,6 +837,7 @@ void DistributionSession::_activeState(const DistributionSession::Action &action
     case Action::INIT_STATE:
         ogs_debug("DistributionSession(%p) entering ACTIVE state", this);
         m_controller->activateOutput();
+        _registerEvent(DistributionSessionEvents::SESSION_ACTIVATED);
         /* if we are not at the desired state, transition to the next */
         if (getState().getValue() != DistSessionState::VAL_ACTIVE) _changeState(&DistributionSession::_deactivatingState);
         break;
@@ -950,6 +869,7 @@ void DistributionSession::_deactivatingState(const DistributionSession::Action &
     case Action::INIT_STATE:
         ogs_debug("DistributionSession(%p) entering DEACTIVATING state", this);
         m_controller->deactivateOutput();
+        _registerEvent(DistributionSessionEvents::DATA_INGEST_SESSION_TERMINATED);
         /* once we've deactivated everything, always go to inactive state */
         if (getState().getValue() == DistSessionState::VAL_DEACTIVATING) {
             DistSessionState next_state;
@@ -990,6 +910,327 @@ void DistributionSession::_setHash()
 {
     std::string json_str(m_createReqData->toJSON(true).serialise());
     m_hash = calculate_hash(std::vector<std::string::value_type>(json_str.begin(), json_str.end()));
+}
+
+void DistributionSession::_registerEvent(DistributionSessionEvents::EventTypeBitMask event_type)
+{
+    m_eventTimestamps.registerEvent(event_type);
+    _sendSubscriptionNotifications();
+}
+
+void DistributionSession::_sendSubscriptionNotifications()
+{
+    for (auto &[subsc_id, subsc] : m_eventSubscriptions) {
+        subsc.pushNotificationsEvent();
+    }
+}
+
+void DistributionSession::_apiSessionCreate(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                           const std::optional<NfServer::InterfaceMetadata> &api,
+                           const NfServer::AppMetadata &app_meta)
+{
+    /* static method */
+    if (request.headerValue(OGS_SBI_CONTENT_TYPE, std::string()) != "application/json") {
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
+                                                "Unsupported Media Type", "Expected content type: application/json"));
+        return;
+    }
+
+    CJson distSession(CJson::Null);
+    try {
+        distSession = CJson::parse(request.content());
+    } catch (ModelException &ex) {
+        send_model_error(ex, stream, 1, message, app_meta, api, "Bad Request",
+                         "Unable to parse MBSTF Distribution Session as JSON");
+        return;
+    } catch (std::exception &ex) {
+        static const char *err = "Unable to parse MBSTF Distribution Session as JSON.";
+        ogs_error("%s", err);
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
+                                                "Bad MBSTF Distribution Session", err));
+        return;
+    }
+
+    {
+        std::string txt(distSession.serialise());
+        ogs_debug("Request Parsed JSON: %s", txt.c_str());
+    }
+
+    std::shared_ptr<DistributionSession> distributionSession;
+    try {
+        distributionSession.reset(new DistributionSession(distSession, true));
+        /* If a subscription came with the create request, add the subscription */
+        const auto &dist_session = distributionSession->distributionSessionReqData()->getDistSession();
+        const auto &opt_subsc = dist_session->getDistSessionSubscription();
+        std::string subsc_id;
+        if (opt_subsc) {
+            subsc_id = distributionSession->addSubscription(opt_subsc.value());
+            distributionSession->m_subscriptionLocation = std::format("{}/{}/subscriptions/{}", request.uri(), distributionSession->distributionSessionId(), subsc_id);
+        }
+    } catch (ModelException &err) {
+        send_model_error(err, stream, 1, message, app_meta, api, "Bad Request",
+                            "Error while populating MBSTF Distribution Session");
+        return;
+    } catch (std::exception &err) {
+        char *error = ogs_msprintf("Error while populating MBSTF Distribution Session: %s", err.what());
+        ogs_error("%s", error);
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
+                                                "Bad Request", error));
+        ogs_free(error);
+        return;
+    }
+
+    try {
+        distributionSession->m_controller.reset(ControllerFactory::makeController(*distributionSession));
+        if (!distributionSession->m_controller) {
+            const std::string &mode = distributionSession->getObjectDistributionOperatingMode();
+            char *error = ogs_msprintf("No handler found for objDistributionOperatingMode [%s]", mode.c_str());
+            ogs_error("%s", error);
+            ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_NOT_IMPLEMENTED, 1, message, app_meta, api,
+                                                    "Not Implemented", error));
+            ogs_free(error);
+            return;
+        }
+    } catch (ModelException &err) {
+        send_model_error(err, stream, 1, message, app_meta, api, "Bad Request",
+                            "Error while populating MBSTF Distribution Session");
+    } catch (std::exception &err) {
+        ogs_error("Error while populating MBSTF Distribution Session: %s", err.what());
+        char *error = ogs_msprintf("Invalid ObjDistributionData parameters [%s]", err.what());
+        ogs_error("%s", error);
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
+                                                "Invalid ObjDistributionData parameters", error));
+        ogs_free(error);
+        return;
+    }
+
+    distributionSession->_transitionTo(distributionSession->getState().getValue());
+    App::self().context()->addDistributionSession(distributionSession);
+
+    // TODO: Subscribe to Events from the Controller - to be forwarded to DistributionSessionSubscriptions
+    distributionSession->_sendSubscriptionNotifications();
+
+    CJson create_rsp_data_json(distributionSession->json(false, true));
+    std::string body(create_rsp_data_json.serialise());
+    ogs_debug("Response Parsed JSON: %s", body.c_str());
+    std::string location = std::format("{}/{}", request.uri(), distributionSession->distributionSessionId());
+    std::optional<std::string> content_type;
+    if (!body.empty()) {
+        content_type = "application/json";
+    }
+    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(location, content_type, distributionSession->generated(),
+                                                                        distributionSession->hash().c_str(),
+                                                                        App::self().context()->cacheControl.distMaxAge,
+                                                                        std::nullopt, api, app_meta));
+    ogs_assert(response);
+    NfServer::populateResponse(response, body, OGS_SBI_HTTP_STATUS_CREATED);
+    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+}
+
+void DistributionSession::_apiSessionDelete(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                           const std::optional<NfServer::InterfaceMetadata> &api,
+                           const NfServer::AppMetadata &app_meta)
+{
+    try {
+        App::self().context()->deleteDistributionSession(distributionSessionId());
+        std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt,
+                                                                            std::nullopt, 0, std::nullopt, api, app_meta));
+        NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
+        ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+    } catch (const std::out_of_range &e) {
+        std::ostringstream err;
+        err << "MBSTF Distribution Session [" << distributionSessionId() << "] does not exist.";
+        ogs_error("%s", err.str().c_str());
+
+        static const std::string param("{sessionId}");
+        std::ostringstream reason;
+        reason << "Invalid MBSTF Distribution Session identifier [" << distributionSessionId() << "]";
+        std::map<std::string, std::string> invalid_params(NfServer::makeInvalidParams(param, reason.str()));
+
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::SUBSCRIPTION_NOT_FOUND, 2, message, app_meta, api,
+                                                "MBSTF Distribution Session not found", err.str(), std::nullopt, invalid_params));
+    }
+}
+
+void DistributionSession::_apiSessionPatch(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                          const std::optional<NfServer::InterfaceMetadata> &api,
+                          const NfServer::AppMetadata &app_meta)
+{
+    std::string content_type(message.contentType());
+    if (content_type != OGS_SBI_CONTENT_PATCH_TYPE) {
+        std::ostringstream err;
+        err << "Content-Type [" << message.contentType() << "] unknown for PATCH method, expecting " OGS_SBI_CONTENT_PATCH_TYPE;
+        ogs_error("%s", err.str().c_str());
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 2, message, app_meta, api,
+                                                "MBSTF Distribution Session patch bad MIME type", err.str()));
+        return;
+    }
+
+    /* parse body */
+    CJson patch_json(CJson::newNull());
+    try {
+        patch_json = CJson::parse(request.content());
+    } catch (ModelException &err) {
+        send_model_error(err, stream, 2, message, app_meta, api, "Message body is not valid JSON",
+                            "MBSTF Distribution Session patch not valid JSON");
+        return;
+    }
+
+    /* Apply patch */
+    auto old_dist_sess = distributionSessionReqData();
+    std::shared_ptr<reftools::mbstf::CreateReqData> new_dist_sess{};
+    try {
+        new_dist_sess.reset(old_dist_sess->newWithJSONPatches(patch_json));
+    } catch (ModelException &err) {
+        send_model_error(err, stream, 2, message, app_meta, api, "Unable to apply JSON Patch",
+                            "MBSTF Distribution Session patch failed to apply");
+        return;
+    }
+
+    /* New state is valid, replace old DistSession */
+    try {
+        distributionSessionReqData(new_dist_sess);
+    } catch (ModelParamsException &ex) {
+        ogs_error("%s", ex.what());
+        send_model_params_error(ex, stream, 2, message, app_meta, api, "Invalid JSON Patch", "MBSTF Distribution Session patch");
+        return;
+    }
+
+    CJson rsp_json = json(false);
+    std::string body(rsp_json.serialise());
+    ogs_debug("Generated JSON: %s", body.c_str());
+    std::optional<std::string> rsp_content_type;
+    if (!body.empty()) {
+        rsp_content_type = "application/json";
+    }
+    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::string(request.uri()), rsp_content_type, generated(),
+                                                                hash().c_str(), App::self().context()->cacheControl.distMaxAge,
+                                                                std::nullopt, api, app_meta));
+    ogs_assert(response);
+    NfServer::populateResponse(response, body, OGS_SBI_HTTP_STATUS_OK);
+    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+}
+
+void DistributionSession::_apiSessionGet(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                        const std::optional<NfServer::InterfaceMetadata> &api,
+                        const NfServer::AppMetadata &app_meta)
+{
+    CJson createdRspData_json(json(false));
+    std::string body(createdRspData_json.serialise());
+    ogs_debug("Generated JSON: %s", body.c_str());
+    std::optional<std::string> content_type;
+    if (!body.empty()) {
+        content_type = "application/json";
+    }
+    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::string(request.uri()), content_type, generated(),
+                                                        hash().c_str(), App::self().context()->cacheControl.distMaxAge,
+                                                        std::nullopt, api, app_meta));
+    ogs_assert(response);
+    NfServer::populateResponse(response, body, OGS_SBI_HTTP_STATUS_OK);
+    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+}
+
+void DistributionSession::_apiSubscriptionCreate(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                                const std::optional<NfServer::InterfaceMetadata> &api,
+                                const NfServer::AppMetadata &app_meta)
+{
+    if (request.headerValue(OGS_SBI_CONTENT_TYPE, std::string()) != "application/json") {
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
+                                                "Unsupported Media Type", "Expected content type: application/json"));
+        return;
+    }
+
+    CJson dist_session_subsc_json(CJson::Null);
+    std::string subsc_id;
+    try {
+        dist_session_subsc_json = CJson::parse(request.content());
+        subsc_id = addSubscription(dist_session_subsc_json, true);
+    } catch (ModelException &ex) {
+        send_model_error(ex, stream, 4, message, app_meta, api, "Bad Request",
+                            "Unable to parse MBSTF Distribution Session Subscription as JSON");
+        return;
+    } catch (std::exception &ex) {
+        static const char *err = "Unable to parse MBSTF Distribution Session Subscription as JSON.";
+        ogs_error("%s", err);
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 4, message, app_meta, api,
+                                                "Bad MBSTF Distribution Session Subscription", err));
+        return;
+    }
+
+    const DistributionSessionSubscription *subsc = nullptr;
+    try {
+        subsc = &getSubscription(subsc_id);
+    } catch (std::out_of_range &ex) {
+        static const char *err = "Lost DistSession subscription after creation";
+        ogs_error("%s", err);
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::SYSTEM_FAILURE, 1, message, app_meta, api,
+                                                  "Lost Distribution Session Subscription", err));
+        return;
+    }
+
+    auto immediate_notifications = subsc->makeReportList();
+    std::shared_ptr<DistSessionSubscription> api_subsc(new DistSessionSubscription(subsc->distSessionSubscription()));
+    StatusSubscribeRspData rsp;
+    rsp.setSubscription(api_subsc);
+    if (!immediate_notifications->getEventReportList().empty()) {
+        rsp.setReportList(immediate_notifications);
+    }
+    std::string rsp_body(rsp.toJSON(false).serialise());
+    std::string location = std::format("{}/{}/subscriptions/{}", request.uri(), distributionSessionId(), subsc->subscriptionId());
+    std::optional<std::string> content_type;
+    if (!rsp_body.empty()) content_type = "application/json";
+    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(location, content_type, std::nullopt /* last-modified */,
+                                                                        std::nullopt /* etag */,
+                                                                        App::self().context()->cacheControl.distMaxAge,
+                                                                        std::nullopt, api, app_meta));
+    ogs_assert(response);
+    NfServer::populateResponse(response, rsp_body, OGS_SBI_HTTP_STATUS_CREATED);
+    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+}
+
+void DistributionSession::_apiSubscriptionDelete(const DistributionSessionSubscription &dist_sess_subsc,
+                                Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                                const std::optional<NfServer::InterfaceMetadata> &api,
+                                const NfServer::AppMetadata &app_meta)
+{
+    removeSubscription(dist_sess_subsc.subscriptionId());
+    std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0,
+                                                                        std::nullopt, api, app_meta));
+    ogs_assert(response);
+    NfServer::populateResponse(response, std::string(), OGS_SBI_HTTP_STATUS_NO_CONTENT);
+    ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+}
+
+void DistributionSession::_apiSubscriptionPatch(const DistributionSessionSubscription &dist_sess_subsc,
+                               Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                               const std::optional<NfServer::InterfaceMetadata> &api,
+                               const NfServer::AppMetadata &app_meta)
+{
+    CJson req_json(CJson::Null);
+    try {
+        req_json = CJson::parse(request.content());
+        updateSubscription(dist_sess_subsc.subscriptionId(), req_json, true);
+        std::string body(dist_sess_subsc.distSessionSubscription().toJSON(false).serialise());
+        std::optional<std::string> content_type;
+        if (!body.empty()) content_type = "application/json";
+        std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, content_type,
+                                                                        std::nullopt /* last-modified */, std::nullopt /* etag */,
+                                                                        App::self().context()->cacheControl.distMaxAge,
+                                                                        std::nullopt, api, app_meta));
+        ogs_assert(response);
+        NfServer::populateResponse(response, body, OGS_SBI_HTTP_STATUS_OK);
+        ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
+    } catch (ModelException &ex) {
+        send_model_error(ex, stream, 4, message, app_meta, api, "Bad Request",
+                            "Unable to parse MBSTF Distribution Session Subscription Patch as JSON");
+        return;
+    } catch (std::exception &ex) {
+        static const char *err = "Unable to parse MBSTF Distribution Session Subscription as JSON.";
+        ogs_error("%s", err);
+        ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
+                                                "Bad MBSTF Distribution Session Subscription", err));
+        return;
+    }
 }
 
 /**** Local private ****/

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -408,6 +408,7 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                     if (subsc.processClientResponse(event)) return true;
                 }
             }
+            break;
         }
     case LocalEvents::SEND_NOTIFICATION:
         {
@@ -415,6 +416,7 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
             const auto &subsc = dist_event.distributionSessionSubscription();
             ogs_debug("Sending notifications for subscription %p", &subsc);
             subsc.sendNotifications();
+            dist_event.releaseEventData();
             return true;
         }
     default:

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -29,7 +29,7 @@
 #include "openapi/model/ObjDistributionData.h"
 #include "common.hh"
 #include "BitRate.hh"
-//#include "Subscriber.hh"
+#include "Subscriber.hh"
 #include "DistributionSessionEvents.hh"
 #include "DistributionSessionSubscription.hh"
 #include "NfServer.hh"
@@ -52,7 +52,7 @@ class Open5GSSBIMessage;
 class Open5GSSBIRequest;
 class Controller;
 
-class DistributionSession : public std::enable_shared_from_this<DistributionSession> { // : public Subscriber {
+class DistributionSession : public std::enable_shared_from_this<DistributionSession>, public Subscriber {
 public:
     using SysTimeMS = std::chrono::system_clock::time_point;
 
@@ -76,6 +76,7 @@ public:
     const std::string &hash() const {return m_hash;};
     void setController(std::shared_ptr<Controller> controller) {m_controller = controller;};
 
+    virtual void processEvent(Event &event, SubscriptionService &event_service);
     static bool processEvent(Open5GSEvent &event);
 
     const reftools::mbstf::DistSessionState &getState() const;

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -30,6 +30,9 @@
 #include "common.hh"
 #include "BitRate.hh"
 //#include "Subscriber.hh"
+#include "DistributionSessionEvents.hh"
+#include "DistributionSessionSubscription.hh"
+#include "NfServer.hh"
 
 namespace fiveg_mag_reftools {
     class CJson;
@@ -37,15 +40,19 @@ namespace fiveg_mag_reftools {
 
 namespace reftools::mbstf {
     class CreateReqData;
+    class DistSessionSubscription;
     class ObjDistributionData;
 }
 
 MBSTF_NAMESPACE_START
 
 class Open5GSEvent;
+class Open5GSSBIStream;
+class Open5GSSBIMessage;
+class Open5GSSBIRequest;
 class Controller;
 
-class DistributionSession { // : public Subscriber {
+class DistributionSession : public std::enable_shared_from_this<DistributionSession> { // : public Subscriber {
 public:
     using SysTimeMS = std::chrono::system_clock::time_point;
 
@@ -59,7 +66,7 @@ public:
 
     virtual ~DistributionSession();
 
-    fiveg_mag_reftools::CJson json(bool as_request) const;
+    fiveg_mag_reftools::CJson json(bool as_request = false, bool include_subscription_location = false) const;
 
     static const std::shared_ptr<DistributionSession> &find(const std::string &id); // throws std::out_of_range if id does not exist
     const std::string &distributionSessionId() const { return m_distributionSessionId; };
@@ -88,6 +95,13 @@ public:
     bool setObjectAcquisitionIdPush(std::optional<std::string> &id);
     const std::optional<std::string> &objectDistributionBaseUrl() const;
 
+    const std::string &addSubscription(const std::shared_ptr<reftools::mbstf::DistSessionSubscription> &dist_session_susbc);
+    const std::string &addSubscription(fiveg_mag_reftools::CJson &json, bool as_request=true);
+    const DistributionSessionSubscription &getSubscription(const std::string &subscription_id) const;
+    void updateSubscription(const std::string &subscription_id, fiveg_mag_reftools::CJson &json, bool as_request=true);
+    void removeSubscription(const std::string &subscription_id);
+    
+    const DistributionSessionEvents &eventTimestamps() const { return m_eventTimestamps; };
     // TODO: Forwarding Events from the Controller to m_eventSubscriptions
     // virtual void processEvent(Event &event, SubscriptionService &event_service);
 
@@ -138,6 +152,33 @@ private:
     void _deactivatingState(const Action &action);
     void _setLastUsed();
     void _setHash();
+    void _registerEvent(DistributionSessionEvents::EventTypeBitMask event_type);
+    void _sendSubscriptionNotifications();
+
+    static void _apiSessionCreate(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                           const std::optional<NfServer::InterfaceMetadata> &api,
+                           const NfServer::AppMetadata &app_meta);
+    void _apiSessionDelete(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                           const std::optional<NfServer::InterfaceMetadata> &api,
+                           const NfServer::AppMetadata &app_meta);
+    void _apiSessionPatch(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                          const std::optional<NfServer::InterfaceMetadata> &api,
+                          const NfServer::AppMetadata &app_meta);
+    void _apiSessionGet(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                        const std::optional<NfServer::InterfaceMetadata> &api,
+                        const NfServer::AppMetadata &app_meta);
+
+    void _apiSubscriptionCreate(Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                                const std::optional<NfServer::InterfaceMetadata> &api,
+                                const NfServer::AppMetadata &app_meta);
+    void _apiSubscriptionDelete(const DistributionSessionSubscription &dist_sess_subsc,
+                                Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                                const std::optional<NfServer::InterfaceMetadata> &api,
+                                const NfServer::AppMetadata &app_meta);
+    void _apiSubscriptionPatch(const DistributionSessionSubscription &dist_sess_subsc,
+                               Open5GSSBIStream &stream, Open5GSSBIMessage &message, Open5GSSBIRequest &request,
+                               const std::optional<NfServer::InterfaceMetadata> &api,
+                               const NfServer::AppMetadata &app_meta);
 
     std::shared_ptr<reftools::mbstf::CreateReqData> m_createReqData;
     SysTimeMS m_generated;
@@ -145,9 +186,10 @@ private:
     std::string m_hash;
     std::string m_distributionSessionId;
     std::shared_ptr<Controller> m_controller;
-    // MBSTF event notification (TODO)
-    //std::list<DistributionSessionSubscription> m_eventSubscriptions;
+    std::map<std::string, DistributionSessionSubscription> m_eventSubscriptions;
     std::function<void(const Action&)> m_currentStateFunction;
+    DistributionSessionEvents m_eventTimestamps;
+    std::optional<std::string> m_subscriptionLocation;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DistributionSessionEvents.cc
+++ b/src/mbstf/DistributionSessionEvents.cc
@@ -1,0 +1,163 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Events
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <optional>
+
+#include "common.hh"
+
+#include "DistributionSessionEvents.hh"
+
+MBSTF_NAMESPACE_START
+
+/* Constructors and Destructor */
+DistributionSessionEvents::DistributionSessionEvents()
+    :dataIngestFailure()
+    ,sessionDeactivated()
+    ,sessionActivated()
+    ,serviceManagementFailure()
+    ,dataIngestSessionEstablished()
+    ,dataIngestSessionTerminated()
+{
+}
+
+DistributionSessionEvents::DistributionSessionEvents(const DistributionSessionEvents &other)
+    :dataIngestFailure(other.dataIngestFailure)
+    ,sessionDeactivated(other.sessionDeactivated)
+    ,sessionActivated(other.sessionActivated)
+    ,serviceManagementFailure(other.serviceManagementFailure)
+    ,dataIngestSessionEstablished(other.dataIngestSessionEstablished)
+    ,dataIngestSessionTerminated(other.dataIngestSessionTerminated)
+{
+}
+
+DistributionSessionEvents::DistributionSessionEvents(DistributionSessionEvents &&other)
+    :dataIngestFailure(std::move(other.dataIngestFailure))
+    ,sessionDeactivated(std::move(other.sessionDeactivated))
+    ,sessionActivated(std::move(other.sessionActivated))
+    ,serviceManagementFailure(std::move(other.serviceManagementFailure))
+    ,dataIngestSessionEstablished(std::move(other.dataIngestSessionEstablished))
+    ,dataIngestSessionTerminated(std::move(other.dataIngestSessionTerminated))
+{
+}
+    
+DistributionSessionEvents::~DistributionSessionEvents()
+{
+}
+
+/* operators */
+DistributionSessionEvents &DistributionSessionEvents::operator=(DistributionSessionEvents &&other)
+{
+    dataIngestFailure = std::move(other.dataIngestFailure);
+    sessionDeactivated = std::move(other.sessionDeactivated);
+    sessionActivated = std::move(other.sessionActivated);
+    serviceManagementFailure = std::move(other.serviceManagementFailure);
+    dataIngestSessionEstablished = std::move(other.dataIngestSessionEstablished);
+    dataIngestSessionTerminated = std::move(other.dataIngestSessionTerminated);
+    return *this;
+}
+
+DistributionSessionEvents &DistributionSessionEvents::operator=(const DistributionSessionEvents &other)
+{
+    dataIngestFailure = other.dataIngestFailure;
+    sessionDeactivated = other.sessionDeactivated;
+    sessionActivated = other.sessionActivated;
+    serviceManagementFailure = other.serviceManagementFailure;
+    dataIngestSessionEstablished = other.dataIngestSessionEstablished;
+    dataIngestSessionTerminated = other.dataIngestSessionTerminated;
+    return *this;
+}
+
+bool DistributionSessionEvents::operator==(const DistributionSessionEvents &other) const
+{
+    return dataIngestFailure == other.dataIngestFailure &&
+           sessionDeactivated == other.sessionDeactivated &&
+           sessionActivated == other.sessionActivated &&
+           serviceManagementFailure == other.serviceManagementFailure &&
+           dataIngestSessionEstablished == other.dataIngestSessionEstablished &&
+           dataIngestSessionTerminated == other.dataIngestSessionTerminated;
+}
+
+int DistributionSessionEvents::updatedSince(const DistributionSessionEvents &other) const
+{
+    int event_types = 0;
+    if (dataIngestFailure && (!other.dataIngestFailure || other.dataIngestFailure.value() < dataIngestFailure.value()))
+        event_types |= DATA_INGEST_FAILURE;
+    if (sessionDeactivated && (!other.sessionDeactivated || other.sessionDeactivated.value() < sessionDeactivated.value()))
+        event_types |= SESSION_DEACTIVATED;
+    if (sessionActivated && (!other.sessionActivated || other.sessionActivated.value() < sessionActivated.value()))
+        event_types |= SESSION_ACTIVATED;
+    if (serviceManagementFailure && (!other.serviceManagementFailure ||
+                                     other.serviceManagementFailure.value() < serviceManagementFailure.value()))
+        event_types |= SERVICE_MANAGEMENT_FAILURE;
+    if (dataIngestSessionEstablished && (!other.dataIngestSessionEstablished ||
+                                         other.dataIngestSessionEstablished.value() < dataIngestSessionEstablished.value()))
+        event_types |= DATA_INGEST_SESSION_ESTABLISHED;
+    if (dataIngestSessionTerminated && (!other.dataIngestSessionTerminated ||
+                                        other.dataIngestSessionTerminated.value() < dataIngestSessionTerminated.value()))
+        event_types |= DATA_INGEST_SESSION_TERMINATED;
+
+    return event_types;
+}
+
+const std::optional<DistributionSessionEvents::DateTime> &DistributionSessionEvents::timepointForEventType(EventTypeBitMask event_type) const
+{
+    return __timepointForEventType(event_type);
+}
+
+const std::optional<DistributionSessionEvents::DateTime> &DistributionSessionEvents::registerEvent(EventTypeBitMask event_type)
+{
+    auto &tp = timepointForEventType(event_type);
+    tp = DateTime::clock::now();
+    return tp;
+}
+
+/*** private: ***/
+std::optional<DistributionSessionEvents::DateTime> &DistributionSessionEvents::timepointForEventType(EventTypeBitMask event_type)
+{
+    return const_cast<std::optional<DateTime>&>(__timepointForEventType(event_type));
+}
+
+const std::optional<DistributionSessionEvents::DateTime> &DistributionSessionEvents::__timepointForEventType(EventTypeBitMask event_type) const
+{
+    switch (event_type) {
+    case DATA_INGEST_FAILURE:
+        return dataIngestFailure;
+    case SESSION_DEACTIVATED:
+        return sessionDeactivated;
+    case SESSION_ACTIVATED:
+        return sessionActivated;
+    case SERVICE_MANAGEMENT_FAILURE:
+        return serviceManagementFailure;
+    case DATA_INGEST_SESSION_ESTABLISHED:
+        return dataIngestSessionEstablished;
+    case DATA_INGEST_SESSION_TERMINATED:
+        return dataIngestSessionTerminated;
+    default:
+        break;
+    }
+    throw std::range_error("Bad event type given to DistributionSessionEvents::timepointForEventType()");
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/DistributionSessionEvents.hh
+++ b/src/mbstf/DistributionSessionEvents.hh
@@ -1,0 +1,78 @@
+#ifndef _MBS_TF_DISTRIBUTION_SESSION_EVENTS_HH_
+#define _MBS_TF_DISTRIBUTION_SESSION_EVENTS_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Event Timestamps class
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <chrono>
+#include <optional>
+
+#include "common.hh"
+
+MBSTF_NAMESPACE_START
+
+class DistributionSessionEvents {
+public:
+    using DateTime = std::chrono::system_clock::time_point;
+
+    typedef enum {
+        NONE = 0,
+        DATA_INGEST_FAILURE = 0x01,
+        SESSION_DEACTIVATED = 0x02,
+        SESSION_ACTIVATED = 0x04,
+        SERVICE_MANAGEMENT_FAILURE = 0x08,
+        DATA_INGEST_SESSION_ESTABLISHED = 0x10,
+        DATA_INGEST_SESSION_TERMINATED = 0x20
+    } EventTypeBitMask;
+
+    /* event timestamps */
+    std::optional<DateTime> dataIngestFailure;
+    std::optional<DateTime> sessionDeactivated;
+    std::optional<DateTime> sessionActivated;
+    std::optional<DateTime> serviceManagementFailure;
+    std::optional<DateTime> dataIngestSessionEstablished;
+    std::optional<DateTime> dataIngestSessionTerminated;
+
+    /* Constructors and Destructor */
+    DistributionSessionEvents();
+    DistributionSessionEvents(const DistributionSessionEvents &other);
+    DistributionSessionEvents(DistributionSessionEvents &&other);
+    
+    virtual ~DistributionSessionEvents();
+
+    /* operators */
+    DistributionSessionEvents &operator=(DistributionSessionEvents &&other);
+    DistributionSessionEvents &operator=(const DistributionSessionEvents &other);
+    bool operator==(const DistributionSessionEvents &other) const;
+    bool operator!=(const DistributionSessionEvents &other) const { return !(*this == other); };
+
+    int updatedSince(const DistributionSessionEvents &other) const; /* returns event type bits */
+    const std::optional<DateTime> &timepointForEventType(EventTypeBitMask event_type) const;
+
+    const std::optional<DateTime> &registerEvent(EventTypeBitMask event_type);
+
+private:
+    std::optional<DateTime> &timepointForEventType(EventTypeBitMask event_type);
+    const std::optional<DateTime> &__timepointForEventType(EventTypeBitMask event_type) const;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_DISTRIBUTION_SESSION_EVENTS_HH_ */

--- a/src/mbstf/DistributionSessionNotificationEvent.cc
+++ b/src/mbstf/DistributionSessionNotificationEvent.cc
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Notification Event
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "common.hh"
+#include "DistributionSessionSubscription.hh"
+#include "LocalEvents.hh"
+#include "Open5GSEvent.hh"
+
+#include "DistributionSessionNotificationEvent.hh"
+
+using reftools::mbstf::DistSessionEventReportList;
+
+MBSTF_NAMESPACE_START
+
+namespace {
+  struct EventData {
+    const DistributionSessionSubscription &dist_session;
+  };
+}
+
+DistributionSessionNotificationEvent::DistributionSessionNotificationEvent(Open5GSEvent &event)
+    :Open5GSEvent(event.ogsEvent())
+{
+}
+
+DistributionSessionNotificationEvent::DistributionSessionNotificationEvent(const DistributionSessionSubscription &dist_session)
+    :Open5GSEvent(new ogs_event_t)
+{
+    ogs_event_t *evt = ogsEvent();
+    evt->id = LocalEvents::SEND_NOTIFICATION;
+    EventData *evt_data = new EventData{dist_session};
+    evt->sbi.data = reinterpret_cast<void*>(evt_data);
+}
+
+const DistributionSessionSubscription &DistributionSessionNotificationEvent::distributionSessionSubscription() const
+{
+    EventData *evt_data = reinterpret_cast<EventData*>(sbiData());
+    return evt_data->dist_session;
+}
+
+void DistributionSessionNotificationEvent::releaseEventData()
+{
+    EventData *evt_data = reinterpret_cast<EventData*>(sbiData());
+    delete evt_data;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/DistributionSessionNotificationEvent.hh
+++ b/src/mbstf/DistributionSessionNotificationEvent.hh
@@ -1,0 +1,51 @@
+#ifndef _MBS_TF_DISTRIBUTION_SESSION_NOTIFICATION_EVENT_HH_
+#define _MBS_TF_DISTRIBUTION_SESSION_NOTIFICATION_EVENT_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Notification Event
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include "common.hh"
+#include "Open5GSEvent.hh"
+
+MBSTF_NAMESPACE_START
+
+class DistributionSessionSubscription;
+
+class DistributionSessionNotificationEvent : public Open5GSEvent {
+public:
+    /* Constructors and Destructor */
+    DistributionSessionNotificationEvent(Open5GSEvent &event);
+    DistributionSessionNotificationEvent(const DistributionSessionSubscription &dist_session);
+    DistributionSessionNotificationEvent() = delete;
+    DistributionSessionNotificationEvent(DistributionSessionNotificationEvent &&other) = delete;
+    DistributionSessionNotificationEvent(const DistributionSessionNotificationEvent &other) = delete;
+
+    virtual ~DistributionSessionNotificationEvent() {};
+
+    /* operators */
+    DistributionSessionNotificationEvent &operator=(DistributionSessionNotificationEvent &&other) = delete;
+    DistributionSessionNotificationEvent &operator=(const DistributionSessionNotificationEvent &other) = delete;
+
+    const DistributionSessionSubscription &distributionSessionSubscription() const;
+    void releaseEventData();
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_DISTRIBUTION_SESSION_NOTIFICATION_EVENT_HH_ */

--- a/src/mbstf/DistributionSessionSubscription.cc
+++ b/src/mbstf/DistributionSessionSubscription.cc
@@ -1,0 +1,333 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Subscription class
+ ******************************************************************************
+ * Copyright: (C)2024-2025 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <chrono>
+#include <list>
+#include <memory>
+#include <string>
+
+#include <uuid/uuid.h>
+
+#include "common.hh"
+#include "App.hh"
+#include "DistributionSession.hh"
+#include "DistributionSessionNotificationEvent.hh"
+#include "openapi/model/DistSessionSubscription.h"
+#include "openapi/model/DistSessionEventReport.h"
+#include "openapi/model/DistSessionEventReportList.h"
+#include "openapi/model/StatusNotifyReqData.h"
+#include "utilities.hh"
+
+#include "DistributionSessionSubscription.hh"
+
+using reftools::mbstf::DistSessionEventReport;
+using reftools::mbstf::DistSessionEventReportList;
+using reftools::mbstf::DistSessionEventType;
+using reftools::mbstf::DistSessionSubscription;
+using reftools::mbstf::StatusNotifyReqData;
+using fiveg_mag_reftools::CJson;
+using fiveg_mag_reftools::ModelException;
+
+MBSTF_NAMESPACE_START
+
+struct RequestData {
+    const DistributionSessionSubscription *subscription;
+    std::shared_ptr<Open5GSSBIRequest> request;
+};
+
+/* Constructors and Destructor */
+DistributionSessionSubscription::DistributionSessionSubscription(const std::weak_ptr<DistributionSession> &dist_session,
+                                                                 CJson &json, bool as_request)
+    :m_distributionSession(dist_session)
+    ,m_subscriptionId()
+    ,m_eventTypes(0)
+    ,m_distSessionSubscription(json, as_request)
+    ,m_expiryTime()
+    ,m_cache(new DistributionSessionSubscription::CacheType{})
+{
+    _setSubscriptionId();
+    _setEventFlags();
+    _setExpiryTime();
+}
+
+DistributionSessionSubscription::DistributionSessionSubscription(const std::weak_ptr<DistributionSession> &dist_session,
+                                                                 const std::shared_ptr<DistSessionSubscription> &dist_session_subsc)
+    :m_distributionSession(dist_session)
+    ,m_subscriptionId()
+    ,m_eventTypes(0)
+    ,m_distSessionSubscription(*dist_session_subsc)
+    ,m_expiryTime()
+    ,m_cache(new DistributionSessionSubscription::CacheType{})
+{
+    _setSubscriptionId();
+    _setEventFlags();
+    _setExpiryTime();
+}
+
+DistributionSessionSubscription::DistributionSessionSubscription(DistributionSessionSubscription &&other)
+    :m_distributionSession(std::move(other.m_distributionSession))
+    ,m_subscriptionId(std::move(other.m_subscriptionId))
+    ,m_eventTypes(std::move(other.m_eventTypes))
+    ,m_distSessionSubscription(std::move(other.m_distSessionSubscription))
+    ,m_expiryTime(std::move(other.m_expiryTime))
+    ,m_cache(other.m_cache)
+{
+    other.m_cache = nullptr;
+}
+
+DistributionSessionSubscription::DistributionSessionSubscription(const DistributionSessionSubscription &other)
+    :m_distributionSession(other.m_distributionSession)
+    ,m_subscriptionId(other.m_subscriptionId)
+    ,m_eventTypes(other.m_eventTypes)
+    ,m_distSessionSubscription(other.m_distSessionSubscription)
+    ,m_expiryTime(other.m_expiryTime)
+    ,m_cache(new DistributionSessionSubscription::CacheType(*other.m_cache))
+{
+}
+
+DistributionSessionSubscription::~DistributionSessionSubscription()
+{
+    if (m_cache) {
+        delete m_cache;
+        m_cache = nullptr;
+    }
+}
+
+/* operators */
+DistributionSessionSubscription &DistributionSessionSubscription::operator=(DistributionSessionSubscription &&other)
+{
+    m_distributionSession = std::move(other.m_distributionSession);
+    m_subscriptionId = std::move(other.m_subscriptionId);
+    m_eventTypes = std::move(other.m_eventTypes);
+    m_distSessionSubscription = std::move(other.m_distSessionSubscription);
+    m_expiryTime = std::move(other.m_expiryTime);
+    if (m_cache) delete m_cache;
+    m_cache = other.m_cache;
+    other.m_cache = nullptr;
+    return *this;
+}
+
+DistributionSessionSubscription &DistributionSessionSubscription::operator=(const DistributionSessionSubscription &other)
+{
+    m_distributionSession = other.m_distributionSession;
+    m_subscriptionId = other.m_subscriptionId;
+    m_eventTypes = other.m_eventTypes;
+    m_distSessionSubscription = other.m_distSessionSubscription;
+    m_expiryTime = other.m_expiryTime;
+    *m_cache = *other.m_cache;
+    return *this;
+}
+
+bool DistributionSessionSubscription::operator==(const DistributionSessionSubscription &other) const
+{
+    //if (m_distributionSession != other.m_distributionSession) return false;
+    if (m_subscriptionId != other.m_subscriptionId) return false;
+    if (m_eventTypes != other.m_eventTypes) return false;
+    if (m_distSessionSubscription != other.m_distSessionSubscription) return false;
+    return true;
+}
+
+const std::string &DistributionSessionSubscription::notifyUri() const
+{
+    auto notify_uri = m_distSessionSubscription.getNotifyUri();
+    if (!notify_uri) {
+        static const std::string empty{};
+        return empty;
+    }
+    return notify_uri.value();
+}
+
+const std::optional<std::string> &DistributionSessionSubscription::correlationId() const
+{
+    return m_distSessionSubscription.getNotifyCorrelationId();
+}
+
+const std::optional<std::string> &DistributionSessionSubscription::nfcInstanceId() const
+{
+    return m_distSessionSubscription.getNfcInstanceId();
+}
+
+DistributionSessionSubscription &DistributionSessionSubscription::update(CJson &json, bool as_request)
+{
+    /* Update from json patch */
+    if (json.isArray()) {
+        for (auto json_patch_it = json.begin(); json_patch_it != json.end(); ++json_patch_it) {
+            m_distSessionSubscription.applyJSONPatch(*json_patch_it);
+        }
+    } else if (json.isObject()) {
+        m_distSessionSubscription.applyJSONPatch(json);
+    } else {
+        throw ModelException("Not a correctly formatted JSON patch list", "DistSessionSubscription");
+    }
+    _setEventFlags();
+    _setExpiryTime();
+    return *this;
+}
+
+/* OpenAPI type constructors */
+std::shared_ptr<DistSessionEventReportList> DistributionSessionSubscription::makeReportList() const
+{
+    std::shared_ptr<DistSessionEventReportList> result(new DistSessionEventReportList);
+    std::shared_ptr<DistributionSession> dist_session(m_distributionSession.lock());
+
+    if (m_cache && dist_session) {
+        /* get list of registered events from the DistributionSession */
+        const auto &dist_sess_event_timestamps = dist_session->eventTimestamps();
+        int bitmasks = m_eventTypes & dist_sess_event_timestamps.updatedSince(m_cache->lastReportedEventTimes);
+        /* compare list to cached times for last reported event and add any that are newer to the result list */
+#define ADD_LIST_EVENT(EVT,FIELD) \
+    do { \
+        if (bitmasks & DistributionSessionEvents::EVT) { \
+            DistSessionEventReport::EventTypeType evt_type(new DistSessionEventReport::EventTypeType::element_type); \
+            *evt_type = DistSessionEventType::VAL_ ## EVT; \
+            std::shared_ptr<DistSessionEventReport> report(new DistSessionEventReport); \
+            report->setEventType(std::move(evt_type)); \
+            report->setTimeStamp(time_point_to_iso8601_utc_str(dist_sess_event_timestamps.FIELD.value())); \
+            result->addEventReportList(report); \
+            m_cache->lastReportedEventTimes.FIELD = dist_sess_event_timestamps.FIELD; \
+        } \
+    } while (0)
+
+        ADD_LIST_EVENT(DATA_INGEST_FAILURE, dataIngestFailure);
+        ADD_LIST_EVENT(SESSION_DEACTIVATED, sessionDeactivated);
+        ADD_LIST_EVENT(SESSION_ACTIVATED, sessionActivated);
+        ADD_LIST_EVENT(SERVICE_MANAGEMENT_FAILURE, serviceManagementFailure);
+        ADD_LIST_EVENT(DATA_INGEST_SESSION_ESTABLISHED, dataIngestSessionEstablished);
+        ADD_LIST_EVENT(DATA_INGEST_SESSION_TERMINATED, dataIngestSessionTerminated);
+
+#undef ADD_LIST_EVENT
+
+        /* add correlation Id if we have it */
+        result->setNotifyCorrelationId(m_distSessionSubscription.getNotifyCorrelationId());
+    }
+
+    return result;
+}
+
+void DistributionSessionSubscription::pushNotificationsEvent() const
+{
+    std::shared_ptr<Open5GSEvent> event(new DistributionSessionNotificationEvent(*this));
+    App::self().ogsApp()->pushEvent(event);
+}
+
+void DistributionSessionSubscription::sendNotifications() const
+{
+    if (!m_cache) return; /* being destroyed or this DistributionSessionSubscription has been moved to another */
+
+    const auto &notify_uri = m_distSessionSubscription.getNotifyUri();
+    if (notify_uri) {
+        auto report_list = makeReportList();
+        const auto &reports = report_list->getEventReportList();
+        if (!reports.empty()) {
+            if (!m_cache->client) {
+                m_cache->client.reset(new Open5GSSBIClient(notify_uri.value()));
+            }
+            std::shared_ptr<StatusNotifyReqData> status_notify_req_data(new StatusNotifyReqData);
+            status_notify_req_data->setReportList(report_list);
+            CJson json = status_notify_req_data->toJSON(true);
+            std::string body(json.serialise());
+            std::shared_ptr<Open5GSSBIRequest> request(new Open5GSSBIRequest(OGS_SBI_HTTP_METHOD_POST, notify_uri.value(),
+                                                std::format("{}/{}", StatusNotifyReqData::apiName, StatusNotifyReqData::apiVersion),
+                                                body, OGS_SBI_CONTENT_JSON_TYPE));
+            RequestData *data = new RequestData{this, request};
+            m_cache->client->sendRequest(ogs_sbi_client_handler, request, data);
+        }
+    }
+}
+
+bool DistributionSessionSubscription::processClientResponse(const Open5GSEvent &event)
+{
+    switch (event.id()) {
+    case OGS_EVENT_SBI_CLIENT:
+    {
+        RequestData *req_data = reinterpret_cast<RequestData*>(event.sbiData());
+        if (req_data && req_data->subscription == this) {
+            auto resp = event.sbiResponse();
+            ogs_debug("Got %i response from notification(s) to %s", resp.status(), req_data->request->uri());
+            delete req_data;
+            return true;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return false;
+}
+
+void DistributionSessionSubscription::_setEventFlags()
+{
+    m_eventTypes = 0;
+    const auto &event_list = m_distSessionSubscription.getEventList();
+    for (const auto &dist_session_event_type : event_list) {
+        if (dist_session_event_type) {
+            switch (dist_session_event_type.value()->getValue()) {
+            case DistSessionEventType::VAL_DATA_INGEST_FAILURE:
+                m_eventTypes |= DistributionSessionEvents::DATA_INGEST_FAILURE;
+                break;
+            case DistSessionEventType::VAL_SESSION_DEACTIVATED:
+                m_eventTypes |= DistributionSessionEvents::SESSION_DEACTIVATED;
+                break;
+            case DistSessionEventType::VAL_SESSION_ACTIVATED:
+                m_eventTypes |= DistributionSessionEvents::SESSION_ACTIVATED;
+                break;
+            case DistSessionEventType::VAL_SERVICE_MANAGEMENT_FAILURE:
+                m_eventTypes |= DistributionSessionEvents::SERVICE_MANAGEMENT_FAILURE;
+                break;
+            case DistSessionEventType::VAL_DATA_INGEST_SESSION_ESTABLISHED:
+                m_eventTypes |= DistributionSessionEvents::DATA_INGEST_SESSION_ESTABLISHED;
+                break;
+            case DistSessionEventType::VAL_DATA_INGEST_SESSION_TERMINATED:
+                m_eventTypes |= DistributionSessionEvents::DATA_INGEST_SESSION_TERMINATED;
+                break;
+            default:
+                ogs_warn("Ignoring unknown DistSessionEventType: %s", dist_session_event_type.value()->getString().c_str());
+                break;
+            }
+        }
+    }
+}
+
+void DistributionSessionSubscription::_setExpiryTime()
+{
+    auto opt_expiry_time = m_distSessionSubscription.getExpiryTime();
+    if (!opt_expiry_time) {
+        m_expiryTime.reset();
+    } else {
+        std::chrono::utc_clock::time_point utc_exp_time;
+        std::istringstream is{opt_expiry_time.value()};
+        is.imbue(std::locale("C"));
+        is >> std::chrono::parse("%FT%TZ", utc_exp_time);
+        m_expiryTime = std::chrono::utc_clock::to_sys(utc_exp_time);
+    }
+}
+
+void DistributionSessionSubscription::_setSubscriptionId()
+{
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    char uuid_str[37];
+    uuid_unparse(uuid, uuid_str);
+    m_subscriptionId = uuid_str;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/DistributionSessionSubscription.hh
+++ b/src/mbstf/DistributionSessionSubscription.hh
@@ -1,0 +1,123 @@
+#ifndef _MBS_TF_DISTRIBUTION_SESSION_SUBSCRIPTION_HH_
+#define _MBS_TF_DISTRIBUTION_SESSION_SUBSCRIPTION_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Subscription class
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <chrono>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "common.hh"
+#include "DistributionSessionEvents.hh"
+#include "Open5GSSBIClient.hh"
+#include "openapi/model/DistSessionSubscription.h"
+
+namespace fiveg_mag_reftools {
+    class CJson;
+}
+
+namespace reftools::mbstf {
+    class DistSessionEventReportList;
+}
+
+MBSTF_NAMESPACE_START
+
+class DistributionSession;
+class Open5GSEvent;
+
+class DistributionSessionSubscription {
+public:
+    using DateTime = std::chrono::system_clock::time_point;
+
+    /* Constructors and Destructor */
+    DistributionSessionSubscription(const std::weak_ptr<DistributionSession> &dist_session, fiveg_mag_reftools::CJson &json,
+                                    bool as_request);
+    DistributionSessionSubscription(const std::weak_ptr<DistributionSession> &dist_session,
+                                    const std::shared_ptr<reftools::mbstf::DistSessionSubscription> &dist_session_subsc);
+    DistributionSessionSubscription() = delete;
+    DistributionSessionSubscription(DistributionSessionSubscription &&other);
+    DistributionSessionSubscription(const DistributionSessionSubscription &other);
+
+    virtual ~DistributionSessionSubscription();
+
+    /* operators */
+    DistributionSessionSubscription &operator=(DistributionSessionSubscription &&other);
+    DistributionSessionSubscription &operator=(const DistributionSessionSubscription &other);
+    bool operator==(const DistributionSessionSubscription &other) const;
+    bool operator!=(const DistributionSessionSubscription &other) const { return !(*this == other); };
+
+    /* Getters */
+    const std::string &subscriptionId() const { return m_subscriptionId; };
+    const int eventTypes() const { return m_eventTypes; }; /* returns ORed DistributionSessionEvents::EventTypeBitMask */
+    const std::string &notifyUri() const;
+    const std::optional<std::string> &correlationId() const;
+    const std::optional<DateTime> &expiryTime() const { return m_expiryTime; };
+    const std::optional<std::string> &nfcInstanceId() const;
+
+    /* Setters */
+    DistributionSessionSubscription &update(fiveg_mag_reftools::CJson &json, bool as_request=false);
+
+    /* OpenAPI type constructors */
+    const reftools::mbstf::DistSessionSubscription &distSessionSubscription() const { return m_distSessionSubscription; };
+    std::shared_ptr<reftools::mbstf::DistSessionEventReportList> makeReportList() const;
+
+    /** Push local SEND_NOTIFICATIONS event
+     * This will push an event onto the event queue which will call sendNotifications() from the event thread
+     */
+    void pushNotificationsEvent() const;
+
+    /** Send Notifications to client
+     * This will find the current report list and if not empty will open a client connection and send the report list to the
+     * notifyUri location.
+     */
+    void sendNotifications() const;
+
+    bool processClientResponse(const Open5GSEvent &event);
+
+private:
+    void _setEventFlags();
+    void _setExpiryTime();
+    void _setSubscriptionId();
+
+    std::weak_ptr<DistributionSession> m_distributionSession; /* Parent distribution session */
+    
+    std::string m_subscriptionId;
+    int m_eventTypes; /* ORed EventTypeBitMask */
+    reftools::mbstf::DistSessionSubscription m_distSessionSubscription;
+    std::optional<DateTime> m_expiryTime;
+    std::optional<std::string> m_subscriptionLocation;
+
+    struct CacheType {
+        CacheType() : lastReportedEventTimes(), client() {};
+        CacheType(const CacheType &other) : lastReportedEventTimes(other.lastReportedEventTimes), client() {};
+        CacheType(CacheType &&other) : lastReportedEventTimes(std::move(other.lastReportedEventTimes)), client(std::move(other.client)) {};
+        CacheType &operator=(const CacheType &other) {lastReportedEventTimes = other.lastReportedEventTimes; client.reset(); return *this; };
+        CacheType &operator=(CacheType &&other) {lastReportedEventTimes = std::move(other.lastReportedEventTimes); client = std::move(other.client); return *this; };
+        DistributionSessionEvents lastReportedEventTimes;
+        std::unique_ptr<Open5GSSBIClient> client;
+    } *m_cache;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_DISTRIBUTION_SESSION_SUBSCRIPTION_HH_ */

--- a/src/mbstf/Event.cc
+++ b/src/mbstf/Event.cc
@@ -84,9 +84,14 @@ void Event::preventDefault()
     m_preventDefault = true;
 }
 
-Event Event::clone()
+Event Event::clone() const
 {
     return Event(*this);
+}
+
+Event *Event::newClone() const
+{
+    return new Event(*this);
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/Event.hh
+++ b/src/mbstf/Event.hh
@@ -40,7 +40,8 @@ public:
     bool stopProcessingFlag() const { return m_stopProcessing; };
     bool preventDefaultFlag() const { return m_preventDefault; };
 
-    virtual Event clone();
+    virtual Event clone() const;
+    virtual Event *newClone() const;
 
     virtual std::string reprString() const { return std::string("Event(\"") + m_eventName + "\")"; };
 private:

--- a/src/mbstf/LocalEvents.hh
+++ b/src/mbstf/LocalEvents.hh
@@ -21,6 +21,7 @@
 #include "ogs-proto.h"
 
 #include "common.hh"
+#include "Open5GSEvent.hh"
 
 MBSTF_NAMESPACE_START
 
@@ -29,6 +30,12 @@ public:
     typedef enum {
         SEND_NOTIFICATION = OGS_MAX_NUM_OF_PROTO_EVENT+1000
     } LocalEventIds;
+
+    static const char *getEventName(Open5GSEvent &event) {
+        if (event.id() < OGS_MAX_NUM_OF_PROTO_EVENT) return ogs_event_get_name(event.ogsEvent());
+        if (event.id() == SEND_NOTIFICATION) return "SEND_NOTIFICATION";
+        return "Unknown event";
+    };
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/LocalEvents.hh
+++ b/src/mbstf/LocalEvents.hh
@@ -1,7 +1,7 @@
-#ifndef _MBS_TF_UTILITIES_HH_
-#define _MBS_TF_UTILITIES_HH_
+#ifndef _MBS_TF_LOCAL_EVENTS_HH_
+#define _MBS_TF_LOCAL_EVENTS_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Common utility functions
+ * 5G-MAG Reference Tools: MBS Traffic Function: Local Events
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
@@ -18,20 +18,21 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
-#include <chrono>
-#include <string>
+#include "ogs-proto.h"
 
 #include "common.hh"
 
 MBSTF_NAMESPACE_START
 
-std::string trim_slashes(const std::string &path);
-
-std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
-std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
+class LocalEvents {
+public:
+    typedef enum {
+        SEND_NOTIFICATION = OGS_MAX_NUM_OF_PROTO_EVENT+1000
+    } LocalEventIds;
+};
 
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:
  */
-#endif /* _MBS_TF_UTILITIES_HH_ */
+#endif /* _MBS_TF_LOCAL_EVENTS_HH_ */

--- a/src/mbstf/MBSTFEventHandler.cc
+++ b/src/mbstf/MBSTFEventHandler.cc
@@ -25,6 +25,7 @@
 
 #include "common.hh"
 #include "DistributionSession.hh"
+#include "LocalEvents.hh"
 #include "Open5GSEvent.hh"
 #include "Open5GSFSM.hh"
 #include "Open5GSSBIServer.hh"
@@ -41,7 +42,7 @@ MBSTF_NAMESPACE_START
 void MBSTFEventHandler::dispatch(Open5GSFSM &fsm, Open5GSEvent &event)
 {
     // Handle Open5GS FSM events here
-    ogs_debug("MBSTF Event: %s", ogs_event_get_name(event.ogsEvent()));
+    ogs_debug("MBSTF Event: %s", LocalEvents::getEventName(event));
 
     if (DistributionSession::processEvent(event)) return;
 
@@ -55,7 +56,7 @@ void MBSTFEventHandler::dispatch(Open5GSFSM &fsm, Open5GSEvent &event)
 
     case OGS_EVENT_SBI_SERVER:
         {
-            Open5GSSBIRequest request(event.sbiRequest());
+            auto request = event.sbiRequest(true);
             Open5GSSBIStream stream(reinterpret_cast<ogs_sbi_stream_t*>(event.sbiData()));
 
             Open5GSSBIMessage message;

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -89,6 +89,9 @@ void ObjectController::processEvent(Event &event, SubscriptionService &event_ser
             inactive_state = DistSessionState::VAL_INACTIVE;
             distributionSession().setState(inactive_state);
         }
+    } else if (event.eventName() == "ObjectAdded") {
+        /* object successfully added to the object store */
+        m_consecutiveIngestFailures = 0;
     }
 }
 

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -83,7 +83,7 @@ void ObjectController::processEvent(Event &event, SubscriptionService &event_ser
         ogs_debug("Object ingest failed for %s: reason = %i", ingest_failed_event.url().c_str(), ingest_failed_event.failureType());
         m_consecutiveIngestFailures++;
         sendEventSynchronous(event); /* repeat ingest failure event to subscribers of this ObjectController */
-        auto max_failures = App::self().context()->consecutiveIngestFailuresBeforeAbort;
+        auto max_failures = App::self().context()->consecutiveIngestFailuresBeforeDeactivate;
         if (max_failures != 0 && m_consecutiveIngestFailures >= max_failures) {
             DistSessionState inactive_state;
             inactive_state = DistSessionState::VAL_INACTIVE;

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -42,7 +42,7 @@ public:
         ,m_packager()
         ,m_nextId(1)
         ,m_consecutiveIngestFailures(0)
-    {};
+    { subscribeTo({"ObjectAdded"}, m_objectStore); };
     ObjectController(const ObjectController &) = delete;
     ObjectController(ObjectController &&) = delete;
 

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -41,6 +41,7 @@ public:
         ,m_pushIngester()
         ,m_packager()
         ,m_nextId(1)
+        ,m_consecutiveIngestFailures(0)
     {};
     ObjectController(const ObjectController &) = delete;
     ObjectController(ObjectController &&) = delete;
@@ -100,6 +101,7 @@ private:
     std::shared_ptr<PushObjectIngester> m_pushIngester;
     std::shared_ptr<ObjectPackager> m_packager;
     std::atomic_int m_nextId;
+    int m_consecutiveIngestFailures;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectIngester.cc
+++ b/src/mbstf/ObjectIngester.cc
@@ -10,11 +10,21 @@
  * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
 
+#include <sstream>
+#include <string>
+
 #include "common.hh"
 
 #include "ObjectIngester.hh"
 
 MBSTF_NAMESPACE_START
+
+std::string ObjectIngester::IngestFailedEvent::reprString() const
+{
+    std::ostringstream oss;
+    oss << "ObjectIngester::IngestFailedEvent(\"" << m_url << "\", " << m_failureType << ")";
+    return oss.str();
+}
 
 void ObjectIngester::workerLoop(ObjectIngester *ingester)
 {

--- a/src/mbstf/ObjectIngester.cc
+++ b/src/mbstf/ObjectIngester.cc
@@ -24,6 +24,11 @@ void ObjectIngester::workerLoop(ObjectIngester *ingester)
 
 }
 
+void ObjectIngester::emitObjectIngestFailedEvent(const std::string &url, ObjectIngester::IngestFailedEvent::FailureType fail_type)
+{
+    sendEventAsynchronous(IngestFailedEvent(url, fail_type));
+}
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/ObjectIngester.hh
+++ b/src/mbstf/ObjectIngester.hh
@@ -53,6 +53,11 @@ public:
         const std::string &url() const { return m_url; };
         FailureType failureType() const { return m_failureType; };
 
+        virtual Event clone() const { return IngestFailedEvent(*this); };
+        virtual Event *newClone() const { return new IngestFailedEvent(*this); };
+
+        virtual std::string reprString() const;
+
     private:
         std::string m_url;
         FailureType m_failureType;

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -118,6 +118,8 @@ void ObjectListController::processEvent(Event &event, SubscriptionService &event
         }
         // event.preventDefault() if checks fail
     }
+    ObjectController::processEvent(event, event_service);
+
     // TODO: Forward ingest and packager events for DistributionSessionSubscriptions notifications
     // else if (event.eventName() == "ObjectIngestFailed") { emitDataIngestFailedEvent(); }
     // else if (event.eventName() == "FluteSessionStarted") { emitSessionActivatedEvent(); }

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -13,6 +13,7 @@
  */
 
 #include <atomic>
+#include <format>
 #include <memory>
 #include <optional>
 #include <thread>
@@ -39,11 +40,28 @@ class ObjectPackager: public SubscriptionService {
 public:
    class ObjectSendCompleted : public Event {
     public:
-        ObjectSendCompleted(const std::string& object_id)
-            : Event("ObjectSendCompleted"), m_object_id(object_id) {}
+        ObjectSendCompleted(const std::string& object_id) :Event("ObjectSendCompleted"), m_object_id(object_id) {};
+        ObjectSendCompleted(const ObjectSendCompleted &other) :Event(other), m_object_id(other.m_object_id) {};
+        ObjectSendCompleted(ObjectSendCompleted &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
 
-        std::string objectId() const { return m_object_id; }
         virtual ~ObjectSendCompleted() {};
+
+        ObjectSendCompleted &operator=(const ObjectSendCompleted &other) {
+            Event::operator=(other);
+            m_object_id = other.m_object_id;
+            return *this;
+        };
+        ObjectSendCompleted &operator=(ObjectSendCompleted &&other) {
+            Event::operator=(std::move(other));
+            m_object_id = std::move(other.m_object_id);
+            return *this;
+        };
+
+        std::string objectId() const { return m_object_id; };
+
+        virtual Event clone() const { return ObjectSendCompleted(*this); };
+        virtual Event *newClone() const { return new ObjectSendCompleted(*this); };
+        virtual std::string reprString() const { return std::format("ObjectSendCompleted(\"{}\")", m_object_id); };
 
     private:
         std::string m_object_id;

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -48,11 +48,28 @@ public:
 
     class ObjectAddedEvent : public Event {
     public:
-        ObjectAddedEvent(const std::string& object_id)
-            : Event("ObjectAdded"), m_object_id(object_id) {}
+        ObjectAddedEvent(const std::string& object_id) :Event("ObjectAdded"), m_object_id(object_id) {};
+        ObjectAddedEvent(const ObjectAddedEvent &other) :Event(other), m_object_id(other.m_object_id) {};
+        ObjectAddedEvent(ObjectAddedEvent &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
+
+        virtual ~ObjectAddedEvent() {};
+
+        ObjectAddedEvent &operator=(const ObjectAddedEvent &other) {
+            Event::operator=(other);
+            m_object_id = other.m_object_id;
+            return *this;
+        };
+        ObjectAddedEvent &operator=(ObjectAddedEvent &&other) {
+            Event::operator=(std::move(other));
+            m_object_id = std::move(other.m_object_id);
+            return *this;
+        };
 
         std::string objectId() const { return m_object_id; }
-        virtual ~ObjectAddedEvent() {};
+
+        virtual Event clone() const { return ObjectAddedEvent(*this); };
+        virtual Event *newClone() const { return new ObjectAddedEvent(*this); };
+        virtual std::string reprString() const { return std::format("ObjectAddedEvent(\"{}\")", m_object_id); };
 
     private:
         std::string m_object_id;
@@ -60,11 +77,28 @@ public:
 
     class ObjectDeletedEvent : public Event {
     public:
-        ObjectDeletedEvent(const std::string& object_id)
-            : Event("ObjectDeleted"), m_object_id(object_id) {}
+        ObjectDeletedEvent(const std::string& object_id) :Event("ObjectDeleted"), m_object_id(object_id) {};
+        ObjectDeletedEvent(const ObjectDeletedEvent &other) :Event(other), m_object_id(other.m_object_id) {};
+        ObjectDeletedEvent(ObjectDeletedEvent &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
+
+        virtual ~ObjectDeletedEvent() {};
+
+        ObjectDeletedEvent &operator=(const ObjectDeletedEvent &other) {
+            Event::operator=(other);
+            m_object_id = other.m_object_id;
+            return *this;
+        };
+        ObjectDeletedEvent &operator=(ObjectDeletedEvent &&other) {
+            Event::operator=(std::move(other));
+            m_object_id = std::move(other.m_object_id);
+            return *this;
+        };
 
         std::string objectId() const { return m_object_id; }
-        virtual ~ObjectDeletedEvent() {};
+
+        virtual Event clone() const { return ObjectDeletedEvent(*this); };
+        virtual Event *newClone() const { return new ObjectDeletedEvent(*this); };
+        virtual std::string reprString() const { return std::format("ObjectDeletedEvent(\"{}\")", m_object_id); };
 
     private:
         std::string m_object_id;

--- a/src/mbstf/Open5GSSBIClient.cc
+++ b/src/mbstf/Open5GSSBIClient.cc
@@ -47,7 +47,6 @@ Open5GSSBIClient::Open5GSSBIClient(ogs_sbi_client_t *client)
 Open5GSSBIClient::Open5GSSBIClient(const std::string &url)
 {
 
-    ogs_sbi_client_t *client = NULL;
     OpenAPI_uri_scheme_e scheme = OpenAPI_uri_scheme_NULL;
     ogs_sockaddr_t *addr = NULL;
     bool rc;
@@ -58,7 +57,7 @@ Open5GSSBIClient::Open5GSSBIClient(const std::string &url)
          throw std::runtime_error("Failed to get sockaddr from uri!");
      }
      m_ogsClient = ogs_sbi_client_add(scheme, addr);
-     ogs_assert(client);
+     ogs_assert(m_ogsClient);
      ogs_freeaddrinfo(addr);
 }
 

--- a/src/mbstf/Open5GSSBIClient.hh
+++ b/src/mbstf/Open5GSSBIClient.hh
@@ -30,6 +30,7 @@ MBSTF_NAMESPACE_START
 
 class Open5GSSBIStream;
 class Open5GSSBIMessage;
+class Open5GSSBIRequest;
 
 class Open5GSSBIClient {
 public:

--- a/src/mbstf/Open5GSSBIClient.hh
+++ b/src/mbstf/Open5GSSBIClient.hh
@@ -47,7 +47,7 @@ public:
     ogs_sockaddr_t *ogsSockaddr(std::shared_ptr<Open5GSSBIClient> &client);
     ogs_sbi_client_t *ogsSBIClient() { return m_ogsClient; };
 
-    /*static*/ bool sendRequest(ogs_sbi_client_cb_f client_notify_cb,  std::shared_ptr<Open5GSSBIRequest> request, void *data);
+    /*static*/ bool sendRequest(ogs_sbi_client_cb_f client_notify_cb, std::shared_ptr<Open5GSSBIRequest> request, void *data);
 
     operator bool() const { return !!m_ogsClient; };
 

--- a/src/mbstf/Open5GSSBIRequest.cc
+++ b/src/mbstf/Open5GSSBIRequest.cc
@@ -31,12 +31,17 @@
 
 MBSTF_NAMESPACE_START
 
+Open5GSSBIRequest::Open5GSSBIRequest(ogs_sbi_request_t *request, bool owner)
+    :m_request(request)
+    ,m_owner(owner)
+{
+    //ogs_debug("Open5GSSBIRequest[%p]: created from ogs_sbi_request_t %p (owner=%i)", this, m_request, m_owner);
+}
+
 Open5GSSBIRequest::Open5GSSBIRequest(const std::string &method, const std::string &uri, const std::string &apiVersion, const std::optional<std::string> &data, const std::optional<std::string> &type)
     :m_request(ogs_sbi_request_new())
     ,m_owner(true)
 {
-
-    m_request = ogs_sbi_request_new();
     m_request->h.method = ogs_strdup(method.c_str());
     m_request->h.uri = ogs_strdup(uri.c_str());
     m_request->h.api.version = ogs_strdup(apiVersion.c_str());
@@ -55,6 +60,16 @@ Open5GSSBIRequest::Open5GSSBIRequest(const std::string &method, const std::strin
         ogs_sbi_header_set(m_request->http.headers, "Content-Type", nullptr);
     }
 
+    //ogs_debug("Open5GSSBIRequest[%p]: created from parameters, ogs_sbi_request_t = %p", this, m_request);
+}
+
+Open5GSSBIRequest::~Open5GSSBIRequest()
+{
+    //ogs_debug("Open5GSSBIRequest[%p]: deleting", this);
+    if (m_owner && m_request) {
+        //ogs_debug("Open5GSSBIRequest[%p]: freeing ogs_sbi_request_t %p", this, m_request);
+        ogs_sbi_request_free(m_request);
+    }
 }
 
 std::string Open5GSSBIRequest::headerValue(const std::string &field, const std::string &defval) const

--- a/src/mbstf/Open5GSSBIRequest.cc
+++ b/src/mbstf/Open5GSSBIRequest.cc
@@ -37,12 +37,12 @@ Open5GSSBIRequest::Open5GSSBIRequest(const std::string &method, const std::strin
 {
 
     m_request = ogs_sbi_request_new();
-    m_request->h.method = (char *)method.c_str();
-    m_request->h.uri = (char *)uri.c_str();
-    m_request->h.api.version = (char *)apiVersion.c_str();
+    m_request->h.method = ogs_strdup(method.c_str());
+    m_request->h.uri = ogs_strdup(uri.c_str());
+    m_request->h.api.version = ogs_strdup(apiVersion.c_str());
 
     if (data) {
-        m_request->http.content = const_cast<char*>(data->c_str());
+        m_request->http.content = ogs_strdup(data->c_str());
         m_request->http.content_length = data->size();
     } else {
         m_request->http.content = nullptr;

--- a/src/mbstf/Open5GSSBIRequest.hh
+++ b/src/mbstf/Open5GSSBIRequest.hh
@@ -37,14 +37,14 @@ public:
     using HeadersMap = std::map<CaseInsensitiveString, std::function<void(const CaseInsensitiveString &field, const char *val)> >;
     using ParametersMap = std::map<std::string, std::function<void(const std::string &param, const char *val)> >;
 
-    Open5GSSBIRequest(ogs_sbi_request_t *request, bool owner = true) :m_request(request), m_owner(owner) {};
+    Open5GSSBIRequest(ogs_sbi_request_t *request, bool owner = true);
     Open5GSSBIRequest(const std::string &method, const std::string &uri, const std::string &apiVersion, const std::optional<std::string> &data, const std::optional<std::string> &type);
     Open5GSSBIRequest() = delete;
     Open5GSSBIRequest(Open5GSSBIRequest &&other) = delete;
     Open5GSSBIRequest(const Open5GSSBIRequest &other) = delete;
     Open5GSSBIRequest &operator=(Open5GSSBIRequest &&other) = delete;
     Open5GSSBIRequest &operator=(const Open5GSSBIRequest &other) = delete;
-    virtual ~Open5GSSBIRequest() {if (m_owner) ogs_sbi_request_free(m_request);};
+    virtual ~Open5GSSBIRequest();
 
     ogs_sbi_request_t *ogsSBIRequest() { return m_request; };
     const ogs_sbi_request_t *ogsSBIRequest() const { return m_request; };

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -205,6 +205,7 @@ void PullObjectIngester::doObjectIngest() {
                 emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
             }
             m_ingestItemsMutex->lock();
+            if (m_fetchList.empty()) sendEventAsynchronous(new ObjectPullQueueExhaustedEvent);
 	}
     }
 }

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -135,7 +135,10 @@ void PullObjectIngester::sortListByPolicy() {
 }
 
 void PullObjectIngester::doObjectIngest() {
-    if(!m_curl) m_curl = std::make_shared<Curl>();
+    if (!m_curl) {
+        m_curl = std::make_shared<Curl>();
+    }
+
     {
         std::lock_guard<std::recursive_mutex> lock(*m_ingestItemsMutex);
         if (m_fetchList.empty()) {
@@ -196,10 +199,10 @@ void PullObjectIngester::doObjectIngest() {
 
             } else if (bytesReceived == -1) {
                 ogs_error("Request timed out.");
-                // emitObjectIngestFailedEvent();
+                emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::TIMED_OUT);
             } else {
                 ogs_error("An error occurred while fetching the data.");
-                // emitObjectIngestFailedEvent();
+                emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
             }
             m_ingestItemsMutex->lock();
 	}

--- a/src/mbstf/PullObjectIngester.hh
+++ b/src/mbstf/PullObjectIngester.hh
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "common.hh"
+#include "Event.hh"
 #include "ObjectIngester.hh"
 #include "ObjectStore.hh"
 
@@ -29,6 +30,15 @@ class PullObjectIngester : public ObjectIngester {
 public:
 
     using time_type = std::chrono::system_clock::time_point;
+
+    class ObjectPullQueueExhaustedEvent : public Event {
+    public:
+        static constexpr const char *event_name = "ObjectPullQueueExhausted";
+        ObjectPullQueueExhaustedEvent() :Event(event_name) {};
+        virtual Event clone() const { return ObjectPullQueueExhaustedEvent(); };
+        virtual Event *newClone() const { return new ObjectPullQueueExhaustedEvent; };
+        virtual std::string reprString() const { return "ObjectPullQueueExhaustedEvent()"; };
+    };
 
     class IngestItem {
     public:

--- a/src/mbstf/PushObjectIngester.cc
+++ b/src/mbstf/PushObjectIngester.cc
@@ -182,6 +182,27 @@ void PushObjectIngester::Request::requestHandler(struct MHD_Connection *connecti
     MHD_destroy_response(m_mhdResponse);
 }
 
+std::string PushObjectIngester::Request::reprString() const
+{
+    std::ostringstream oss;
+    oss << "PushObjectIngester::Request().method(\"" << m_method << "\").urlPath(\"" << m_urlPath << "\").protocolVersion(\""
+        << m_protocolVersion << "\")";
+    if (m_etag) {
+        oss << ".etag(\"" << m_etag.value() << "\")";
+    }
+    if (m_contentType) {
+        oss << ".contentType(\"" << m_contentType.value() << "\")";
+    }
+    if (m_expires) {
+        oss << ".expiryTime(\"" << m_expires.value() << "\")";
+    }
+    if (m_lastModified) {
+        oss << ".lastModified(\"" << m_lastModified.value() << "\")";
+    }
+
+    return oss.str();
+}
+
 /********************** PushObjectIngester::ObjectPushEvent ***************/
 
 PushObjectIngester::ObjectPushEvent *PushObjectIngester::ObjectPushEvent::makeStartEvent(const std::shared_ptr<Request> &request)

--- a/src/mbstf/PushObjectIngester.cc
+++ b/src/mbstf/PushObjectIngester.cc
@@ -170,6 +170,12 @@ void PushObjectIngester::Request::requestHandler(struct MHD_Connection *connecti
         processRequest();
     }
 
+    if (m_statusCode >= 400 && m_statusCode <= 499) {
+        m_pushObjectIngester.emitObjectIngestFailedEvent(m_urlPath, ObjectIngester::IngestFailedEvent::CLIENT_ERROR);
+    } else if (m_statusCode >= 500 && m_statusCode <= 599) {
+        m_pushObjectIngester.emitObjectIngestFailedEvent(m_urlPath, ObjectIngester::IngestFailedEvent::SERVER_ERROR);
+    }
+
     ogs_info("Queue response (%u) for %s to microhttpd", m_statusCode, m_urlPath.c_str());
     // Queue the request
     MHD_queue_response(connection, m_statusCode, m_mhdResponse);

--- a/src/mbstf/PushObjectIngester.hh
+++ b/src/mbstf/PushObjectIngester.hh
@@ -28,7 +28,7 @@ MBSTF_NAMESPACE_START
 class ObjectStore;
 class ObjectController;
 
-class PushObjectIngester : public ObjectIngester, public SubscriptionService {
+class PushObjectIngester : public ObjectIngester {
 public:
 
     class Request {

--- a/src/mbstf/SubscriptionService.cc
+++ b/src/mbstf/SubscriptionService.cc
@@ -273,7 +273,7 @@ bool SubscriptionService::sendEventSynchronous(Event &event)
 void SubscriptionService::sendEventAsynchronous(Event &&event)
 {
     std::lock_guard guard(*m_asyncMutex);
-    m_asyncEventQueue.emplace_back(std::shared_ptr<Event>(new Event(std::move(event))));
+    m_asyncEventQueue.emplace_back(std::shared_ptr<Event>(event.newClone()));
     m_asyncCondVar.notify_all();
     startAsyncLoop();
 }

--- a/src/mbstf/mbstf.yaml.in
+++ b/src/mbstf/mbstf.yaml.in
@@ -188,7 +188,7 @@ mbstf:
       - addr: 127.0.0.61
         port: 0 # ephemeral
     totalMaxBitRateSoftLimit: 1000 # 1Gbps
-    consecutiveIngestFailuresBeforeAbort: 5
+    consecutiveIngestFailuresBeforeDeactivate: 5
     serverResponseCacheControl:
       - distMaxAge: 60
         ObjectMaxAge: 60

--- a/src/mbstf/mbstf.yaml.in
+++ b/src/mbstf/mbstf.yaml.in
@@ -188,6 +188,7 @@ mbstf:
       - addr: 127.0.0.61
         port: 0 # ephemeral
     totalMaxBitRateSoftLimit: 1000 # 1Gbps
+    consecutiveIngestFailuresBeforeAbort: 5
     serverResponseCacheControl:
       - distMaxAge: 60
         ObjectMaxAge: 60

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -90,10 +90,17 @@ libmbstf_dist_sources = files('''
     DASHManifestHandler.hh
     DistributionSession.cc
     DistributionSession.hh
+    DistributionSessionEvents.cc
+    DistributionSessionEvents.hh
+    DistributionSessionNotificationEvent.cc
+    DistributionSessionNotificationEvent.hh
+    DistributionSessionSubscription.cc
+    DistributionSessionSubscription.hh
     Event.cc
     Event.hh
     EventHandler.hh
     hash.hh
+    LocalEvents.hh
     ManifestHandler.hh
     ManifestHandlerFactory.cc
     ManifestHandlerFactory.hh

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -16,6 +16,8 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <chrono>
+#include <format>
 #include <string>
 
 #include "common.hh"
@@ -37,6 +39,14 @@ std::string time_point_to_http_datetime_str(const std::chrono::system_clock::tim
     return std::format("%b, %d %b %Y %T GMT", datetime);
 }
 
+std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime)
+{
+    std::ostringstream oss;
+    auto datetime_us = std::chrono::time_point_cast<std::chrono::microseconds>(datetime);
+    oss.imbue(std::locale("C"));
+    oss << std::format("{0:%F}T{0:%T}Z", datetime_us);
+    return oss.str();
+}
 
 MBSTF_NAMESPACE_STOP
 

--- a/tests/test_SubscriberSubscription.cc
+++ b/tests/test_SubscriberSubscription.cc
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <exception>
+#include <format>
 #include <iostream>
 #include <optional>
 #include <mutex>
@@ -30,10 +31,13 @@ class EventType1 : public Event
 {
 public:
     EventType1(int data) :Event("Type1"),m_data(data) {};
+    EventType1(const EventType1 &other) :Event(other), m_data(other.m_data) {};
 
     virtual ~EventType1() {};
 
-    virtual Event clone() {return EventType1(m_data);};
+    virtual Event clone() const {return EventType1(*this);};
+    virtual Event *newClone() const {return new EventType1(*this);};
+    virtual std::string reprString() const { return std::format("EventType1({})", m_data); };
 
     int data() const { return m_data; };
 
@@ -45,10 +49,13 @@ class EventType2 : public Event
 {
 public:
     EventType2(int data) :Event("Type2"),m_data(data) {};
+    EventType2(const EventType2 &other) :Event(other), m_data(other.m_data) {};
 
     virtual ~EventType2() {};
 
-    virtual Event clone() {return EventType2(m_data);};
+    virtual Event clone() const {return EventType2(*this);};
+    virtual Event *newClone() const {return new EventType2(*this);};
+    virtual std::string reprString() const { return std::format("EventType2({})", m_data); };
 
     int data() const { return m_data; };
 


### PR DESCRIPTION
Closes #38
Closes #40 

This adds the Distribution Session Status Subscription RESTful API and notification request generation for subscribers.
Will also set the Distribution Session state to INACTIVE if there are too many consecutive ingest failures or a SINGLE PULL mode exhausts its acquisitions list.