### PR TITLE
MBSTF: Various fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-mbs-transport-function', 'c', 'cpp',
-        version : '1.2.1',
+        version : '1.2.2',
         license : '5G-MAG Public',
         meson_version : '>= 1.4.0',
         default_options : [

--- a/src/mbstf/Controller.hh
+++ b/src/mbstf/Controller.hh
@@ -40,6 +40,7 @@ public:
     virtual void establishActiveInputs() = 0;   /* Established state for DistSession */
     virtual void activateOutput() = 0;          /* Active state for DistSession */
     virtual void deactivateOutput() = 0;        /* Deactivating state for DistSession */
+    virtual void flushPackagerQueue() = 0;      /* Empty packaging queue */
 
 private:
     DistributionSession &m_distributionSession;

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -701,11 +701,14 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
     auto old_obj_distribution_data = old_dist_session->getObjDistributionData();
     auto new_obj_distribution_data = new_dist_session->getObjDistributionData();
-    if ((!old_obj_distribution_data != !new_obj_distribution_data) || (old_obj_distribution_data &&
-        new_obj_distribution_data.value()->getObjDistributionOperatingMode() !=
-                old_obj_distribution_data.value()->getObjDistributionOperatingMode())) {
+    if (!old_obj_distribution_data != !new_obj_distribution_data) {
         ex.addInvalidParameter("distSession.objDistributionData.objDistributionOperatingMode",
-                                "Cannot change objDistributionOperatingMode");
+                                "Cannot remove objDistributionOperatingMode");
+    } else if (old_obj_distribution_data &&
+        *new_obj_distribution_data.value()->getObjDistributionOperatingMode() !=
+                *old_obj_distribution_data.value()->getObjDistributionOperatingMode()) {
+        ex.addInvalidParameter("distSession.objDistributionData.objDistributionOperatingMode",
+                                std::format("Cannot change objDistributionOperatingMode ({} != {})", new_obj_distribution_data.value()->getObjDistributionOperatingMode()->getString(), old_obj_distribution_data.value()->getObjDistributionOperatingMode()->getString()));
     }
 
     /* If errors then report them */

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -722,7 +722,12 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
 
     /* Make sure we are in the right state */
-    _transitionTo(new_dist_session->getDistSessionState()->getValue());
+    auto new_state = new_dist_session->getDistSessionState()->getValue();
+    if (new_state == DistSessionState::VAL_INACTIVE || new_state == DistSessionState::VAL_DEACTIVATING) {
+        /* If you request deactivating or inactive, make sure no more files are packaged */
+        m_controller->flushPackagerQueue();
+    }
+    _transitionTo(new_state);
 
     /* Update the last-used and hash values to reflect the new CreateReqData */
     _setLastUsed();

--- a/src/mbstf/DistributionSessionSubscription.cc
+++ b/src/mbstf/DistributionSessionSubscription.cc
@@ -352,7 +352,6 @@ static int __notify_client_cb(int status, ogs_sbi_response_t *response, void *da
     int rv;
     RequestData *req_data = reinterpret_cast<RequestData*>(data);
 
-    e = ogs_event_new(OGS_EVENT_SBI_CLIENT);
     ogs_assert(e);
     e->sbi.request = req_data->request->ogsSBIRequest();
     e->sbi.response = response;

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -156,6 +156,11 @@ void ObjectController::deactivateOutput()
     if (m_packager) deactivateObjectPackager();
 }
 
+void ObjectController::flushPackagerQueue()
+{
+    if (m_packager) m_packager->flushQueue();
+}
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -77,6 +77,7 @@ public:
     virtual void establishActiveInputs();   /* Established state for DistSession */
     virtual void activateOutput();          /* Active state for DistSession */
     virtual void deactivateOutput();        /* Deactivating state for DistSession */
+    virtual void flushPackagerQueue();      /* Ensure there are no objects queued for packaging */
 
 protected:
     const std::shared_ptr<PullObjectIngester> &addPullObjectIngester(const std::shared_ptr<PullObjectIngester> &pull_obj_ingester);

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -180,8 +180,8 @@ void ObjectListPackager::doObjectPackage() {
                 LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
         m_transmitter->register_completion_callback(
                 [this](uint32_t toi) {
-                    ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter->number_of_files());
-                    bool queue_empty = (m_transmitter->number_of_files() == 0);
+                    ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+                    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
                     if (m_queuedToi == toi) {
                         m_queued = false;
                         objectSendCompletion(m_queuedObjectId, queue_empty);
@@ -274,6 +274,12 @@ void ObjectListPackager::objectSendCompletion(std::string &object_id, bool queue
 {
     std::shared_ptr<Event> event(new ObjectListPackager::ObjectSendCompleted(object_id, queue_empty));
     sendEventAsynchronous(event);
+}
+
+void ObjectListPackager::flushQueue()
+{
+    std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
+    m_packageItems.clear();
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -282,6 +282,22 @@ void ObjectListPackager::flushQueue()
     m_packageItems.clear();
 }
 
+bool ObjectListPackager::deactivate()
+{
+    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+    m_deactivating = true;
+    ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+    if (queue_empty) {
+        ogs_debug("Deactivating FLUTE stream, no files to purge");
+        abort();
+        m_transmitter->deactivate();
+        m_deactivating = false;
+        return true;
+    }
+    return false;
+}
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -78,6 +78,8 @@ public:
                          uint32_t rateLimit,
                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
 
+    virtual void flushQueue();
+
 protected:
     virtual void doObjectPackage();
 

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -78,6 +78,7 @@ public:
                          uint32_t rateLimit,
                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
 
+    virtual bool deactivate();
     virtual void flushQueue();
 
 protected:

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -122,6 +122,7 @@ public:
 
     virtual void activate();
     virtual bool deactivate(); // returns true if deactivation was immediate
+    virtual void flushQueue() {};
 
 protected:
     const ObjectStore &objectStore() const { return m_objectStore; };

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -178,7 +178,7 @@ ObjectStore::~ObjectStore()
 {
 }
 
-void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata) {
+void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     //std::unique_lock<std::shared_mutex> lock(m_mutex);
 
@@ -190,7 +190,11 @@ void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, M
     }
 
     std::shared_ptr<Event> event(new ObjectStore::ObjectAddedEvent(object_id));
-    sendEventAsynchronous(event);
+    if (synchronous_event) {
+        sendEventSynchronous(*event);
+    } else {
+        sendEventAsynchronous(event);
+    }
 }
 
 const ObjectStore::ObjectData& ObjectStore::getObjectData(const std::string& object_id) const {

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -240,7 +240,7 @@ public:
     ObjectStore &operator=(const ObjectStore&) = delete;
     ObjectStore &operator=(ObjectStore&&) = delete;
 
-    void addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata);
+    void addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event = false);
     const ObjectData& getObjectData(const std::string& object_id) const;
     ObjectData& getObjectData(const std::string& object_id);
     const Metadata& getMetadata(const std::string& object_id) const;

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -224,8 +224,7 @@ void PullObjectIngester::doObjectIngest() {
 	        if (!etag.empty()) {
                     metadata.entityTag(etag);
 	        }
-	        this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata));
-
+	        this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
             } else if (bytesReceived == -1) {
                 ogs_error("Request timed out.");
                 emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::TIMED_OUT);

--- a/subprojects/rt-libflute.wrap
+++ b/subprojects/rt-libflute.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/5G-MAG/rt-libflute.git
-revision = rt-libflute-0.12.0
+revision = rt-libflute-0.12.1
 method = cmake
 
 #diff_files = rt-libflute/IpSec-xfrm_algo.patch


### PR DESCRIPTION
These are fixes for issues found during testing of the MBSF and MBSTF.

1. Memory leak on sending notifications
   - Removed extra event object creation
1. Race condition may cause requested objects not to be sent.
   - Stopped race condition and added in extra checks to make sure packing queue is flushed before going inactive.
   - Fixes #52 
1. Update to DistributionSession can fail with a false error about objDistributioOperatingMode being changed when replacing the whole DistributionSession object.
   - Fixed check to compare values rather than pointers.