### PR TITLE
Detect MTU for UDP tunnel instead of using fixed 1500 bytes

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '109')
+option('fiveg_api_approval', type: 'string', value: '110')
 option('fiveg_api_release', type: 'string', value: '18')

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -133,7 +133,9 @@ DistributionSession::~DistributionSession()
 {
     if (!m_eventTimestamps.sessionDeactivated) {
         _registerEvent(DistributionSessionEvents::SESSION_DEACTIVATED);
+        _sendSubscriptionNotifications();
     }
+    m_controller.reset(); // Detach controller
 }
 
 CJson DistributionSession::json(bool as_request, bool include_subscription_location) const
@@ -700,9 +702,9 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
     auto old_obj_distribution_data = old_dist_session->getObjDistributionData();
     auto new_obj_distribution_data = new_dist_session->getObjDistributionData();
-    if (old_obj_distribution_data && new_obj_distribution_data &&
+    if ((!old_obj_distribution_data != !new_obj_distribution_data) || (old_obj_distribution_data &&
         new_obj_distribution_data.value()->getObjDistributionOperatingMode() !=
-                old_obj_distribution_data.value()->getObjDistributionOperatingMode()) {
+                old_obj_distribution_data.value()->getObjDistributionOperatingMode())) {
         ex.addInvalidParameter("distSession.objDistributionData.objDistributionOperatingMode",
                                 "Cannot change objDistributionOperatingMode");
     }

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -133,7 +133,6 @@ DistributionSession::~DistributionSession()
 {
     if (!m_eventTimestamps.sessionDeactivated) {
         _registerEvent(DistributionSessionEvents::SESSION_DEACTIVATED);
-        _sendSubscriptionNotifications();
     }
     m_controller.reset(); // Detach controller
 }

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -71,7 +71,7 @@ void ObjectListController::setObjectPackager() {
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -71,8 +71,7 @@ void ObjectListController::setObjectPackager() {
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    //TODO: get the MTU for the dest_ip_addr or tunnel_addr
-    unsigned short mtu = 1498; // 1500 - GTP overhead; to allow for downstream encapsulation to the gNodeB
+    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -71,7 +71,7 @@ void ObjectListController::setObjectPackager() {
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -68,7 +68,7 @@ void ObjectStreamingController::setObjectPackager()
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -68,7 +68,7 @@ void ObjectStreamingController::setObjectPackager()
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -35,6 +35,7 @@
 #include "PushObjectIngester.hh"
 #include "SubscriptionService.hh"
 #include "ObjectListPackager.hh"
+#include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
 
 #include "ObjectStreamingController.hh"
@@ -67,8 +68,7 @@ void ObjectStreamingController::setObjectPackager()
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    //TODO: get the MTU for the dest_ip_addr
-    unsigned short mtu = 1498; // 1500 - GTP overhead; need to bodge this so that there's enough room in downstream gNodeB packets
+    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/common.hh
+++ b/src/mbstf/common.hh
@@ -19,12 +19,17 @@
  * under the License.
  */
 
+/* MBSTF Namespace macros */
 #define MBSTF_NAMESPACE com::fiveg_mag::ref_tools::mbstf
 #define MBSTF_NAMESPACE_START namespace MBSTF_NAMESPACE {
 #define MBSTF_NAMESPACE_STOP  }
 #define MBSTF_NAMESPACE_USING using namespace MBSTF_NAMESPACE
 #define MBSTF_NAMESPACE_NAME(a) MBSTF_NAMESPACE::a
 
+/* Constants */
+#define GTP_HEADER_SIZE 2
+
+/* Open5GS Logging */
 extern int __mbstf_log_domain;
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __mbstf_log_domain

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -16,6 +16,12 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include "ogs-core.h"
+
 #include <chrono>
 #include <format>
 #include <string>
@@ -46,6 +52,44 @@ std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_
     oss.imbue(std::locale("C"));
     oss << std::format("{0:%F}T{0:%T}Z", datetime_us);
     return oss.str();
+}
+
+int get_route_mtu(const ogs_sockaddr_t &sock_addr)
+{
+    ogs_sock_t *sock = ogs_sock_socket(sock_addr.ogs_sa_family, SOCK_DGRAM, 0);
+    ogs_sock_connect(sock, const_cast<ogs_sockaddr_t*>(&sock_addr));
+    int mtu = 1500;
+    socklen_t mtu_size = sizeof(mtu);
+    if (sock_addr.ogs_sa_family == AF_INET) {
+        getsockopt(sock->fd, IPPROTO_IP, IP_MTU, &mtu, &mtu_size);
+    } else if (sock_addr.ogs_sa_family == AF_INET6) {
+        getsockopt(sock->fd, IPPROTO_IPV6, IPV6_MTU, &mtu, &mtu_size);
+    }
+    ogs_sock_destroy(sock);
+    return mtu;
+}
+
+int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
+{
+    int mtu = 1500; // default to 1500 if no MTU can be found.
+
+    if (tunnel_ip) { // Use MTU of tunnel if provided
+        ogs_sockaddr_t *sa = nullptr;
+        if (ogs_addaddrinfo(&sa, AF_UNSPEC, tunnel_ip.value().c_str(), tunnel_port, AI_NUMERICSERV) == OGS_OK) {
+            mtu = get_route_mtu(*sa);
+            ogs_freeaddrinfo(sa);
+        } // else error already reported
+    } else { // No tunnel provided so try MTU of direct destination
+        if (dest_ip) {
+            ogs_sockaddr_t *sa = nullptr;
+            if (ogs_addaddrinfo(&sa, AF_UNSPEC, dest_ip.value().c_str(), dest_port, AI_NUMERICSERV) == OGS_OK) {
+                mtu = get_route_mtu(*sa);
+                ogs_freeaddrinfo(sa);
+            }
+        }
+    }
+    return mtu;
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -54,7 +54,7 @@ std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_
     return oss.str();
 }
 
-int get_route_mtu(const ogs_sockaddr_t &sock_addr)
+int get_path_mtu(const ogs_sockaddr_t &sock_addr)
 {
     ogs_sock_t *sock = ogs_sock_socket(sock_addr.ogs_sa_family, SOCK_DGRAM, 0);
     ogs_sock_connect(sock, const_cast<ogs_sockaddr_t*>(&sock_addr));
@@ -69,7 +69,7 @@ int get_route_mtu(const ogs_sockaddr_t &sock_addr)
     return mtu;
 }
 
-int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
                             const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
 {
     int mtu = 1500; // default to 1500 if no MTU can be found.
@@ -77,14 +77,14 @@ int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t
     if (tunnel_ip) { // Use MTU of tunnel if provided
         ogs_sockaddr_t *sa = nullptr;
         if (ogs_addaddrinfo(&sa, AF_UNSPEC, tunnel_ip.value().c_str(), tunnel_port, AI_NUMERICSERV) == OGS_OK) {
-            mtu = get_route_mtu(*sa);
+            mtu = get_path_mtu(*sa);
             ogs_freeaddrinfo(sa);
         } // else error already reported
     } else { // No tunnel provided so try MTU of direct destination
         if (dest_ip) {
             ogs_sockaddr_t *sa = nullptr;
             if (ogs_addaddrinfo(&sa, AF_UNSPEC, dest_ip.value().c_str(), dest_port, AI_NUMERICSERV) == OGS_OK) {
-                mtu = get_route_mtu(*sa);
+                mtu = get_path_mtu(*sa);
                 ogs_freeaddrinfo(sa);
             }
         }

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -30,6 +30,10 @@ std::string trim_slashes(const std::string &path);
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
 
+int get_route_mtu(const ogs_sockaddr_t &sock_addr);
+int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -30,8 +30,8 @@ std::string trim_slashes(const std::string &path);
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
 
-int get_route_mtu(const ogs_sockaddr_t &sock_addr);
-int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+int get_path_mtu(const ogs_sockaddr_t &sock_addr);
+int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
                             const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
 
 MBSTF_NAMESPACE_STOP


### PR DESCRIPTION
Add the detection of the interface MTU that will be used for the UDP tunnel to the MB-UPF to make best use of the network.

PR 5G-MAG/open5gs#37 is need in the 5G-MAG 5MBS version of Open5GS for this to pass packets correctly onto the gNodeB. Without the PR the MB-UPF may truncate the packets delivered via the UDP tunnel if the tunnel operates on a network with greater than 1500 MTU (e.g. the loopback interface *lo*).

Closes #34 