### PR TITLE
Use new FLUTE activate/deactivate in rt-libflute

### DIFF
--- a/src/mbstf/App.cc
+++ b/src/mbstf/App.cc
@@ -18,6 +18,7 @@
  */
 
 #include "ogs-core.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include <stdexcept>
 

--- a/src/mbstf/Curl.cc
+++ b/src/mbstf/Curl.cc
@@ -16,6 +16,7 @@
 #include <map>
 
 #include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include "common.hh"
 #include "mbstf-version.h"

--- a/src/mbstf/DASHManifestHandler.cc
+++ b/src/mbstf/DASHManifestHandler.cc
@@ -27,6 +27,8 @@
 #include <libmpd++/SegmentAvailability.hh>
 
 #include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
+
 #include "common.hh"
 #include "DistributionSession.hh"
 #include "ManifestHandler.hh"
@@ -67,8 +69,6 @@ DASHManifestHandler::DASHManifestHandler(const ObjectStore::Object &object, Obje
       oss << is;
       ogs_debug("    %s", oss.str().c_str());
     }
-
-
 }
 
 DASHManifestHandler::~DASHManifestHandler()
@@ -77,7 +77,6 @@ DASHManifestHandler::~DASHManifestHandler()
 
 std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifestHandler::nextIngestItems()
 {
-
     std::list<PullObjectIngester::IngestItem> ingest_items;
     static const std::string empty;
     auto current_time = std::chrono::system_clock::now();
@@ -95,7 +94,7 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
         if(ms.availabilityStartTime() < current_time)
 	    ms.availabilityStartTime(current_time);
     }
-    ogs_info("MEDIA SEGS: %zu", media_segments.size());
+    ogs_debug("MEDIA SEGS: %zu", media_segments.size());
     for (auto &sa : media_segments) {
       std::ostringstream oss;
       oss << sa;
@@ -106,7 +105,7 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
 
         media_segments.sort();
 
-        ogs_info("AVAILABLE SEGS: SORTED  %zu", media_segments.size());
+        ogs_debug("AVAILABLE SEGS: SORTED  %zu", media_segments.size());
 	for (auto &seg : media_segments) {
             std::ostringstream oss;
             oss << seg;
@@ -119,12 +118,16 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
 
         // Find existing object in the ObjectStore for same URL
         const auto &object_store = m_controller->objectStore();
+        const auto &obj_ingest_base_url = m_controller->distributionSession().getObjectIngestBaseUrl();
+        const auto &obj_dist_base_url = m_controller->distributionSession().objectDistributionBaseUrl();
         auto existing_obj = object_store.findMetadataByURL(segment_url);
 
-        ingest_items.emplace_back(existing_obj?existing_obj->objectId():nextObjectId(), first_media_segment.segmentURL(), empty,
-                                    m_controller->distributionSession().getObjectIngestBaseUrl(),
-				    m_controller->distributionSession().objectDistributionBaseUrl(),
-                                    first_media_segment.availabilityEndTime());
+        if (existing_obj) {
+            ingest_items.emplace_back(*existing_obj, first_media_segment.availabilityEndTime());
+        } else {
+            ingest_items.emplace_back(nextObjectId(), first_media_segment.segmentURL(), empty, obj_ingest_base_url,
+                                      obj_dist_base_url, first_media_segment.availabilityEndTime());
+        }
         removeExtraPullObjectsEntry(first_media_segment);
 
 	try {
@@ -134,17 +137,18 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
 	    throw;
         }
         auto it = media_segments.begin();
-        // Iterate from second element.
+        // Iterate from second element to find ones with the same availabilityStartTime() as the first and add them to result.
         for ( ++it; it != media_segments.end(); ++it ) {
             if (it->availabilityStartTime() != fetch_time) break;
             segment_url = it->segmentURL();
             existing_obj = object_store.findMetadataByURL(segment_url);
 	    removeExtraPullObjectsEntry(*it);
-	    ingest_items.emplace_back(existing_obj?existing_obj->objectId():nextObjectId(), segment_url, empty,
-                                      m_controller->distributionSession().getObjectIngestBaseUrl(),
-                                      m_controller->distributionSession().objectDistributionBaseUrl(),
-                                      it->availabilityEndTime());
-
+            if (existing_obj) {
+                ingest_items.emplace_back(*existing_obj, it->availabilityEndTime());
+            } else {
+                ingest_items.emplace_back(nextObjectId(), segment_url, empty, obj_ingest_base_url, obj_dist_base_url,
+                                          it->availabilityEndTime());
+            }
             if (it->segmentURL() == manifest_url) m_refreshMpd = true;
         }
     }
@@ -164,18 +168,10 @@ void DASHManifestHandler::addMPDRefreshToExtraPullObjects()
     }
 }
 
-
 void DASHManifestHandler::removeExtraPullObjectsEntry(const SegmentAvailability &segment)
 {
-    for (auto it = m_extraPullObjects.begin(); it != m_extraPullObjects.end(); it++)
-    {
-       if(it->segmentURL() == segment.segmentURL()) {
-          m_extraPullObjects.erase(it);
-	  break;
-       }
-    }
+    m_extraPullObjects.remove_if([&segment](const SegmentAvailability &item){ return item.segmentURL() == segment.segmentURL(); });
 }
