### PR TITLE
Uplift to TS 29.581 V18.6.0

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '110')
+option('fiveg_api_approval', type: 'string', value: '111')
 option('fiveg_api_release', type: 'string', value: '18')

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -54,6 +54,7 @@
 #include "Open5GSTimer.hh"
 #include "Open5GSYamlDocument.hh"
 #include "Open5GSNetworkFunction.hh"
+#include "SsmPort.hh"
 #include "openapi/model/CreateReqData.h"
 #include "openapi/model/CreateRspData.h"
 #include "openapi/model/DistSession.h"
@@ -82,12 +83,13 @@ using reftools::mbstf::DistSessionEventReportList;
 using reftools::mbstf::DistSessionSubscription;
 using reftools::mbstf::IpAddr;
 using reftools::mbstf::ObjDistributionData;
-using reftools::mbstf::UpTrafficFlowInfo;
 using reftools::mbstf::ObjAcquisitionMethod;
 using reftools::mbstf::ObjDistributionOperatingMode;
+using reftools::mbstf::PktDistributionOperatingMode;
 using reftools::mbstf::StatusSubscribeReqData;
 using reftools::mbstf::StatusSubscribeRspData;
 using reftools::mbstf::TunnelAddress;
+using reftools::mbstf::UpTrafficFlowInfo;
 
 MBSTF_NAMESPACE_START
 
@@ -104,6 +106,7 @@ static void send_model_params_error(const ModelParamsException &err, Open5GSSBIS
                                     Open5GSSBIMessage &message, const NfServer::AppMetadata &app_meta,
                                     const std::optional<NfServer::InterfaceMetadata> &api, const std::string &no_cause_reason,
                                     const std::string &log_prefix);
+static void _validate(const std::shared_ptr<DistSession> &dist_session);
 
 /**** public: ****/
 
@@ -122,12 +125,13 @@ DistributionSession::DistributionSession(CJson &json, bool as_request)
     ,m_subscriptionLocation()
 {
 
-    std::shared_ptr<DistSession> distSession = m_createReqData->getDistSession();
+    std::shared_ptr<DistSession> dist_session = m_createReqData->getDistSession();
 
+    _validate(dist_session);
     _setLastUsed();
     m_generated = m_lastUsed;
     _setHash();
-    m_distributionSessionId = distSession->getDistSessionId();
+    m_distributionSessionId = dist_session->getDistSessionId();
     _changeState(&DistributionSession::_constructedState);
 }
 
@@ -471,21 +475,28 @@ const ObjDistributionData::ObjAcquisitionIdsPullType &DistributionSession::getOb
     }
 }
 
-const std::optional<std::string> &DistributionSession::getDestIpAddr() const
+const SsmPort DistributionSession::getSsmPort() const
 {
-    std::shared_ptr<CreateReqData> create_req_data = distributionSessionReqData();
-    std::shared_ptr<DistSession> dist_session = create_req_data->getDistSession();
-    const std::optional<std::shared_ptr< UpTrafficFlowInfo > > &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
-    if (up_traffic_flow_info.has_value()) {
-        std::shared_ptr<UpTrafficFlowInfo> up_traffic_flow = up_traffic_flow_info.value();
-        const std::shared_ptr<IpAddr> ipAddr = up_traffic_flow->getDestIpAddr();
-        if (ipAddr) {
-            return ipAddr->getIpv4Addr();
-        }
-    }
+    const auto &create_req_data = distributionSessionReqData();
+    if (!create_req_data) return SsmPort();
+    const auto &dist_session = create_req_data->getDistSession();
+    if (!dist_session) return SsmPort();
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (!up_traffic_flow_info || !up_traffic_flow_info.value()) return SsmPort();
+    return SsmPort(up_traffic_flow_info.value());
+}
 
-    static const std::optional<std::string> empty = std::nullopt;
-    return empty;
+uint64_t DistributionSession::getTSI() const
+{
+    const auto &create_req_data = distributionSessionReqData();
+    if (!create_req_data) return 0;
+    const auto &dist_session = create_req_data->getDistSession();
+    if (!dist_session) return 0;
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (!up_traffic_flow_info || !up_traffic_flow_info.value()) return 0;
+    const auto &tsi = up_traffic_flow_info.value()->getTransportSessionId();
+    if (!tsi) return 0;
+    return static_cast<uint32_t>(tsi.value());
 }
 
 const std::optional<std::string> &DistributionSession::getTunnelAddr() const
