### PR TITLE
Release MBS Transport Function v1.2.2

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -1,0 +1,45 @@
+name: check-build
+
+on:
+    pull_request:
+        branches:
+            - development
+            - main
+
+permissions:
+    contents: read
+
+jobs:
+    build:
+        runs-on: ubuntu-24.04
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+                    submodules: recursive
+
+            -   name: Install dependencies
+                run: |
+                    sudo add-apt-repository universe
+                    sudo apt update
+                    sudo apt install -y \
+                      git ninja-build build-essential flex bison libglibmm-2.4-dev libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev \
+                      libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libtins-dev \
+                      libtalloc-dev libpcre2-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-test-dev libspdlog-dev \
+                      libtinyxml2-dev libconfig++-dev uuid-dev libxml2-dev gcc-14 g++-14 curl wget default-jdk cmake jq util-linux-extra mm-common python3-pip
+                    sudo sh -c 'for i in cpp g++ gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do rm -f /usr/bin/$i; ln -s $i-14 /usr/bin/$i; done'
+                    sudo python3 -m pip install --break-system-packages --upgrade meson
+
+            -   name: Configure build with meson
+                run: |
+                    meson setup build --prefix "$PWD/install"
+
+            -   name: Build with ninja
+                run: |
+                    ninja -C build
+
+            -   name: Install
+                run: |
+                    meson install -C build --no-rebuild

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-mbs-transport-function', 'c', 'cpp',
-        version : '1.2.1',
+        version : '1.2.2',
         license : '5G-MAG Public',
         meson_version : '>= 1.4.0',
         default_options : [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '109')
+option('fiveg_api_approval', type: 'string', value: '110')
 option('fiveg_api_release', type: 'string', value: '18')

--- a/src/mbstf/Controller.hh
+++ b/src/mbstf/Controller.hh
@@ -40,6 +40,7 @@ public:
     virtual void establishActiveInputs() = 0;   /* Established state for DistSession */
     virtual void activateOutput() = 0;          /* Active state for DistSession */
     virtual void deactivateOutput() = 0;        /* Deactivating state for DistSession */
+    virtual void flushPackagerQueue() = 0;      /* Empty packaging queue */
 
 private:
     DistributionSession &m_distributionSession;

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -701,11 +701,14 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
     auto old_obj_distribution_data = old_dist_session->getObjDistributionData();
     auto new_obj_distribution_data = new_dist_session->getObjDistributionData();
-    if ((!old_obj_distribution_data != !new_obj_distribution_data) || (old_obj_distribution_data &&
-        new_obj_distribution_data.value()->getObjDistributionOperatingMode() !=
-                old_obj_distribution_data.value()->getObjDistributionOperatingMode())) {
+    if (!old_obj_distribution_data != !new_obj_distribution_data) {
         ex.addInvalidParameter("distSession.objDistributionData.objDistributionOperatingMode",
-                                "Cannot change objDistributionOperatingMode");
+                                "Cannot remove objDistributionOperatingMode");
+    } else if (old_obj_distribution_data &&
+        *new_obj_distribution_data.value()->getObjDistributionOperatingMode() !=
+                *old_obj_distribution_data.value()->getObjDistributionOperatingMode()) {
+        ex.addInvalidParameter("distSession.objDistributionData.objDistributionOperatingMode",
+                                std::format("Cannot change objDistributionOperatingMode ({} != {})", new_obj_distribution_data.value()->getObjDistributionOperatingMode()->getString(), old_obj_distribution_data.value()->getObjDistributionOperatingMode()->getString()));
     }
 
     /* If errors then report them */

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -133,7 +133,9 @@ DistributionSession::~DistributionSession()
 {
     if (!m_eventTimestamps.sessionDeactivated) {
         _registerEvent(DistributionSessionEvents::SESSION_DEACTIVATED);
+        _sendSubscriptionNotifications();
     }
+    m_controller.reset(); // Detach controller
 }
 
 CJson DistributionSession::json(bool as_request, bool include_subscription_location) const
@@ -700,9 +702,9 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
     auto old_obj_distribution_data = old_dist_session->getObjDistributionData();
     auto new_obj_distribution_data = new_dist_session->getObjDistributionData();