-
 
 std::string DASHManifestHandler::nextObjectId()
 {
@@ -190,7 +186,6 @@ std::string DASHManifestHandler::generateUUID() {
     return std::string(uuid_str);
 }
 
-
 ManifestHandler::durn_type DASHManifestHandler::getDefaultDeadline()
 {
     // TODO: get the segment length from the DASH MPD
@@ -201,29 +196,22 @@ bool DASHManifestHandler::update(const ObjectStore::Object &new_manifest)
 {
     // Process the new MPD and see what has changed, throw an exception of the Object is not understood or invalid
 
+    auto new_mpd = ingest_manifest(new_manifest);
     {
         std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
         m_refreshMpd = false;
-        m_mpd = ingest_manifest(new_manifest);
-        m_mpd.selectAllRepresentations();
-        //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
-        m_extraPullObjects = m_mpd.selectedInitializationSegments();
+        if (m_mpd != new_mpd) {
+            ogs_debug("New MPD update, changing MPD");
+            m_mpd = new_mpd;
+            m_manifest = &new_manifest;
+            m_mpd.selectAllRepresentations();
+            //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
+            m_extraPullObjects = m_mpd.selectedInitializationSegments();
+        }
     }
     addMPDRefreshToExtraPullObjects();
 
-    return true; // assume manifest updated, use false for no manifest change
-}
-
-void DASHManifestHandler::adjustAvailabilityStartTime() {
-    if(!m_extraPullObjects.empty()) {
-        time_type current_time = std::chrono::system_clock::now();
-        for (auto &segment : m_extraPullObjects) {
-            if (segment.availabilityStartTime() < current_time) {
-                segment.availabilityStartTime(current_time);
-            }
-        }
-        m_extraPullObjects.sort();
-    }
+    return true; // update completed successfully
 }
 
 static bool g_registered = ManifestHandlerFactory::registerManifestHandler("application/dash+xml", new ManifestHandlerConstructorClass<DASHManifestHandler>());

--- a/src/mbstf/DASHManifestHandler.cc
+++ b/src/mbstf/DASHManifestHandler.cc
@@ -9,15 +9,19 @@
  * program. If this file is missing then the license can be retrieved from
  * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
-#include <chrono>
-#include <string>
-#include <cstring>
-#include <sstream>
-#include <iostream>
-#include <stdexcept>
-#include <exception>
-#include <optional>
 #include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <list>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+
 #include <uuid/uuid.h>
 
 #include <libmpd++/SegmentAvailability.hh>
@@ -45,10 +49,12 @@ static LIBMPDPP_NAMESPACE_CLASS(MPD) ingest_manifest(const ObjectStore::Object &
 
 DASHManifestHandler::DASHManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution)
     :ManifestHandler(controller, pull_distribution)
+    ,m_mpdMutex()
     ,m_mpd(ingest_manifest(object))
     ,m_manifest(&object)
     ,m_refreshMpd(false)
 {
+    std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
     m_mpd.selectAllRepresentations();
 
     //Use selectedInitializationSegments() to fetch Initialization Segments
@@ -79,7 +85,11 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
     std::string manifest_url;
     time_type fetch_time;
 
-    std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> media_segments = m_mpd.selectedSegmentAvailability();
+    std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> media_segments;
+    {
+        std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
+        media_segments = m_mpd.selectedSegmentAvailability();
+    }
     media_segments.insert(media_segments.end(), m_extraPullObjects.begin(), m_extraPullObjects.end());
     for (auto &ms: media_segments) {
         if(ms.availabilityStartTime() < current_time)
@@ -144,13 +154,14 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
 
 void DASHManifestHandler::addMPDRefreshToExtraPullObjects()
 {
-
-      if (m_pullDistribution && m_mpd.hasMinimumUpdatePeriod()) {
+    std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
+    if (m_pullDistribution && m_mpd.hasMinimumUpdatePeriod()) {
         auto min_update_time = m_manifest->second.receivedTime() + m_mpd.minimumUpdatePeriod().value();
-        auto time_to_update = m_manifest->second.hasExpiryTime() ? std::max(min_update_time, m_manifest->second.ExpiryTime()): min_update_time;
-         m_extraPullObjects.push_back(SegmentAvailability(time_to_update, 0s, m_manifest->second.getFetchedUrl(), m_mpd.availabilityEndTime()));
-
-     }
+        auto time_to_update = m_manifest->second.hasExpiryTime()?std::max(min_update_time, m_manifest->second.ExpiryTime())
+                                                                :min_update_time;
+        m_extraPullObjects.push_back(SegmentAvailability(time_to_update, 0s, m_manifest->second.getFetchedUrl(),
+                                                         m_mpd.availabilityEndTime()));
+    }
 }
 
 
@@ -162,9 +173,7 @@ void DASHManifestHandler::removeExtraPullObjectsEntry(const SegmentAvailability 
           m_extraPullObjects.erase(it);
 	  break;
        }
-
     }
-
 }
 
 
@@ -192,11 +201,14 @@ bool DASHManifestHandler::update(const ObjectStore::Object &new_manifest)
 {
     // Process the new MPD and see what has changed, throw an exception of the Object is not understood or invalid
 
-    m_refreshMpd = false;
-    m_mpd = ingest_manifest(new_manifest);
-    m_mpd.selectAllRepresentations();
-    //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
-    m_extraPullObjects = m_mpd.selectedInitializationSegments();
+    {
+        std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
+        m_refreshMpd = false;
+        m_mpd = ingest_manifest(new_manifest);
+        m_mpd.selectAllRepresentations();
+        //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
+        m_extraPullObjects = m_mpd.selectedInitializationSegments();
+    }
     addMPDRefreshToExtraPullObjects();
 
     return true; // assume manifest updated, use false for no manifest change

--- a/src/mbstf/DASHManifestHandler.hh
+++ b/src/mbstf/DASHManifestHandler.hh
@@ -11,6 +11,10 @@
  * program. If this file is missing then the license can be retrieved from
  * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
+#include <list>
+#include <string>
+#include <thread>
+#include <utility>
 
 #include <libmpd++/libmpd++.hh>
 
@@ -45,6 +49,7 @@ private:
   void addMPDRefreshToExtraPullObjects();
   void removeExtraPullObjectsEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &segment);
 
+  std::recursive_mutex m_mpdMutex;
   LIBMPDPP_NAMESPACE_CLASS(MPD)  m_mpd;
   const ObjectStore::Object *m_manifest;
   bool m_refreshMpd;

--- a/src/mbstf/DASHManifestHandler.hh
+++ b/src/mbstf/DASHManifestHandler.hh
@@ -45,7 +45,6 @@ public:
 
 private:
   std::string generateUUID();
-  void adjustAvailabilityStartTime();
   void addMPDRefreshToExtraPullObjects();
   void removeExtraPullObjectsEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &segment);
 

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -730,6 +730,11 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     return *this;
 }
 
+void DistributionSession::haveEmptyQueue()
+{
+    _haveEmptyQueue();
+}
+
 /**** private: ****/
 
 DistributionSession::InitStateAction DistributionSession::Action::initState()
@@ -742,6 +747,11 @@ DistributionSession::StateTransitionAction DistributionSession::Action::stateTra
     return DistributionSession::StateTransitionAction(new_state);
 }
 