@@ -499,19 +510,6 @@ const std::optional<std::string> &DistributionSession::getTunnelAddr() const
 
     static const std::optional<std::string> empty = std::nullopt;
     return empty;
-}
-
-in_port_t DistributionSession::getPortNumber() const
-{
-    in_port_t port_number = 0;
-    std::shared_ptr<CreateReqData> create_req_data = distributionSessionReqData();
-    std::shared_ptr<DistSession> dist_session = create_req_data->getDistSession();
-    std::optional<std::shared_ptr<UpTrafficFlowInfo> > up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
-    if (up_traffic_flow_info.has_value()) {
-        std::shared_ptr<UpTrafficFlowInfo> up_traffic_flow = up_traffic_flow_info.value();
-        port_number = static_cast<in_port_t>(up_traffic_flow->getPortNumber());
-    }
-    return port_number;
 }
 
 in_port_t DistributionSession::getTunnelPortNumber() const
@@ -1365,6 +1363,70 @@ static void send_model_params_error(const ModelParamsException &err, Open5GSSBIS
                                                error));
     }
     ogs_error("%s: %s", log_prefix.c_str(), oss.str().c_str());
+}
+
+static void _validate(const std::shared_ptr<DistSession> &dist_session)
+{
+    /* check for DistSession irregularities that are not caught by the OpenAPI model classes */
+
+    if (!dist_session) {
+        throw ModelException("No distSession in CreateReqData", "DistributionSession", "distSession",
+                             ProblemCause::MANDATORY_IE_MISSING);
+    }
+
+    const auto &obj_distr_data = dist_session->getObjDistributionData();
+    const auto &pkt_distr_data = dist_session->getPktDistributionData();
+    if ((!obj_distr_data && !pkt_distr_data) || (obj_distr_data && pkt_distr_data)) {
+        throw ModelException("DistSession must have one of pktDistributionData or objDistributionData", "DistributionSession",
+                             "distSession", ProblemCause::MANDATORY_IE_MISSING);
+    }
+
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (obj_distr_data) {
+        if (!up_traffic_flow_info) {
+            throw ModelException("upTrafficFlowInfo must be present if objDistributionData is present", "DistributionSession",
+                                 "distSession.upTrafficFlowInfo", ProblemCause::MANDATORY_IE_MISSING);
+        } else {
+            const auto &src_ip = up_traffic_flow_info.value()->getSrcIpAddr();
+            if (!src_ip) {
+                throw ModelException("upTrafficFlowInfo.srcIpAddr must be present if objDistributionData is present",
+                                     "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                     ProblemCause::MANDATORY_IE_MISSING);
+            }
+            const auto &tsi = up_traffic_flow_info.value()->getTransportSessionId();
+            if (!tsi) {
+                throw ModelException("upTrafficFlowInfo.transportSessionId must be present if objDistributionData is present",
+                                     "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                     ProblemCause::MANDATORY_IE_MISSING);
+            }
+        }
+    } else {
+        const auto &pkt_distr_mode = pkt_distr_data.value()->getPktDistributionOperatingMode();
+        if (up_traffic_flow_info) {
+            const auto &src_ip = up_traffic_flow_info.value()->getSrcIpAddr();
+            if (*pkt_distr_mode == PktDistributionOperatingMode::VAL_PACKET_FORWARD_ONLY) {
+                if (src_ip) {
+                    throw ModelException("upTrafficFlowInfo cannot contain srcIpAddr if pktDistributionData is present and "
+                                         "pktDistributionData.pktDistributionOperatingMode is PACKET_FORWARD_ONLY",
+                                         "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                         ProblemCause::OPTIONAL_IE_INCORRECT);
+                }
+            } else {
+                if (!src_ip) {
+                      throw ModelException("upTrafficFlowInfo.srcIpAddr must be present if "
+                                           "pktDistributionData.pktDistributionOperatingMode is not PACKET_FORWARD_ONLY",
+                                           "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                           ProblemCause::MANDATORY_IE_MISSING);
+                }
+            }
+        } else {
+            if (*pkt_distr_mode == PktDistributionOperatingMode::VAL_PACKET_PROXY) {
+                throw ModelException("upTrafficFlowInfo must be present if pktDistributionData is present and "
+                                     "pktDistributionData.pktDistributionOperatingMode is PACKET_PROXY", "DistributionSession",
+                                     "distSession.upTrafficFlowInfo", ProblemCause::MANDATORY_IE_MISSING);
+            }
+        }
+    }
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -51,6 +51,7 @@ class Open5GSSBIStream;
 class Open5GSSBIMessage;
 class Open5GSSBIRequest;
 class Controller;
+class SsmPort;
 
 class DistributionSession : public std::enable_shared_from_this<DistributionSession>, public Subscriber {
 public:
@@ -83,9 +84,9 @@ public:
     DistributionSession &setState(const reftools::mbstf::DistSessionState &state);
     const reftools::mbstf::ObjDistributionData::ObjAcquisitionIdsPullType &getObjectAcquisitionPullUrls() const;
     const std::string &getObjectDistributionOperatingMode() const;
-    const std::optional<std::string> &getDestIpAddr() const;
+    const SsmPort getSsmPort() const;
+    uint64_t getTSI() const;
     const std::optional<std::string> &getTunnelAddr() const;
-    in_port_t getPortNumber() const;
     in_port_t getTunnelPortNumber() const;
     uint32_t getRateLimit() const;
     std::optional<BitRate> getMbr() const;

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -35,6 +35,7 @@
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
@@ -72,13 +73,12 @@ ObjectCarouselController::~ObjectCarouselController()
 
 void ObjectCarouselController::setObjectPackager()
 {
-    const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+    auto ssm_port = distributionSession().getSsmPort();
     const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
-    packager(new ObjectCarouselPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    packager(new ObjectCarouselPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     auto pkgr = getObjectCarouselPackager();
     subscribeToService(*pkgr);
     startWorker();
@@ -172,14 +172,13 @@ void ObjectCarouselController::reconfigureObjectPackager()
     if (distributionSession().getState() == DistSessionState::VAL_ACTIVE) {
         auto packager = getObjectCarouselPackager();
         if (packager) {
-            const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+            auto ssm_port = distributionSession().getSsmPort();
             const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
             uint32_t rate_limit = distributionSession().getRateLimit();
-            in_port_t port = distributionSession().getPortNumber();
             in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
 
-            if (dest_ip_addr) {
-                packager->updateFluteInfo(dest_ip_addr.value(), port, rate_limit, tunnel_addr, tunnel_port);
+            if (ssm_port) {
+                packager->updateFluteInfo(ssm_port, rate_limit, tunnel_addr, tunnel_port);
             }
         }
     }

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -109,9 +109,9 @@ void ObjectCarouselPackager::PackageItem::startedTransmission(const ObjectCarous
 
 ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
                                        const std::list<ObjectCarouselPackager::PackageItem> &objects_to_package,
-                                       const std::optional<std::string> &address,
-                                       uint32_t rate_limit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+                                       const SsmPort &ssm_port, uint32_t rate_limit, unsigned short mtu,
+                                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(objects_to_package)
     ,m_packagingUpdateCondVar()
@@ -131,9 +131,9 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
 }
 
 ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                                       std::list<PackageItem> &&objects_to_package, const std::optional<std::string> &address,
-                                       uint32_t rate_limit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+                                       std::list<PackageItem> &&objects_to_package, const SsmPort &ssm_port,
+                                       uint32_t rate_limit, unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(std::move(objects_to_package))
     ,m_packagingUpdateCondVar()
@@ -153,9 +153,9 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
 }
 
 ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                                       const std::optional<std::string> &address, uint32_t rate_limit, unsigned short mtu,
-                                       in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+                                       const SsmPort &ssm_port, uint32_t rate_limit, unsigned short mtu,
+                                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems()
     ,m_packagingUpdateCondVar()
@@ -206,8 +206,7 @@ bool ObjectCarouselPackager::remove(const PackageItem &item) {
     return true;
 }
 
-bool ObjectCarouselPackager::updateFluteInfo(const std::string &address, in_port_t port,
-                                             uint32_t rate_limit,
+bool ObjectCarouselPackager::updateFluteInfo(const SsmPort &ssm_port, uint32_t rate_limit,
                                              const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
 {
     std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
@@ -215,10 +214,18 @@ bool ObjectCarouselPackager::updateFluteInfo(const std::string &address, in_port
     /* Do nothing if we don't have a Transmitter */
     if (!m_transmitter) return false;
 
-    /* set destination endpoint address if it has changed */
-    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(address), port);
+    /* set SSM address if it has changed */
+    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(ssm_port.destinationAddress()), ssm_port.port());
     if (dest_addr != m_transmitter->endpoint()) {
         m_transmitter->endpoint(dest_addr);
+    }
+    const auto &source_addr = ssm_port.sourceAddress();
+    std::optional<boost::asio::ip::address> src_addr;
+    if (source_addr) {
+        src_addr = boost::asio::ip::make_address(source_addr.value());
+    }
+    if (src_addr != m_transmitter->source_address()) {
+        m_transmitter->source_address(src_addr);
     }
 
     /* set new MBR if it has changed */
@@ -249,10 +256,12 @@ void ObjectCarouselPackager::ensureTransmitter()
 {
     std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
     if (!m_transmitter) {
-        std::optional<std::string> destAddr = destIpAddr();
-        if (!destAddr) return;
-        m_transmitter.reset(new LibFlute::Transmitter(destAddr.value(), static_cast<short>(port()), 0, mtu(), rateLimit(), m_io,
-                                                  m_tunnelEndpoint, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
+        const auto &ssm_port = ssmPort();
+        if (!ssm_port) return;
+        m_transmitter.reset(new LibFlute::Transmitter(ssm_port.destinationAddress(), static_cast<short>(ssm_port.port()), tsi(), mtu(),
+                                                      rateLimit(), m_io, m_tunnelEndpoint,
+                                                      LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005, true,
+                                                      ssm_port.sourceAddress()));
         m_transmitter->register_completion_callback(
             [this](uint32_t toi) {
                 ogs_debug("Object with TOI %d completed", toi);

--- a/src/mbstf/ObjectCarouselPackager.hh
+++ b/src/mbstf/ObjectCarouselPackager.hh
@@ -82,14 +82,14 @@ public:
 
     ObjectCarouselPackager() = delete;
     ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                       const std::list<PackageItem> &objects_to_package, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const std::list<PackageItem> &objects_to_package, const SsmPort &ssm_port,
+                       uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&objects_to_package,
-                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
+    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, const SsmPort &ssm_port,
+                       uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     virtual ~ObjectCarouselPackager();
 
@@ -98,9 +98,8 @@ public:
     bool remove(const PackageItem &item);
     const std::list<PackageItem> &getPackageItems() const { return m_packageItems; };
 
-    bool updateFluteInfo(const std::string &address, in_port_t port,
-                         uint32_t rateLimit,
-                         const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    bool updateFluteInfo(const SsmPort &ssm_port, uint32_t rateLimit, const std::optional<std::string> &tunnel_address,
+                         in_port_t tunnel_port);
 
     virtual bool deactivate();
     virtual void flushQueue();

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -33,6 +33,7 @@
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
@@ -69,14 +70,13 @@ ObjectListController::~ObjectListController()
 }
 
 void ObjectListController::setObjectPackager() {
-    std::optional<std::string> dest_ip_addr = distributionSession().getDestIpAddr();
+    auto ssm_port = distributionSession().getSsmPort();
     std::optional<std::string> tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
     const auto &obj_list = objectStore().getObjects();
-    packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore
     for (const auto &[obj_id, object] : obj_list) {
         sendToPackager(object);

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -30,6 +30,7 @@
 #include "ObjectListController.hh"
 #include "ObjectPackager.hh"
 #include "ObjectStore.hh"
+#include "SsmPort.hh"
 
 #include "ObjectListPackager.hh"
 
@@ -80,10 +81,10 @@ ObjectListPackager::PackageItem &ObjectListPackager::PackageItem::operator=(Pack
 // ObjectListPackager
 
 ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                                       const std::list<PackageItem> &object_to_package,
-                                       const std::optional<std::string> &address,
-                                       uint32_t rateLimit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+                                       const std::list<PackageItem> &object_to_package, const SsmPort &ssm_port,
+                                       uint32_t rateLimit, unsigned short mtu, const std::optional<std::string> &tunnel_address,
+                                       in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(object_to_package)
     ,m_tunnelEndpoint()
@@ -96,9 +97,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
 }
 
 ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                                       std::list<PackageItem> &&object_to_package, const std::optional<std::string> &address,
-                                       uint32_t rateLimit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+                                       std::list<PackageItem> &&object_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
+                                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(std::move(object_to_package))
     ,m_tunnelEndpoint()
@@ -111,9 +112,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
 }
 
 ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu,
-                                       in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+                                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
+                                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems()
     ,m_tunnelEndpoint()
@@ -148,8 +149,7 @@ bool ObjectListPackager::add(PackageItem &&item) {
     return true;
 }
 
-bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t port,
-                                         uint32_t rateLimit,
+bool ObjectListPackager::updateFluteInfo(const SsmPort &ssm_port, uint32_t rateLimit,
                                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
 {
     std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
@@ -157,10 +157,18 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
     /* Do nothing if we don't have a Transmitter */
     if (!m_transmitter) return false;
 
-    /* set destination endpoint address if it has changed */
-    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(address), port);
+    /* set SSM address if it has changed */
+    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(ssm_port.destinationAddress()), ssm_port.port());
     if (dest_addr != m_transmitter->endpoint()) {
         m_transmitter->endpoint(dest_addr);
+    }
+    const auto &source_addr = ssm_port.sourceAddress();
+    std::optional<boost::asio::ip::address> src_addr;
+    if (source_addr) {
+        src_addr = boost::asio::ip::make_address(source_addr.value());
+    }
+    if (src_addr != m_transmitter->source_address()) {
+        m_transmitter->source_address(src_addr);
     }
 
     /* set new MBR if it has changed */
@@ -183,23 +191,25 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
 }
 
 void ObjectListPackager::doObjectPackage() {
-    std::optional<std::string> destAddr = destIpAddr();
+    const SsmPort &ssm_port = ssmPort();
 
-    if (!destAddr) return;
+    if (!ssm_port) return;
 
     {
         std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
 
         if (!m_transmitter) {
             m_transmitter.reset(new LibFlute::Transmitter(
-                    destAddr.value(),
-                    static_cast<short>(port()),
-                    0,
+                    ssm_port.destinationAddress(),
+                    static_cast<short>(ssm_port.port()),
+                    tsi(),
                     mtu(),
                     rateLimit(),
                     m_io,
                     m_tunnelEndpoint,
-                    LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
+                    LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005,
+                    true,
+                    ssm_port.sourceAddress()));
             m_transmitter->register_completion_callback(
                     [this](uint32_t toi) {
                         ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -66,23 +66,20 @@ public:
 
     ObjectListPackager() = delete;
     ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                       const std::list<PackageItem> &object_to_package, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+                       const std::list<PackageItem> &object_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
+                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     ObjectListPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&object_to_package,
-                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectListPackager(ObjectStore &object_store, ObjectController &controller, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectListPackager(ObjectStore &object_store, ObjectController &controller, const SsmPort &ssm_port, uint32_t rateLimit,
+                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     virtual ~ObjectListPackager();
 
     bool add(const PackageItem &item);
     bool add(PackageItem &&item);
 
-    bool updateFluteInfo(const std::string &address, in_port_t port,
-                         uint32_t rateLimit,
-                         const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    bool updateFluteInfo(const SsmPort &ssm_port, uint32_t rateLimit, const std::optional<std::string> &tunnel_address,
+                         in_port_t tunnel_port);
 
     virtual bool deactivate();
     virtual void flushQueue();

--- a/src/mbstf/ObjectPackager.cc
+++ b/src/mbstf/ObjectPackager.cc
@@ -25,6 +25,8 @@
 
 // local includes
 #include "common.hh"
+#include "ObjectController.hh"
+#include "DistributionSession.hh"
 
 // this class include
 #include "ObjectPackager.hh"
@@ -57,13 +59,8 @@ void ObjectPackager::workerLoop(ObjectPackager *packager)
     packager->m_workerRunning = false;
 }
 
-ObjectPackager& ObjectPackager::setDestIpAddr(const std::optional<std::string> &dest_ip_addr) {
-    m_destIpAddr = dest_ip_addr;
-    return *this;
-}
-
-ObjectPackager& ObjectPackager::setPort(in_port_t port) {
-    m_port = port;
+ObjectPackager& ObjectPackager::setSsmPort(const SsmPort &ssm_port) {
+    m_ssmPort = ssm_port;
     return *this;
 }
 
@@ -100,6 +97,11 @@ bool ObjectPackager::deactivate()
         return true;
     }
     return false;
+}
+
+uint64_t ObjectPackager::tsi() const
+{
+    return m_controller.distributionSession().getTSI();
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -25,6 +25,7 @@
 
 #include "common.hh"
 #include "Event.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
 
 namespace LibFlute{
@@ -35,7 +36,6 @@ MBSTF_NAMESPACE_START
 
 class ObjectStore;
 class ObjectController;
-class Event;
 
 class ObjectPackager: public SubscriptionService {
 public:
@@ -126,11 +126,11 @@ public:
     ObjectPackager(ObjectPackager &&) = delete;
     ObjectPackager(const ObjectPackager &) = delete;
 
-    ObjectPackager(ObjectStore &objectStore, ObjectController &controller, std::optional<std::string> destIpAddr = std::nullopt, uint32_t rateLimit = 0, unsigned short mtu = 0, in_port_t port = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
+    ObjectPackager(ObjectStore &objectStore, ObjectController &controller, const SsmPort &ssm_port = SsmPort(), uint32_t rateLimit = 0, unsigned short mtu = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
         :m_transmitterMutex(new decltype(m_transmitterMutex)::element_type)
         ,m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_deactivating(false), m_queuedObjectId()
-        ,m_objectStore(objectStore), m_controller(controller), m_destIpAddr(destIpAddr), m_rateLimit(rateLimit), m_mtu(mtu)
-        ,m_port(port), m_workerThread(), m_workerCancel(false), m_workerRunning(false)
+        ,m_objectStore(objectStore), m_controller(controller), m_ssmPort(ssm_port), m_rateLimit(rateLimit), m_mtu(mtu)
+        ,m_workerThread(), m_workerCancel(false), m_workerRunning(false)
         ,m_tunnelAddress(tunnel_address), m_tunnelPort(tunnel_port)
     {
     };
@@ -144,8 +144,7 @@ public:
 
     virtual ~ObjectPackager();
 
-    ObjectPackager& setDestIpAddr(const std::optional<std::string> &destIpAddr);
-    ObjectPackager& setPort(in_port_t port);
+    ObjectPackager& setSsmPort(const SsmPort &ssm_port);
     ObjectPackager& setMtu(unsigned short mtu);
     ObjectPackager& setRateLimit(uint32_t rateLimit);
     void startWorker() {
@@ -164,11 +163,11 @@ protected:
     ObjectStore &objectStore() { return m_objectStore; };
     const ObjectController &controller() const { return m_controller; };
     ObjectController &controller() { return m_controller; };
-    const std::optional<std::string> &destIpAddr() const { return m_destIpAddr; };
+    const SsmPort &ssmPort() const { return m_ssmPort; };
     const std::optional<std::string> &tunnelAddr() const { return m_tunnelAddress; };
     uint32_t rateLimit() const { return m_rateLimit; };
     unsigned short mtu() const { return m_mtu; };
-    in_port_t port() const { return m_port; };
+    uint64_t tsi() const;
     in_port_t tunnelPort() const { return m_tunnelPort; };
 
     virtual void doObjectPackage() = 0;
@@ -185,10 +184,9 @@ private:
     static void workerLoop(ObjectPackager*);
     ObjectStore &m_objectStore;
     ObjectController &m_controller;
-    std::optional<std::string> m_destIpAddr;
+    SsmPort m_ssmPort;
     uint32_t m_rateLimit;
     unsigned short m_mtu;
-    in_port_t m_port;
     std::thread m_workerThread;
     std::atomic_bool m_workerCancel;
     std::atomic_bool m_workerRunning;

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -30,11 +30,12 @@
 #include "Event.hh"
 #include "ManifestHandlerFactory.hh"
 #include "ObjectController.hh"
+#include "ObjectListPackager.hh"
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
-#include "ObjectListPackager.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
 #include "openapi/model/ProblemCause.hh"
@@ -67,13 +68,12 @@ ObjectStreamingController::~ObjectStreamingController()
 
 void ObjectStreamingController::setObjectPackager()
 {
-    const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+    auto ssm_port = distributionSession().getSsmPort();
     const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
-    packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);
     startWorker();
@@ -160,14 +160,13 @@ void ObjectStreamingController::reconfigureObjectPackager()
     if (distributionSession().getState() == DistSessionState::VAL_ACTIVE) {
         auto packager = getObjectListPackager();
         if (packager) {
-            const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+            auto ssm_port = distributionSession().getSsmPort();
             const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
             uint32_t rate_limit = distributionSession().getRateLimit();
-            in_port_t port = distributionSession().getPortNumber();
             in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
 
-            if (dest_ip_addr) {
-                packager->updateFluteInfo(dest_ip_addr.value(), port, rate_limit, tunnel_addr, tunnel_port);
+            if (ssm_port) {
+                packager->updateFluteInfo(ssm_port, rate_limit, tunnel_addr, tunnel_port);
             }
         }
     }

--- a/src/mbstf/SsmPort.cc
+++ b/src/mbstf/SsmPort.cc
@@ -1,0 +1,118 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: SSM with Port class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <stdint.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "common.hh"
+#include "openapi/model/IpAddr.h"
+#include "openapi/model/UpTrafficFlowInfo.h"
+
+#include "SsmPort.hh"
+
+using reftools::mbstf::IpAddr;
+using reftools::mbstf::UpTrafficFlowInfo;
+
+MBSTF_NAMESPACE_START
+
+static std::string _conv_IpAddr_to_string(const std::shared_ptr<IpAddr> &ip_addr);
+
+/*** SsmPort class ***/
+
+SsmPort::SsmPort()
+    :m_sourceAddr()
+    ,m_destAddr()
+    ,m_port(0)
+{
+}
+
+SsmPort::SsmPort(const std::shared_ptr<UpTrafficFlowInfo> &up_traffic_flow_info)
+    :m_sourceAddr()
+    ,m_destAddr()
+    ,m_port(0)
+{
+    if (up_traffic_flow_info) {
+        m_port = static_cast<in_port_t>(up_traffic_flow_info->getPortNumber());
+        auto &src_addr = up_traffic_flow_info->getSrcIpAddr();
+        if (src_addr) {
+            m_sourceAddr = _conv_IpAddr_to_string(src_addr.value());
+        }
+        m_destAddr = _conv_IpAddr_to_string(up_traffic_flow_info->getDestIpAddr());
+    }
+}
+
+SsmPort::SsmPort(in_port_t port, const std::string &multicast_destination, const std::optional<std::string> &unicast_source)
+    :m_sourceAddr(unicast_source)
+    ,m_destAddr(multicast_destination)
+    ,m_port(port)
+{
+}
+
+SsmPort::SsmPort(const SsmPort &other)
+    :m_sourceAddr(other.m_sourceAddr)
+    ,m_destAddr(other.m_destAddr)
+    ,m_port(other.m_port)
+{
+}
+
+SsmPort::SsmPort(SsmPort &&other)
+    :m_sourceAddr(std::move(other.m_sourceAddr))
+    ,m_destAddr(std::move(other.m_destAddr))
+    ,m_port(other.m_port)
+{
+}
+
+SsmPort &SsmPort::operator=(const SsmPort &other)
+{
+    m_sourceAddr = other.m_sourceAddr;
+    m_destAddr = other.m_destAddr;
+    m_port = other.m_port;
+    return *this;
+}
+
+SsmPort &SsmPort::operator=(SsmPort &&other)
+{
+    m_sourceAddr = std::move(other.m_sourceAddr);
+    m_destAddr = std::move(other.m_destAddr);
+    m_port = other.m_port;
+    return *this;
+}
+
+bool SsmPort::operator==(const SsmPort &other) const
+{
+    return m_port == other.m_port && m_destAddr == other.m_destAddr && m_sourceAddr == other.m_sourceAddr;
+}
+
+/*** Local functions ***/
+
+static std::string _conv_IpAddr_to_string(const std::shared_ptr<IpAddr> &ip_addr)
+{
+    if (!ip_addr) return std::string();
+    const auto &ipv4_addr = ip_addr->getIpv4Addr();
+    if (ipv4_addr) return ipv4_addr.value();
+    const auto &ipv6_addr = ip_addr->getIpv6Addr();
+    if (ipv6_addr && ipv6_addr.value()) {
+        return *ipv6_addr.value();
+    }
+    const auto &ipv6_prefix = ip_addr->getIpv6Prefix();
+    if (ipv6_prefix && ipv6_prefix.value()) {
+        return *ipv6_prefix.value();
+    }
+    return std::string();
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/SsmPort.hh
+++ b/src/mbstf/SsmPort.hh
@@ -1,0 +1,73 @@
+#ifndef _MBS_TF_SSM_PORT_HH_
+#define _MBS_TF_SSM_PORT_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: SSM with Port class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <stdint.h>
+#include <netinet/in.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "common.hh"
+
+namespace reftools::mbstf {
+    class UpTrafficFlowInfo;
+}
+
+MBSTF_NAMESPACE_START
+
+class SsmPort {
+public:
+    SsmPort();
+    SsmPort(const std::shared_ptr<reftools::mbstf::UpTrafficFlowInfo> &up_traffic_flow_info);
+    SsmPort(in_port_t port, const std::string &multicast_destination, const std::optional<std::string> &unicast_source);
+    SsmPort(const SsmPort &other);
+    SsmPort(SsmPort &&other);
+
+    virtual ~SsmPort() {};
+
+    SsmPort &operator=(const SsmPort &other);
+    SsmPort &operator=(SsmPort &&other);
+
+    bool operator==(const SsmPort &other) const;
+    bool operator!=(const SsmPort &other) const { return !(*this == other); };
+
+    operator bool() const { return m_port != 0 && !m_destAddr.empty(); };
+
+    const std::optional<std::string> &sourceAddress() const { return m_sourceAddr; };
+    bool hasSourceAddress() const { return m_sourceAddr.has_value(); };
+    SsmPort &sourceAddress(const std::nullopt_t &val) { m_sourceAddr.reset(); return *this; };
+    SsmPort &sourceAddress(const std::optional<std::string> &val) { m_sourceAddr = val; return *this; };
+    SsmPort &sourceAddress(std::optional<std::string> &&val) { m_sourceAddr = std::move(val); return *this; };
+    SsmPort &sourceAddress(const std::string &val) { m_sourceAddr = val; return *this; };
+    SsmPort &sourceAddress(std::string &&val) { m_sourceAddr = std::move(val); return *this; };
+
+    const std::string &destinationAddress() const { return m_destAddr; };
+    SsmPort &destinationAddress(const std::string &val) { m_destAddr = val; return *this; };
+    SsmPort &destinationAddress(std::string &&val) { m_destAddr = std::move(val); return *this; };
+
+    in_port_t port() const { return m_port; };
+    SsmPort &port(in_port_t val) { m_port = val; return *this; };
+
+private:
+    std::optional<std::string> m_sourceAddr;
+    std::string m_destAddr;
+    in_port_t m_port;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* _MBS_TF_SSM_PORT_HH_ */

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -161,6 +161,8 @@ libmbstf_dist_sources = files('''
     PullObjectIngester.hh
     PushObjectIngester.cc
     PushObjectIngester.hh
+    SsmPort.cc
+    SsmPort.hh
     SubscriptionService.cc
     SubscriptionService.hh
     Subscriber.cc

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -30,6 +30,7 @@
 #include <sstream>
 
 #include "common.hh"
+#include "SsmPort.hh"
 
 #include "utilities.hh"
 
@@ -103,8 +104,7 @@ int get_path_mtu(const ogs_sockaddr_t &sock_addr)
     return mtu;
 }
 
-int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
-                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
+int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
 {
     int mtu = 1500; // default to 1500 if no MTU can be found.
 
@@ -115,9 +115,9 @@ int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t 
             ogs_freeaddrinfo(sa);
         } // else error already reported
     } else { // No tunnel provided so try MTU of direct destination
-        if (dest_ip) {
+        if (ssm_port) {
             ogs_sockaddr_t *sa = nullptr;
-            if (ogs_addaddrinfo(&sa, AF_UNSPEC, dest_ip.value().c_str(), dest_port, AI_NUMERICSERV) == OGS_OK) {
+            if (ogs_addaddrinfo(&sa, AF_UNSPEC, ssm_port.destinationAddress().c_str(), ssm_port.port(), AI_NUMERICSERV) == OGS_OK) {
                 mtu = get_path_mtu(*sa);
                 ogs_freeaddrinfo(sa);
             }

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -19,11 +19,14 @@
  * under the License.
  */
 #include <chrono>
+#include <optional>
 #include <string>
 
 #include "common.hh"
 
 MBSTF_NAMESPACE_START
+
+class SsmPort;
 
 std::string trim_slashes(const std::string &path);
 
@@ -33,8 +36,7 @@ std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::s
 std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std::string &rfc9110_str);
 
 int get_path_mtu(const ogs_sockaddr_t &sock_addr);
-int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
-                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
+int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
 
 MBSTF_NAMESPACE_STOP
 

--- a/subprojects/rt-libflute.wrap
+++ b/subprojects/rt-libflute.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 url = https://github.com/5G-MAG/rt-libflute.git
-revision = rt-libflute-0.12.2
+#revision = rt-libflute-0.12.3
+revision = development
 method = cmake
 
 #diff_files = rt-libflute/IpSec-xfrm_algo.patch


### PR DESCRIPTION
The UpTrafficFlowInfo data type, from TS 29.581 V18.6.0 onwards, contains the SSM source address and the FLUTE session TSI to use.

With this PR the MBSTF can accept these new values and pass them to the FLUTE library to set the multicast source address and TSI values. This allows the MBSF to pass through the SSM source address and allocate a TSI. The MBSF can then use these values in the User Service Announcement Bundles to correctly identify the generated FLUTE streams.

Closes #56 