### PR TITLE
Bug-fixes: Various issues found during MBSF Uplift testing

### DIFF
--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -728,12 +728,20 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
 
     /* Make sure we are in the right state */
-    auto new_state = new_dist_session->getDistSessionState()->getValue();
-    if (new_state == DistSessionState::VAL_INACTIVE || new_state == DistSessionState::VAL_DEACTIVATING) {
+    const auto &old_state = old_dist_session->getDistSessionState();
+    const auto &new_state = new_dist_session->getDistSessionState();
+    auto new_state_enum = new_state->getValue();
+    if (new_state_enum == DistSessionState::VAL_INACTIVE || new_state_enum == DistSessionState::VAL_DEACTIVATING) {
         /* If you request deactivating or inactive, make sure no more files are packaged */
         m_controller->flushPackagerQueue();
     }
-    _transitionTo(new_state);
+    try {
+        _transitionTo(new_state_enum);
+    } catch (std::runtime_error &exc) {
+        // bad state transition
+        ex.addInvalidParameter("distSession.distSessionState", exc.what());
+        throw ex;
+    }
 
     /* Update the last-used and hash values to reflect the new CreateReqData */
     _setLastUsed();
@@ -826,7 +834,7 @@ void DistributionSession::_inactiveState(const DistributionSession::Action &acti
                 _changeState(&DistributionSession::_establishedState);
                 break;
             case DistSessionState::VAL_DEACTIVATING:
-                throw std::runtime_error("Invalid state transition in DistSession");
+                throw std::runtime_error("Invalid state transition from INACTIVE to DEACTIVATING in DistSession");
             default:
                 throw std::runtime_error("Request for unhandled state in DistSession");
             }
@@ -861,7 +869,7 @@ void DistributionSession::_establishedState(const DistributionSession::Action &a
                 _changeState(&DistributionSession::_activeState);
                 break;
             case DistSessionState::VAL_DEACTIVATING:
-                throw std::runtime_error("Invalid state transition in DistSession");
+                throw std::runtime_error("Invalid state transition from ESTABLISHED to DEACTIVATING in DistSession");
             default:
                 throw std::runtime_error("Request for unhandled state in DistSession");
             }
@@ -891,7 +899,7 @@ void DistributionSession::_activeState(const DistributionSession::Action &action
                 _changeState(&DistributionSession::_deactivatingState);
                 break;
             case DistSessionState::VAL_ESTABLISHED:
-                throw std::runtime_error("Invalid state transition in DistSession");
+                throw std::runtime_error("Invalid state transition from ACTIVE to ESTABLISHED in DistSession");
             case DistSessionState::VAL_ACTIVE:
                 break;
             default:

--- a/src/mbstf/SubscriptionService.cc
+++ b/src/mbstf/SubscriptionService.cc
@@ -257,7 +257,9 @@ std::string SubscriptionService::reprString() const
 bool SubscriptionService::sendEventSynchronous(Event &event)
 {
     std::lock_guard guard(*m_asyncMutex);
-    auto self = shared_from_this(); /* make sure we don't get deleted while sending events */
+    // make sure we don't get deleted while sending events
+    auto self = weak_from_this().lock();
+    if (!self) return false; // If this object has been deleted, abort event
     auto it = m_namedEventSubscriptions.find(event.eventName());
     if (it != m_namedEventSubscriptions.end()) {
         for (auto &subsc : it->second) {
@@ -326,7 +328,9 @@ void SubscriptionService::asyncEventsLoopRunner(SubscriptionService *svc)
 void SubscriptionService::asyncEventsLoop()
 {
     using namespace std::literals;
-    auto self = shared_from_this(); /* make sure we don't get deleted while sending events, but exit if we are the last holder */
+    /* make sure we don't get deleted while sending events, but exit if we are the last holder */
+    auto self = weak_from_this().lock();
+    if (!self) return; // object has already been deleted
     while (!m_asyncCancel && self.use_count() > 1) {
         std::lock_guard guard(*m_asyncMutex);
         while (!m_asyncCancel && m_asyncEventQueue.empty() && self.use_count() > 1) {


### PR DESCRIPTION
Fixes for:
- `std::bad_weak_ptr` raised in `SubscriptionService` objects during asynchronous event reporting.
- Uncaught exception when a bad state transition is reported.

These were found during interactions with the MBSTF during testing for 5G-MAG/rt-mbs-function#27.