+DistributionSession::EmptyQueueAction DistributionSession::Action::emptyQueue()
+{
+    return DistributionSession::EmptyQueueAction();
+}
+
 void DistributionSession::_transitionTo(DistSessionState::Enum new_state)
 {
     auto act = Action::stateTransition(new_state);
@@ -752,6 +762,11 @@ void DistributionSession::_changeState(void (DistributionSession::*f)(const Dist
 {
     m_currentStateFunction = std::bind(f, this, std::placeholders::_1);
     m_currentStateFunction(Action::initState());
+}
+
+void DistributionSession::_haveEmptyQueue()
+{
+    m_currentStateFunction(Action::emptyQueue());
 }
 
 void DistributionSession::_constructedState(const DistributionSession::Action &action)
@@ -883,6 +898,8 @@ void DistributionSession::_deactivatingState(const DistributionSession::Action &
     case Action::INIT_STATE:
         ogs_debug("DistributionSession(%p) entering DEACTIVATING state", this);
         m_controller->deactivateOutput();
+        break;
+    case Action::EMPTY_QUEUE:
         _registerEvent(DistributionSessionEvents::DATA_INGEST_SESSION_TERMINATED);
         /* once we've deactivated everything, always go to inactive state */
         if (getState().getValue() == DistSessionState::VAL_DEACTIVATING) {
@@ -902,7 +919,6 @@ void DistributionSession::_deactivatingState(const DistributionSession::Action &
                 break;
             case DistSessionState::VAL_ESTABLISHED:
             case DistSessionState::VAL_ACTIVE:
-                throw std::runtime_error("Invalid state transition in DistSession");
             case DistSessionState::VAL_DEACTIVATING:
                 break;
             default:

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -103,18 +103,20 @@ public:
     void removeSubscription(const std::string &subscription_id);
     
     const DistributionSessionEvents &eventTimestamps() const { return m_eventTimestamps; };
-    // TODO: Forwarding Events from the Controller to m_eventSubscriptions
-    // virtual void processEvent(Event &event, SubscriptionService &event_service);
+
+    void haveEmptyQueue();
 
 private:
     class InitStateAction;
     class StateTransitionAction;
+    class EmptyQueueAction;
 
     class Action {
     public:
         typedef enum {
             INIT_STATE,
-            STATE_TRANSITION
+            STATE_TRANSITION,
+            EMPTY_QUEUE
         } ActionType;
 
         Action(ActionType typ): m_type(typ) {};
@@ -124,6 +126,7 @@ private:
 
         static InitStateAction initState();
         static StateTransitionAction stateTransition(reftools::mbstf::DistSessionState::Enum new_state);
+        static EmptyQueueAction emptyQueue();
     protected:
         ActionType m_type;
     };
@@ -144,8 +147,14 @@ private:
         reftools::mbstf::DistSessionState::Enum m_newState;
     };
 
+    class EmptyQueueAction : public Action {
+    public:
+        EmptyQueueAction() :Action(Action::EMPTY_QUEUE) {};
+    };
+
     void _transitionTo(reftools::mbstf::DistSessionState::Enum new_state);
     void _changeState(void (DistributionSession::*f)(const DistributionSession::Action &action));
+    void _haveEmptyQueue();
     void _constructedState(const Action &action);
     void _inactiveState(const Action &action);
     void _establishedState(const Action &action);

--- a/src/mbstf/DistributionSessionSubscription.cc
+++ b/src/mbstf/DistributionSessionSubscription.cc
@@ -24,6 +24,8 @@
 
 #include <uuid/uuid.h>
 
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
+
 #include "common.hh"
 #include "App.hh"
 #include "DistributionSession.hh"

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -13,6 +13,8 @@
 #include <memory>
 #include <list>
 
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
+
 #include "common.hh"
 #include "App.hh"
 #include "Controller.hh"

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -83,6 +83,10 @@ void ObjectController::processEvent(Event &event, SubscriptionService &event_ser
 	} else {
             ogs_debug("Keeping object [%s] in object store after sending...", object_id.c_str());
 	}
+
+        if (objSendEvent.queueEmpty()) {
+            distributionSession().haveEmptyQueue();
+        }
     } else if (event.eventName() == ObjectIngester::IngestFailedEvent::event_name) {
         ObjectIngester::IngestFailedEvent &ingest_failed_event = dynamic_cast<ObjectIngester::IngestFailedEvent&>(event);
         ogs_debug("Object ingest failed for %s: reason = %i", ingest_failed_event.url().c_str(), ingest_failed_event.failureType());
@@ -111,6 +115,7 @@ std::string ObjectController::nextObjectId()
 const std::shared_ptr<ObjectPackager> &ObjectController::packager(ObjectPackager *packager)
 {
     m_packager.reset(packager);
+    subscribeTo({"ObjectSendCompleted"}, *m_packager.get());
     return m_packager;
 }
 
@@ -121,13 +126,12 @@ const std::optional<std::string> &ObjectController::getObjectDistributionBaseUrl
 void ObjectController::reconfigureObjectStore()
 {
     auto &dist_session = distributionSession();
-    m_objectStore.reconfigureMetadatas(dist_session.getObjectIngestBaseUrl(), dist_session.objectDistributionBaseUrl());
+    m_objectStore->reconfigureMetadatas(dist_session.getObjectIngestBaseUrl(), dist_session.objectDistributionBaseUrl());
 }
 
 void ObjectController::establishInactiveInputs()
 {
     m_pullIngesters.clear();
-    m_packager.reset();
     if (distributionSession().getObjectAcquisitionMethod() == "PUSH" && !m_pushIngester) initPushObjectIngester();
 }
 
@@ -138,12 +142,16 @@ void ObjectController::establishActiveInputs()
 
 void ObjectController::activateOutput()
 {
-    if (!m_packager) setObjectPackager();
+    if (!m_packager) {
+        setObjectPackager();
+    } else {
+        activateObjectPackager();
+    }
 }
 
 void ObjectController::deactivateOutput()
 {
-    if (m_packager) unsetObjectPackager();
+    if (m_packager) deactivateObjectPackager();
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -36,13 +36,13 @@ public:
     ObjectController(DistributionSession &distributionSession)
         :Controller(distributionSession)
 	,Subscriber()
-        ,m_objectStore(*this)
+        ,m_objectStore(new ObjectStore(*this))
         ,m_pullIngesters()
         ,m_pushIngester()
         ,m_packager()
         ,m_nextId(1)
         ,m_consecutiveIngestFailures(0)
-    { subscribeTo({"ObjectAdded"}, m_objectStore); };
+    { subscribeTo({"ObjectAdded"}, objectStore()); };
     ObjectController(const ObjectController &) = delete;
     ObjectController(ObjectController &&) = delete;
 
@@ -51,8 +51,8 @@ public:
     ObjectController &operator=(const ObjectController &) = delete;
     ObjectController &operator=(ObjectController &&) = delete;
 
-    const ObjectStore &objectStore() const { return m_objectStore; };
-    ObjectStore &objectStore() { return m_objectStore; };
+    const ObjectStore &objectStore() const { return *m_objectStore.get(); };
+    ObjectStore &objectStore() { return *m_objectStore.get(); };
 
     const std::list<std::shared_ptr<PullObjectIngester>> &getPullObjectIngesters() const {return m_pullIngesters;};
 
@@ -93,11 +93,13 @@ protected:
     virtual void initPullObjectIngesters() = 0;
     virtual void setObjectPackager() = 0;
     virtual void unsetObjectPackager() = 0;
+    virtual void activateObjectPackager() = 0;
+    virtual void deactivateObjectPackager() = 0;
 
     std::recursive_mutex m_pullObjectIngestersMutex;
 
 private:
-    ObjectStore m_objectStore;
+    std::shared_ptr<ObjectStore> m_objectStore;
     std::list<std::shared_ptr<PullObjectIngester>> m_pullIngesters;
     std::shared_ptr<PushObjectIngester> m_pushIngester;
     std::shared_ptr<ObjectPackager> m_packager;

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -93,6 +93,16 @@ void ObjectListController::unsetObjectPackager() {
     packager(nullptr);
 }
 
+void ObjectListController::activateObjectPackager() {
+    packager()->activate();
+}
+
+void ObjectListController::deactivateObjectPackager() {
+    if (packager()->deactivate()) {
+        distributionSession().haveEmptyQueue();
+    }
+}
+
 std::shared_ptr<ObjectListPackager> ObjectListController::getObjectListPackager() const
 {
     return std::dynamic_pointer_cast<ObjectListPackager>(packager());

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -22,6 +22,7 @@
 #include <uuid/uuid.h>
 
 #include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include "common.hh"
 #include "ControllerFactory.hh"
@@ -183,8 +184,14 @@ void ObjectListController::initPullObjectIngesters()
 
                 }
 
-                urls.emplace_back(std::move(PullObjectIngester::IngestItem(nextObjectId(), obj_ingest_url, url_str,
-                                                                           object_ingest_base_url, object_distribution_base_url)));
+                const auto *metadata = objectStore().findMetadataByURL(obj_ingest_url);
+                if (metadata) {
+                    /* refetch existing object */
+                    urls.emplace_back(*metadata);
+                } else {
+                    /* fetch new URL */
+                    urls.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url);
+                }
             }
         }
 

--- a/src/mbstf/ObjectListController.hh
+++ b/src/mbstf/ObjectListController.hh
@@ -66,6 +66,8 @@ protected:
     virtual void initPullObjectIngesters();
     virtual void setObjectPackager();
     virtual void unsetObjectPackager();
+    virtual void activateObjectPackager();
+    virtual void deactivateObjectPackager();
 
 private:
     void sendToPackager(const std::string &objectId);

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -115,6 +115,7 @@ bool ObjectListPackager::add(const PackageItem &item) {
     ogs_debug("ObjectListPackager::add(): deactivating=%s", m_deactivating?"true":"false");
     if (m_deactivating) return false;
     std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.objectId() == pkg_item.objectId(); });
     m_packageItems.push_back(item);
     sortListByPolicy();
     return true;
@@ -124,6 +125,7 @@ bool ObjectListPackager::add(PackageItem &&item) {
     ogs_debug("ObjectListPackager::add(): deactivating=%s", m_deactivating?"true":"false");
     if (m_deactivating) return false;
     std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.objectId() == pkg_item.objectId(); });
     m_packageItems.push_back(std::move(item));
     sortListByPolicy();
     return true;
@@ -162,112 +164,101 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
 }
 
 void ObjectListPackager::doObjectPackage() {
-#if 0
-    try {
-#else
-    {
-#endif
-        std::optional<std::string> destAddr = destIpAddr();
+    std::optional<std::string> destAddr = destIpAddr();
 
-        if (destAddr)
-        {
-            if (!m_transmitter) {
-                m_transmitter = new LibFlute::Transmitter(
-                        destAddr.value(),
-                        static_cast<short>(port()),
-                        0,
-                        mtu(),
-                        rateLimit(),
-                        m_io,
-                        m_tunnelEndpoint,
-                        LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
-                m_transmitter->register_completion_callback(
-                        [this](uint32_t toi) {
-                            ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter->number_of_files());
-                            bool queue_empty = (m_transmitter->number_of_files() == 0);
-                            if (m_queuedToi == toi) {
-                                m_queued = false;
-                                objectSendCompletion(m_queuedObjectId, queue_empty);
-                                ogs_info("Transmitted: Object with TOI: %d", toi);
-                            } else {
-                                ogs_error("Unscheduled completion of Object with TOI: %d", toi);
-                            }
-                            std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
-                            if (m_deactivating && queue_empty) {
-                                ogs_debug("Deactivating FLUTE stream on last file");
-                                m_transmitter->deactivate();
-                                abort();
-                                m_deactivating = false;
-                            }
-                        });
+    if (!destAddr) return;
 
-                // emitFluteSessionStartedEvent();
-            }
-            {
-                std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
-
-                if (!m_packageItems.empty() && !m_queued) {
-                    auto &item = m_packageItems.front();
-	            m_packageItemsMutex->unlock();
-                    std::string location;
-		    m_queuedObjectId = item.objectId();
-                    std::vector<unsigned char> &objData = objectStore().getObjectData(item.objectId());
-                    ObjectStore::Metadata &metadata = objectStore().getMetadata(item.objectId());
-                    std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
-                    std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
-
-                    // If we need to substitute objIngestBaseUrl for objDistributionBaseUrl then do so
-                    if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
-                        metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
-                        location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
+    if (!m_transmitter) {
+        m_transmitter = new LibFlute::Transmitter(
+                destAddr.value(),
+                static_cast<short>(port()),
+                0,
+                mtu(),
+                rateLimit(),
+                m_io,
+                m_tunnelEndpoint,
+                LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
+        m_transmitter->register_completion_callback(
+                [this](uint32_t toi) {
+                    ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter->number_of_files());
+                    bool queue_empty = (m_transmitter->number_of_files() == 0);
+                    if (m_queuedToi == toi) {
+                        m_queued = false;
+                        objectSendCompletion(m_queuedObjectId, queue_empty);
+                        ogs_info("Transmitted: Object with TOI: %d", toi);
                     } else {
-                        // Just use the fetched URL
-                        location = metadata.getFetchedUrl();
+                        ogs_error("Unscheduled completion of Object with TOI: %d", toi);
                     }
-                    std::shared_ptr<LibFlute::Transmitter::FileDescription> file_desc(metadata.fluteFileDescription());
-                    if (!file_desc) {
-                        ogs_debug("New FileDescription(%s, ...)", location.c_str());
-                        file_desc.reset(new LibFlute::Transmitter::FileDescription(location, objData));
-                        metadata.fluteFileDescription(file_desc);
-                    } else {
-                        ogs_debug("Existing FileDescription(%s, ...)", file_desc->file_entry().content_location.c_str());
-                        file_desc->set_content_location(location);
-                        ogs_debug("Set FileDescription location to %s", location.c_str());
-                        file_desc->set_content(objData);
+                    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+                    if (m_deactivating && queue_empty) {
+                        ogs_debug("Deactivating FLUTE stream on last file");
+                        m_transmitter->deactivate();
+                        abort();
+                        m_deactivating = false;
                     }
-                        
-                    m_queued = true;
-                    LibFlute::Transmitter::FileDescription::date_time_type expires_at;
-                    const auto &cache_expires = metadata.cacheExpires();
-                    if (cache_expires) {
-                        expires_at = cache_expires.value();
-                    } else {
-                        expires_at = LibFlute::Transmitter::FileDescription::date_time_type::clock::now() + 60s;
-                    }
-                    file_desc->set_expiry_time(expires_at);
+                });
 
-                    file_desc->set_content_type(metadata.mediaType());
-
-                    const auto &entity_tag = metadata.entityTag();
-                    if (entity_tag) {
-                        file_desc->set_etag(entity_tag.value());
-                    }
-
-                    m_queuedToi = m_transmitter->send(file_desc);
-
-                    m_packageItemsMutex->lock();
-                    m_packageItems.pop_front();
-                }
-	    }
-
-            m_io.run_one();
-        }
-#if 0
-    } catch (std::exception &ex) {
-        ogs_error("Exiting on unhandled exception: %s", ex.what());
-        // emitFluteSessionFailedEvent();
-#endif
+        // emitFluteSessionStartedEvent();
     }
+
+    {
+        std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
+
+        if (!m_packageItems.empty() && !m_queued) {
+            auto &item = m_packageItems.front();
+            m_packageItemsMutex->unlock();
+            std::string location;
+            m_queuedObjectId = item.objectId();
+            std::vector<unsigned char> &objData = objectStore().getObjectData(item.objectId());
+            ObjectStore::Metadata &metadata = objectStore().getMetadata(item.objectId());
+            std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
+            std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
+
+            // If we need to substitute objIngestBaseUrl for objDistributionBaseUrl then do so
+            if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
+                metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
+                location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
+            } else {
+                // Just use the fetched URL
+                location = metadata.getFetchedUrl();
+            }
+            std::shared_ptr<LibFlute::Transmitter::FileDescription> file_desc(metadata.fluteFileDescription());
+            if (!file_desc) {
+                ogs_debug("New FileDescription(%s, ...)", location.c_str());
+                file_desc.reset(new LibFlute::Transmitter::FileDescription(location, objData));
+                metadata.fluteFileDescription(file_desc);
+            } else {
+                ogs_debug("Existing FileDescription(%s, ...)", file_desc->file_entry().content_location.c_str());
+                file_desc->set_content_location(location);
+                ogs_debug("Set FileDescription location to %s", location.c_str());
+                file_desc->set_content(objData);
+            }
+
+            m_queued = true;
+            LibFlute::Transmitter::FileDescription::date_time_type expires_at;
+            const auto &cache_expires = metadata.cacheExpires();
+            if (cache_expires) {
+                expires_at = cache_expires.value();
+            } else {
+                expires_at = LibFlute::Transmitter::FileDescription::date_time_type::clock::now() + 60s;
+            }
+            file_desc->set_expiry_time(expires_at);
+
+            file_desc->set_content_type(metadata.mediaType());
+
+            const auto &entity_tag = metadata.entityTag();
+            if (entity_tag) {
+                file_desc->set_etag(entity_tag.value());
+            }
+
+            m_queuedToi = m_transmitter->send(file_desc);
+
+            m_packageItemsMutex->lock();
+            m_packageItems.pop_front();
+        }
+    }
+
+    m_io.run_one();
 }
 
 void ObjectListPackager::sortListByPolicy() {

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -21,6 +21,7 @@
 #include <netinet/in.h>
 
 #include "ogs-app.h" // ogs_error(), ogs_info()
+#include "ogs-sbi.h"
 #include "Transmitter.h" // LibFlute
 
 #include "common.hh"
@@ -104,10 +105,15 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
 
 ObjectListPackager::~ObjectListPackager() {
     abort();
-    if (m_transmitter) delete m_transmitter;
+    if (m_transmitter) {
+        delete m_transmitter;
+        m_transmitter = NULL;
+    }
 }
 
 bool ObjectListPackager::add(const PackageItem &item) {
+    ogs_debug("ObjectListPackager::add(): deactivating=%s", m_deactivating?"true":"false");
+    if (m_deactivating) return false;
     std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
     m_packageItems.push_back(item);
     sortListByPolicy();
@@ -115,6 +121,8 @@ bool ObjectListPackager::add(const PackageItem &item) {
 }
 
 bool ObjectListPackager::add(PackageItem &&item) {
+    ogs_debug("ObjectListPackager::add(): deactivating=%s", m_deactivating?"true":"false");
+    if (m_deactivating) return false;
     std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
     m_packageItems.push_back(std::move(item));
     sortListByPolicy();
@@ -154,7 +162,11 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
 }
 
 void ObjectListPackager::doObjectPackage() {
+#if 0
     try {
+#else
+    {
+#endif
         std::optional<std::string> destAddr = destIpAddr();
 
         if (destAddr)
@@ -171,12 +183,21 @@ void ObjectListPackager::doObjectPackage() {
                         LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
                 m_transmitter->register_completion_callback(
                         [this](uint32_t toi) {
+                            ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter->number_of_files());
+                            bool queue_empty = (m_transmitter->number_of_files() == 0);
                             if (m_queuedToi == toi) {
                                 m_queued = false;
-                                objectSendCompletion(m_queuedObjectId);
+                                objectSendCompletion(m_queuedObjectId, queue_empty);
                                 ogs_info("Transmitted: Object with TOI: %d", toi);
                             } else {
                                 ogs_error("Unscheduled completion of Object with TOI: %d", toi);
+                            }
+                            std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+                            if (m_deactivating && queue_empty) {
+                                ogs_debug("Deactivating FLUTE stream on last file");
+                                m_transmitter->deactivate();
+                                abort();
+                                m_deactivating = false;
                             }
                         });
 
@@ -241,9 +262,11 @@ void ObjectListPackager::doObjectPackage() {
 
             m_io.run_one();
         }
+#if 0
     } catch (std::exception &ex) {
         ogs_error("Exiting on unhandled exception: %s", ex.what());
         // emitFluteSessionFailedEvent();
+#endif
     }
 }
 
@@ -256,9 +279,9 @@ void ObjectListPackager::sortListByPolicy() {
     });
 }
 
-void ObjectListPackager::objectSendCompletion(std::string &object_id)
+void ObjectListPackager::objectSendCompletion(std::string &object_id, bool queue_empty)
 {
-    std::shared_ptr<Event> event(new ObjectListPackager::ObjectSendCompleted(object_id));
+    std::shared_ptr<Event> event(new ObjectListPackager::ObjectSendCompleted(object_id, queue_empty));
     sendEventAsynchronous(event);
 }
 

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -83,7 +83,7 @@ protected:
 
 private:
     void sortListByPolicy();
-    void objectSendCompletion(std::string &object_id);
+    void objectSendCompletion(std::string &object_id, bool queue_empty);
     std::list<PackageItem> m_packageItems;
     std::optional<boost::asio::ip::udp::endpoint> m_tunnelEndpoint;
     std::unique_ptr<std::recursive_mutex> m_packageItemsMutex;

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -115,10 +115,14 @@ std::string ObjectManifestController::generateUUID()
 
 void ObjectManifestController::workerLoop(ObjectManifestController *controller)
 {
+    controller->m_scheduledPullRunning = true;
     /* Don't process if the session is inactive or deactivating */
     {
         const auto &session_state = controller->distributionSession().getState();
-        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) return;
+        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+            controller->m_scheduledPullRunning = false;
+            return;
+        }
     }
 
     /* wait for a ManifestHandler to be created */
@@ -129,22 +133,35 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
                 break;
             }
             const auto &session_state = controller->distributionSession().getState();
-            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) return;
+            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+                controller->m_scheduledPullRunning = false;
+                return;
+            }
         }
         // Avoid a tight busy-loop: yield or sleep for a short time.
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
-    if (controller->m_scheduledPullCancel) return;
+    if (controller->m_scheduledPullCancel) {
+        controller->m_scheduledPullRunning = false;
+        return;
+    }
+
     {
         const auto &session_state = controller->distributionSession().getState();
-        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) return;
+        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+            controller->m_scheduledPullRunning = false;
+            return;
+        }
     }
 
     while (!controller->m_scheduledPullCancel) {
         {
             const auto &session_state = controller->distributionSession().getState();
-            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) return;
+            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+                controller->m_scheduledPullRunning = false;
+                return;
+            }
         }
 
         std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> next_ingest_items;