-    if (old_obj_distribution_data && new_obj_distribution_data &&
+    if ((!old_obj_distribution_data != !new_obj_distribution_data) || (old_obj_distribution_data &&
         new_obj_distribution_data.value()->getObjDistributionOperatingMode() !=
-                old_obj_distribution_data.value()->getObjDistributionOperatingMode()) {
+                old_obj_distribution_data.value()->getObjDistributionOperatingMode())) {
         ex.addInvalidParameter("distSession.objDistributionData.objDistributionOperatingMode",
                                 "Cannot change objDistributionOperatingMode");
     }

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -722,7 +722,12 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
 
     /* Make sure we are in the right state */
-    _transitionTo(new_dist_session->getDistSessionState()->getValue());
+    auto new_state = new_dist_session->getDistSessionState()->getValue();
+    if (new_state == DistSessionState::VAL_INACTIVE || new_state == DistSessionState::VAL_DEACTIVATING) {
+        /* If you request deactivating or inactive, make sure no more files are packaged */
+        m_controller->flushPackagerQueue();
+    }
+    _transitionTo(new_state);
 
     /* Update the last-used and hash values to reflect the new CreateReqData */
     _setLastUsed();

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -133,7 +133,6 @@ DistributionSession::~DistributionSession()
 {
     if (!m_eventTimestamps.sessionDeactivated) {
         _registerEvent(DistributionSessionEvents::SESSION_DEACTIVATED);
-        _sendSubscriptionNotifications();
     }
     m_controller.reset(); // Detach controller
 }

--- a/src/mbstf/DistributionSessionSubscription.cc
+++ b/src/mbstf/DistributionSessionSubscription.cc
@@ -352,7 +352,6 @@ static int __notify_client_cb(int status, ogs_sbi_response_t *response, void *da
     int rv;
     RequestData *req_data = reinterpret_cast<RequestData*>(data);
 
-    e = ogs_event_new(OGS_EVENT_SBI_CLIENT);
     ogs_assert(e);
     e->sbi.request = req_data->request->ogsSBIRequest();
     e->sbi.response = response;

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -156,6 +156,11 @@ void ObjectController::deactivateOutput()
     if (m_packager) deactivateObjectPackager();
 }
 
+void ObjectController::flushPackagerQueue()
+{
+    if (m_packager) m_packager->flushQueue();
+}
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -77,6 +77,7 @@ public:
     virtual void establishActiveInputs();   /* Established state for DistSession */
     virtual void activateOutput();          /* Active state for DistSession */
     virtual void deactivateOutput();        /* Deactivating state for DistSession */
+    virtual void flushPackagerQueue();      /* Ensure there are no objects queued for packaging */
 
 protected:
     const std::shared_ptr<PullObjectIngester> &addPullObjectIngester(const std::shared_ptr<PullObjectIngester> &pull_obj_ingester);

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -71,7 +71,7 @@ void ObjectListController::setObjectPackager() {
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -71,8 +71,7 @@ void ObjectListController::setObjectPackager() {
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    //TODO: get the MTU for the dest_ip_addr or tunnel_addr
-    unsigned short mtu = 1498; // 1500 - GTP overhead; to allow for downstream encapsulation to the gNodeB
+    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -71,7 +71,7 @@ void ObjectListController::setObjectPackager() {
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -180,8 +180,8 @@ void ObjectListPackager::doObjectPackage() {
                 LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
         m_transmitter->register_completion_callback(
                 [this](uint32_t toi) {
-                    ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter->number_of_files());
-                    bool queue_empty = (m_transmitter->number_of_files() == 0);
+                    ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+                    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
                     if (m_queuedToi == toi) {
                         m_queued = false;
                         objectSendCompletion(m_queuedObjectId, queue_empty);
@@ -274,6 +274,12 @@ void ObjectListPackager::objectSendCompletion(std::string &object_id, bool queue
 {
     std::shared_ptr<Event> event(new ObjectListPackager::ObjectSendCompleted(object_id, queue_empty));
     sendEventAsynchronous(event);
+}
+
+void ObjectListPackager::flushQueue()
+{
+    std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
+    m_packageItems.clear();
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -282,6 +282,22 @@ void ObjectListPackager::flushQueue()
     m_packageItems.clear();
 }
 
+bool ObjectListPackager::deactivate()
+{
+    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+    m_deactivating = true;
+    ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+    if (queue_empty) {
+        ogs_debug("Deactivating FLUTE stream, no files to purge");
+        abort();
+        m_transmitter->deactivate();
+        m_deactivating = false;
+        return true;
+    }
+    return false;
+}
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -78,6 +78,8 @@ public:
                          uint32_t rateLimit,
                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
 
+    virtual void flushQueue();
+
 protected:
     virtual void doObjectPackage();
 

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -78,6 +78,7 @@ public:
                          uint32_t rateLimit,
                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
 
+    virtual bool deactivate();
     virtual void flushQueue();
 
 protected:

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -122,6 +122,7 @@ public:
 
     virtual void activate();
     virtual bool deactivate(); // returns true if deactivation was immediate
+    virtual void flushQueue() {};
 
 protected:
     const ObjectStore &objectStore() const { return m_objectStore; };

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -178,7 +178,7 @@ ObjectStore::~ObjectStore()
 {
 }
 
-void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata) {
+void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     //std::unique_lock<std::shared_mutex> lock(m_mutex);
 
@@ -190,7 +190,11 @@ void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, M
     }
 
     std::shared_ptr<Event> event(new ObjectStore::ObjectAddedEvent(object_id));
-    sendEventAsynchronous(event);
+    if (synchronous_event) {
+        sendEventSynchronous(*event);
+    } else {
+        sendEventAsynchronous(event);
+    }
 }
 
 const ObjectStore::ObjectData& ObjectStore::getObjectData(const std::string& object_id) const {

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -240,7 +240,7 @@ public:
     ObjectStore &operator=(const ObjectStore&) = delete;
     ObjectStore &operator=(ObjectStore&&) = delete;
 
-    void addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata);
+    void addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event = false);
     const ObjectData& getObjectData(const std::string& object_id) const;
     ObjectData& getObjectData(const std::string& object_id);
     const Metadata& getMetadata(const std::string& object_id) const;

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -68,7 +68,7 @@ void ObjectStreamingController::setObjectPackager()
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -68,7 +68,7 @@ void ObjectStreamingController::setObjectPackager()
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -35,6 +35,7 @@
 #include "PushObjectIngester.hh"
 #include "SubscriptionService.hh"
 #include "ObjectListPackager.hh"
+#include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
 
 #include "ObjectStreamingController.hh"
@@ -67,8 +68,7 @@ void ObjectStreamingController::setObjectPackager()
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    //TODO: get the MTU for the dest_ip_addr
-    unsigned short mtu = 1498; // 1500 - GTP overhead; need to bodge this so that there's enough room in downstream gNodeB packets
+    unsigned short mtu = get_tunnelled_route_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - 2; // -2 bytes for GTP overhead
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -224,8 +224,7 @@ void PullObjectIngester::doObjectIngest() {
 	        if (!etag.empty()) {
                     metadata.entityTag(etag);
 	        }
-	        this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata));
-
+	        this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
             } else if (bytesReceived == -1) {
                 ogs_error("Request timed out.");
                 emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::TIMED_OUT);

--- a/src/mbstf/common.hh
+++ b/src/mbstf/common.hh
@@ -19,12 +19,17 @@
  * under the License.
  */
 
+/* MBSTF Namespace macros */
 #define MBSTF_NAMESPACE com::fiveg_mag::ref_tools::mbstf
 #define MBSTF_NAMESPACE_START namespace MBSTF_NAMESPACE {
 #define MBSTF_NAMESPACE_STOP  }
 #define MBSTF_NAMESPACE_USING using namespace MBSTF_NAMESPACE
 #define MBSTF_NAMESPACE_NAME(a) MBSTF_NAMESPACE::a
 
+/* Constants */
+#define GTP_HEADER_SIZE 2
+
+/* Open5GS Logging */
 extern int __mbstf_log_domain;
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __mbstf_log_domain

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -16,6 +16,12 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include "ogs-core.h"
+
 #include <chrono>
 #include <format>
 #include <string>
@@ -46,6 +52,44 @@ std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_
     oss.imbue(std::locale("C"));
     oss << std::format("{0:%F}T{0:%T}Z", datetime_us);
     return oss.str();
+}
+
+int get_route_mtu(const ogs_sockaddr_t &sock_addr)
+{
+    ogs_sock_t *sock = ogs_sock_socket(sock_addr.ogs_sa_family, SOCK_DGRAM, 0);
+    ogs_sock_connect(sock, const_cast<ogs_sockaddr_t*>(&sock_addr));
+    int mtu = 1500;
+    socklen_t mtu_size = sizeof(mtu);
+    if (sock_addr.ogs_sa_family == AF_INET) {
+        getsockopt(sock->fd, IPPROTO_IP, IP_MTU, &mtu, &mtu_size);
+    } else if (sock_addr.ogs_sa_family == AF_INET6) {
+        getsockopt(sock->fd, IPPROTO_IPV6, IPV6_MTU, &mtu, &mtu_size);
+    }
+    ogs_sock_destroy(sock);
+    return mtu;
+}
+
+int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
+{
+    int mtu = 1500; // default to 1500 if no MTU can be found.
+
+    if (tunnel_ip) { // Use MTU of tunnel if provided
+        ogs_sockaddr_t *sa = nullptr;
+        if (ogs_addaddrinfo(&sa, AF_UNSPEC, tunnel_ip.value().c_str(), tunnel_port, AI_NUMERICSERV) == OGS_OK) {
+            mtu = get_route_mtu(*sa);
+            ogs_freeaddrinfo(sa);
+        } // else error already reported
+    } else { // No tunnel provided so try MTU of direct destination
+        if (dest_ip) {
+            ogs_sockaddr_t *sa = nullptr;
+            if (ogs_addaddrinfo(&sa, AF_UNSPEC, dest_ip.value().c_str(), dest_port, AI_NUMERICSERV) == OGS_OK) {
+                mtu = get_route_mtu(*sa);
+                ogs_freeaddrinfo(sa);
+            }
+        }
+    }
+    return mtu;
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -54,7 +54,7 @@ std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_
     return oss.str();
 }
 
-int get_route_mtu(const ogs_sockaddr_t &sock_addr)
+int get_path_mtu(const ogs_sockaddr_t &sock_addr)
 {
     ogs_sock_t *sock = ogs_sock_socket(sock_addr.ogs_sa_family, SOCK_DGRAM, 0);
     ogs_sock_connect(sock, const_cast<ogs_sockaddr_t*>(&sock_addr));
@@ -69,7 +69,7 @@ int get_route_mtu(const ogs_sockaddr_t &sock_addr)
     return mtu;
 }
 
-int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
                             const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
 {
     int mtu = 1500; // default to 1500 if no MTU can be found.
@@ -77,14 +77,14 @@ int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t
     if (tunnel_ip) { // Use MTU of tunnel if provided
         ogs_sockaddr_t *sa = nullptr;
         if (ogs_addaddrinfo(&sa, AF_UNSPEC, tunnel_ip.value().c_str(), tunnel_port, AI_NUMERICSERV) == OGS_OK) {
-            mtu = get_route_mtu(*sa);
+            mtu = get_path_mtu(*sa);
             ogs_freeaddrinfo(sa);
         } // else error already reported
     } else { // No tunnel provided so try MTU of direct destination
         if (dest_ip) {
             ogs_sockaddr_t *sa = nullptr;
             if (ogs_addaddrinfo(&sa, AF_UNSPEC, dest_ip.value().c_str(), dest_port, AI_NUMERICSERV) == OGS_OK) {
-                mtu = get_route_mtu(*sa);
+                mtu = get_path_mtu(*sa);
                 ogs_freeaddrinfo(sa);
             }
         }

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -30,6 +30,10 @@ std::string trim_slashes(const std::string &path);
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
 
+int get_route_mtu(const ogs_sockaddr_t &sock_addr);
+int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
+
 MBSTF_NAMESPACE_STOP
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -30,8 +30,8 @@ std::string trim_slashes(const std::string &path);
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
 
-int get_route_mtu(const ogs_sockaddr_t &sock_addr);
-int get_tunnelled_route_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
+int get_path_mtu(const ogs_sockaddr_t &sock_addr);
+int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
                             const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
 
 MBSTF_NAMESPACE_STOP

--- a/subprojects/rt-libflute.wrap
+++ b/subprojects/rt-libflute.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/5G-MAG/rt-libflute.git
-revision = rt-libflute-0.12.1
+revision = rt-libflute-0.12.2
 method = cmake
 
 #diff_files = rt-libflute/IpSec-xfrm_algo.patch

--- a/subprojects/rt-libflute.wrap
+++ b/subprojects/rt-libflute.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/5G-MAG/rt-libflute.git
-revision = rt-libflute-0.12.0
+revision = rt-libflute-0.12.1
 method = cmake
 
 #diff_files = rt-libflute/IpSec-xfrm_algo.patch


### PR DESCRIPTION
This is a feature improvement and bug fix release for the 5G-MAG Reference Tools MBSTF, and will be released as v1.2.2.

This release contains the following:
- Automatically detect path MTU for UDP tunnelled connection to the MB-UPF to make best use of the network.
- The MBSTF will now wait for a `SINGLE` operation mode, `PULL` acquisition, Distribution Session's object queue to flush before automatically transitioning the Distribution Session to `INACTIVE`. This prevents the FLUTE session being deactivated before sending the last pulled objects.
- Various bug fixes.
- Memory leak fixes.
- Synchronise with latest release version of rt-libflute.

~~The first release candidate for v1.2.2 has been tagged `rt-mbs-transport-function-1.2.2-rc1`.~~
The second release candidate for v1.2.2 has been tagged `rt-mbs-transport-function-1.2.2-rc2`.