@@ -181,7 +198,10 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
 	std::this_thread::sleep_until(fetch_time);
         {
             const auto &session_state = controller->distributionSession().getState();
-            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) return;
+            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+                controller->m_scheduledPullRunning = false;
+                return;
+            }
         }
 
         {
@@ -200,11 +220,13 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
             }
 	}
     }
+    controller->m_scheduledPullRunning = false;
 }
 
 void ObjectManifestController::startWorker()
 {
-    if(m_scheduledPullThread.get_id() == std::thread::id()) {
+    if (!m_scheduledPullRunning) {
+        if (m_scheduledPullThread.joinable()) m_scheduledPullThread.detach();
         m_scheduledPullThread = std::thread(&ObjectManifestController::workerLoop, this);
     }
 }

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -20,6 +20,7 @@
 #include <netinet/in.h>
 
 #include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include "common.hh"
 #include "DistributionSession.hh"
@@ -79,7 +80,14 @@ void ObjectManifestController::initPullObjectIngesters()
 
                 }
 
-                urls.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url);
+                const auto *metadata = objectStore().findMetadataByURL(obj_ingest_url);
+                if (metadata) {
+                    /* this is a refetch */
+                    urls.emplace_back(*metadata);
+                } else {
+                    /* this is a new URL */
+                    urls.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url);
+                }
             }
         }
 

--- a/src/mbstf/ObjectManifestController.hh
+++ b/src/mbstf/ObjectManifestController.hh
@@ -46,7 +46,7 @@ public:
 
     void abort() {
         m_scheduledPullCancel = true;
-        if (m_scheduledPullThread.joinable()) {
+        if (m_scheduledPullThread.get_id() != std::this_thread::get_id() && m_scheduledPullThread.joinable()) {
             m_scheduledPullThread.join();
         }
 
@@ -95,6 +95,7 @@ private:
     mutable std::recursive_mutex m_manifestHandlerMutex;
     std::thread m_scheduledPullThread;
     std::atomic_bool m_scheduledPullCancel;
+    std::atomic_bool m_scheduledPullRunning;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectPackager.cc
+++ b/src/mbstf/ObjectPackager.cc
@@ -10,9 +10,16 @@
  * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
 
+// spdlog includes
 #include "spdlog/spdlog.h"
 
+// rt-libflute includes
+#include "Transmitter.h"
+
+// local includes
 #include "common.hh"
+
+// this class include
 #include "ObjectPackager.hh"
 
 MBSTF_NAMESPACE_START
@@ -22,9 +29,11 @@ auto spdlog_logger = spdlog::default_logger();
 
 void ObjectPackager::workerLoop(ObjectPackager *packager)
 {
+    packager->m_workerRunning = true;
     while(!packager->m_workerCancel){
        packager->doObjectPackage();
     }
+    packager->m_workerRunning = false;
 }
 
 ObjectPackager& ObjectPackager::setDestIpAddr(const std::optional<std::string> &dest_ip_addr) {
@@ -45,6 +54,31 @@ ObjectPackager& ObjectPackager::setMtu(unsigned short mtu) {
 ObjectPackager& ObjectPackager::setRateLimit(uint32_t rateLimit) {
     m_rateLimit = rateLimit;
     return *this;
+}
+
+void ObjectPackager::activate()
+{
+    if (m_transmitter) {
+        ogs_debug("Activating FLUTE stream");
+        m_transmitter->activate();
+    }
+    m_workerCancel = false;
+    startWorker();
+}
+
+bool ObjectPackager::deactivate()
+{
+    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+    m_deactivating = true;
+    ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter?m_transmitter->number_of_files():0);
+    if (m_transmitter && m_transmitter->number_of_files() == 0) {
+        ogs_debug("Deactivating FLUTE stream, no files to purge");
+        m_workerCancel = true;
+        m_transmitter->deactivate();
+        m_deactivating = false;
+        return true;
+    }
+    return false;
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectPackager.cc
+++ b/src/mbstf/ObjectPackager.cc
@@ -9,6 +9,8 @@
  * program. If this file is missing then the license can be retrieved from
  * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
+// Open5GS includes
+#include "ogs-sbi.h" // include before "common.hh" to get correct logging domain
 
 // spdlog includes
 #include "spdlog/spdlog.h"

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -40,31 +40,49 @@ class ObjectPackager: public SubscriptionService {
 public:
    class ObjectSendCompleted : public Event {
     public:
-        ObjectSendCompleted(const std::string& object_id) :Event("ObjectSendCompleted"), m_object_id(object_id) {};
-        ObjectSendCompleted(const ObjectSendCompleted &other) :Event(other), m_object_id(other.m_object_id) {};
-        ObjectSendCompleted(ObjectSendCompleted &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
+        ObjectSendCompleted(const std::string& object_id, bool queue_empty)
+            :Event("ObjectSendCompleted")
+            ,m_object_id(object_id)
+            ,m_queue_empty(queue_empty)
+        {};
+        ObjectSendCompleted(const ObjectSendCompleted &other)
+            :Event(other)
+            ,m_object_id(other.m_object_id)
+            ,m_queue_empty(other.m_queue_empty)
+        {};
+        ObjectSendCompleted(ObjectSendCompleted &&other)
+            :Event(std::move(other))
+            ,m_object_id(std::move(other.m_object_id))
+            ,m_queue_empty(other.m_queue_empty)
+        {};
 
         virtual ~ObjectSendCompleted() {};
 
         ObjectSendCompleted &operator=(const ObjectSendCompleted &other) {
             Event::operator=(other);
             m_object_id = other.m_object_id;
+            m_queue_empty = other.m_queue_empty;
             return *this;
         };
         ObjectSendCompleted &operator=(ObjectSendCompleted &&other) {
             Event::operator=(std::move(other));
             m_object_id = std::move(other.m_object_id);
+            m_queue_empty = other.m_queue_empty;
             return *this;
         };
 
         std::string objectId() const { return m_object_id; };
+        bool queueEmpty() const { return m_queue_empty; };
 
         virtual Event clone() const { return ObjectSendCompleted(*this); };
         virtual Event *newClone() const { return new ObjectSendCompleted(*this); };
-        virtual std::string reprString() const { return std::format("ObjectSendCompleted(\"{}\")", m_object_id); };
+        virtual std::string reprString() const {
+            return std::format("ObjectSendCompleted(\"{}\", queue_empty={})", m_object_id, m_queue_empty);
+        };
 
     private:
         std::string m_object_id;
+        bool m_queue_empty;
     };
 
 
@@ -73,16 +91,16 @@ public:
     ObjectPackager(const ObjectPackager &) = delete;
 
     ObjectPackager(ObjectStore &objectStore, ObjectController &controller, std::optional<std::string> destIpAddr = std::nullopt, uint32_t rateLimit = 0, unsigned short mtu = 0, in_port_t port = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
-        :m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_queuedObjectId()
+        :m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_deactivating(false), m_queuedObjectId()
         ,m_objectStore(objectStore), m_controller(controller), m_destIpAddr(destIpAddr), m_rateLimit(rateLimit), m_mtu(mtu)
-        ,m_port(port), m_workerThread(), m_workerCancel(false)
+        ,m_port(port), m_workerThread(), m_workerCancel(false), m_workerRunning(false)
         ,m_tunnelAddress(tunnel_address), m_tunnelPort(tunnel_port)
     {
     };
 
     void abort() {
         m_workerCancel = true;
-        if (m_workerThread.joinable()) {
+        if (m_workerThread.get_id() != std::this_thread::get_id() && m_workerThread.joinable()) {
             m_workerThread.join();
         }
     };
@@ -96,10 +114,14 @@ public:
     ObjectPackager& setMtu(unsigned short mtu);
     ObjectPackager& setRateLimit(uint32_t rateLimit);
     void startWorker() {
-        if (m_workerThread.get_id() != std::thread::id()) return;
+        if (!!m_workerRunning) return;
         if (!!m_workerCancel) return;
+        if (m_workerThread.joinable()) m_workerThread.detach();
         m_workerThread = std::thread(workerLoop, this);
     };
+
+    virtual void activate();
+    virtual bool deactivate(); // returns true if deactivation was immediate
 
 protected:
     const ObjectStore &objectStore() const { return m_objectStore; };
@@ -119,6 +141,9 @@ protected:
     boost::asio::io_service m_io;
     uint32_t m_queuedToi;
     bool m_queued;
+    bool m_deactivating;
+    std::recursive_mutex m_deactivateMutex;
+    std::condition_variable_any m_deactivateCond;
     std::string m_queuedObjectId;
 
 private:
@@ -131,6 +156,7 @@ private:
     in_port_t m_port;
     std::thread m_workerThread;
     std::atomic_bool m_workerCancel;
+    std::atomic_bool m_workerRunning;
     std::optional<std::string> m_tunnelAddress;
     in_port_t m_tunnelPort;
 };

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -21,6 +21,8 @@
 #include <new>
 
 #include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to get correct logging domain
+
 #include "common.hh"
 
 #include "SubscriptionService.hh"

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -22,6 +22,7 @@
 #include <uuid/uuid.h>
 
 #include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include "common.hh"
 #include "ControllerFactory.hh"

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -83,6 +83,17 @@ void ObjectStreamingController::unsetObjectPackager()
     packager(nullptr);
 }
 
+void ObjectStreamingController::activateObjectPackager() {
+    packager()->activate();
+    startWorker();
+}
+
+void ObjectStreamingController::deactivateObjectPackager() {
+    if (packager()->deactivate()) {
+        distributionSession().haveEmptyQueue();
+    }
+}
+
 std::shared_ptr<ObjectListPackager> ObjectStreamingController::getObjectListPackager() const
 {
     return std::dynamic_pointer_cast<ObjectListPackager>(packager());

--- a/src/mbstf/ObjectStreamingController.hh
+++ b/src/mbstf/ObjectStreamingController.hh
@@ -67,6 +67,8 @@ public:
 protected:
     virtual void setObjectPackager();
     virtual void unsetObjectPackager();
+    virtual void activateObjectPackager();
+    virtual void deactivateObjectPackager();
 
 private:
     void sendToPackager(const std::string &object_id);

--- a/src/mbstf/Open5GSSBIMessage.cc
+++ b/src/mbstf/Open5GSSBIMessage.cc
@@ -16,12 +16,12 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <stdexcept>
+#include <memory>
 
 #include "ogs-app.h"
 #include "ogs-proto.h"
-
-#include <stdexcept>
-#include <memory>
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include "common.hh"
 #include "Open5GSSBIRequest.hh"

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -9,6 +9,7 @@
  * program. If this file is missing then the license can be retrieved from
  * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
+#include "ogs-sbi.h" // include before "common.hh" to get correct logging domain
 
 #include <memory>
 #include <stdexcept>
@@ -75,7 +76,7 @@ bool PullObjectIngester::fetch(const std::string &object_id, const std::optional
 {
     std::lock_guard<std::recursive_mutex> lock(*m_ingestItemsMutex);
 
-    // If this is a refetch for a pending object, just update the current fetch list item
+    // If this is a fetch for an already pending fetch object, just update the current fetch list item
     decltype(m_fetchList)::iterator it;
     for (it = m_fetchList.begin(); it != m_fetchList.end(); ++it) {
         if (it->objectId() == object_id) {
@@ -88,7 +89,7 @@ bool PullObjectIngester::fetch(const std::string &object_id, const std::optional
 
     // otherwise we need a new fetch based on the ObjectStore entry
     if (it == m_fetchList.end()) {
-        m_fetchList.emplace_back(this->objectStore().getMetadata(object_id), download_deadline);
+        m_fetchList.emplace_back(objectStore().getMetadata(object_id), download_deadline);
     }
 
     sortListByPolicy();
@@ -103,8 +104,22 @@ bool PullObjectIngester::fetch(const IngestItem &item) {
         objectStore().getMetadata(item.objectId());
         return fetch(item.objectId(), item.deadline());
     } catch (const std::out_of_range &ex) {
-        // No previous version, this isn't a refresh
-        m_fetchList.push_back(item);
+        // No previous version, this isn't a refresh, but may still be a re-request for an existing list item
+        decltype(m_fetchList)::iterator it;
+        for (it = m_fetchList.begin(); it != m_fetchList.end(); ++it) {
+            if (it->objectId() == item.objectId()) {
+                if (item.deadline().has_value()) {
+                    it->deadline(item.deadline().value());
+                }
+                break;
+            }
+        }
+
+        // otherwise we need a new fetch based on the ObjectStore entry
+        if (it == m_fetchList.end()) {
+            m_fetchList.push_back(item);
+        }
+
         sortListByPolicy();
         m_ingestItemsCondVar.notify_all();
     }
@@ -117,8 +132,22 @@ bool PullObjectIngester::fetch(IngestItem &&item) {
         objectStore().getMetadata(item.objectId());
         return fetch(item.objectId(), item.deadline());
     } catch (const std::out_of_range &ex) {
-        // No previous version, this isn't a refresh
-        m_fetchList.push_back(std::move(item));
+        // No previous version, this isn't a refresh, but may still be a re-request for an existing list item
+        decltype(m_fetchList)::iterator it;
+        for (it = m_fetchList.begin(); it != m_fetchList.end(); ++it) {
+            if (it->objectId() == item.objectId()) {
+                if (item.deadline().has_value()) {
+                    it->deadline(item.deadline().value());
+                }
+                break;
+            }
+        }
+
+        // otherwise we need a new fetch based on the ObjectStore entry
+        if (it == m_fetchList.end()) {
+            m_fetchList.push_back(std::move(item));
+        }
+
         sortListByPolicy();
         m_ingestItemsCondVar.notify_all();
     }

--- a/src/mbstf/PushObjectIngester.cc
+++ b/src/mbstf/PushObjectIngester.cc
@@ -24,6 +24,8 @@
 #include <netdb.h>
 #include <uuid/uuid.h>
 
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
+
 #include "common.hh"
 #include "App.hh"
 #include "hash.hh"


### PR DESCRIPTION
This changes the way the life-cycle for *DistSession*s works. Instead of destroying the `ObjectListPackager` object when the *DistSession* state is changed to *DEACTIVATING*, the `ObjectListPackager` object remains and the rt-libflute `Transmitter` object is deactivated instead to pause transmission. When the *DistSession* state changes to *ACTIVE* the rt-libflute `Transmitter` object is activated to resume the previous FLUTE session.

This new MBSTF functionality depends on the version of *rt-libflute* in 5G-MAG/rt-libflute#49 (or later).

# Known issues

When a *DistSession* of type *STREAMING* with pull-based acquisition of ingest objects is reactivated, the Service Entry Point (e.g. DASH MPD) is transmitted multiple times. This is perfectly within the specification for FLUTE sessions, just a little wasteful on transmitted bits. This is covered by issue #44 and will not be remedied in this PR.