### PR TITLE
Release of MBS Transport Function v1.3.0

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -25,10 +25,12 @@ jobs:
                     sudo add-apt-repository universe
                     sudo apt update
                     sudo apt install -y \
-                      git ninja-build build-essential flex bison libglibmm-2.4-dev libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev \
-                      libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libtins-dev \
-                      libtalloc-dev libpcre2-dev libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-test-dev libspdlog-dev \
-                      libtinyxml2-dev libconfig++-dev uuid-dev libxml2-dev gcc-14 g++-14 curl wget default-jdk cmake jq util-linux-extra mm-common python3-pip
+                      git ninja-build build-essential flex bison libglibmm-2.4-dev libsctp-dev libgnutls28-dev libgcrypt-dev \
+                      libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev \
+                      libcurl4-gnutls-dev libtins-dev libtalloc-dev libpcre2-dev libboost-system-dev libboost-thread-dev \
+                      libboost-program-options-dev libboost-test-dev libspdlog-dev libtinyxml2-dev libconfig++-dev uuid-dev \
+                      libxml2-dev gcc-14 g++-14 curl wget default-jdk cmake jq util-linux-extra mm-common python3-pip \
+                      ca-certificates
                     sudo sh -c 'for i in cpp g++ gcc gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do rm -f /usr/bin/$i; ln -s $i-14 /usr/bin/$i; done'
                     sudo python3 -m pip install --break-system-packages --upgrade meson
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 # License: 5G-MAG Public License (v1.0)
-# Copyright: (C) 2024-2025 British Broadcasting Corporation
+# Copyright: (C) 2024-2026 British Broadcasting Corporation
 # Author(s): David Waring <david.waring2@bbc.co.uk>
 #            Dev Audsin <dev.audsin@bbc.co.uk>
 #
@@ -10,7 +10,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-mbs-transport-function', 'c', 'cpp',
-        version : '1.2.2',
+        version : '1.3.0',
         license : '5G-MAG Public',
         meson_version : '>= 1.4.0',
         default_options : [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '110')
+option('fiveg_api_approval', type: 'string', value: '111')
 option('fiveg_api_release', type: 'string', value: '18')

--- a/src/mbstf/App.cc
+++ b/src/mbstf/App.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Main app entry point
+ * 5G-MAG Reference Tools: MBS Transport Function: Main app entry point
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/App.hh
+++ b/src/mbstf/App.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_APP_HH_
 #define _MBS_TF_APP_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Main app entry point
+ * 5G-MAG Reference Tools: MBS Transport Function: Main app entry point
  ******************************************************************************
  * Copyright: (C)2024-2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/BitRate.cc
+++ b/src/mbstf/BitRate.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: BitRate string handler
+ * 5G-MAG Reference Tools: MBS Transport Function: BitRate string handler
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/BitRate.hh
+++ b/src/mbstf/BitRate.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_BIT_RATE_HH_
 #define _MBS_TF_BIT_RATE_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: BitRate string handler
+ * 5G-MAG Reference Tools: MBS Transport Function: BitRate string handler
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/CaseInsensitiveTraits.hh
+++ b/src/mbstf/CaseInsensitiveTraits.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_CASE_INSENSITIVE_TRAITS_HH_
 #define _MBS_TF_CASE_INSENSITIVE_TRAITS_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Case insensitive char traits
+ * 5G-MAG Reference Tools: MBS Transport Function: Case insensitive char traits
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author: David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: App context class
+ * 5G-MAG Reference Tools: MBS Transport Function: App context class
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -73,7 +73,7 @@ bool Context::parseConfig()
                 if (mbstf_key == "sbi" || mbstf_key == "service_name" || mbstf_key == "discovery") {
                     // Handled by SBI config parser
                 } else if (mbstf_key == "serverResponseCacheControl") {
-		    Open5GSYamlIter cc_array(mbstf_iter);
+                    Open5GSYamlIter cc_array(mbstf_iter);
                     if (cc_array.type() == YAML_MAPPING_NODE) {
                         parseCacheControl(cc_array);
                     } else if (cc_array.type() == YAML_SEQUENCE_NODE) {
@@ -86,7 +86,7 @@ bool Context::parseConfig()
                         throw std::out_of_range("Bad configuration node at mbstf.serverResponseCacheControl");
                      }
 
-		} else if (mbstf_key == "distSessionAPI" || mbstf_key == "httpPushIngest" || mbstf_key == "rtpIngest") {
+                } else if (mbstf_key == "distSessionAPI" || mbstf_key == "httpPushIngest" || mbstf_key == "rtpIngest") {
                     Open5GSYamlIter distSess_array(mbstf_iter);
                     do {
                         if (distSess_array.type() == YAML_MAPPING_NODE) {
@@ -159,6 +159,15 @@ void Context::deleteDistributionSession(const std::string &distributionSessionid
     }
 }
 
+const std::shared_ptr<DistributionSession> &Context::findDistributionSession(const std::string &distributionSessionid)
+{
+    auto it = distributionSessions.find(distributionSessionid);
+    if (it != distributionSessions.end()) {
+        return it->second;
+    }
+    static const std::shared_ptr<DistributionSession> null_dist_sess(nullptr);
+    return null_dist_sess;
+}
 
 void Context::parseCacheControl(Open5GSYamlIter &iter) {
     while (iter.next()) {
@@ -195,14 +204,14 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
 
      while (iter.next()) {
          std::string sbi_key(iter.key());
-	 if(sbi_key == "family") {
-	     const char *v = iter.value();
-	     if (v) family = atoi(v);
+         if(sbi_key == "family") {
+             const char *v = iter.value();
+             if (v) family = atoi(v);
              if (family != AF_UNSPEC && family != AF_INET && family != AF_INET6) {
                  ogs_warn("Ignore family(%d) : ""AF_UNSPEC(%d), " "AF_INET(%d), AF_INET6(%d) ", family, AF_UNSPEC, AF_INET, AF_INET6);
                  family = AF_UNSPEC;
              }
-	 } else if ((sbi_key == "addr") || (sbi_key == "name")) {
+         } else if ((sbi_key == "addr") || (sbi_key == "name")) {
              Open5GSYamlIter hostname_iter(iter);
              ogs_assert(hostname_iter.type() != YAML_MAPPING_NODE);
              do {
@@ -212,7 +221,7 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
                     ogs_assert(num < OGS_MAX_NUM_OF_HOSTNAME);
                     hostname[num++] = hostname_iter.value();
                 } while (hostname_iter.type() == YAML_SEQUENCE_NODE);
-	 } else if (sbi_key == "advertise") {
+         } else if (sbi_key == "advertise") {
              Open5GSYamlIter advertise_iter(iter);
              ogs_assert(advertise_iter.type() != YAML_MAPPING_NODE);
              do {
@@ -229,17 +238,17 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
              dev = iter.value();
         } else if (sbi_key == "option") {
              /*
-	     rv = ogs_app_config_parse_sockopt(&iter, &option);
+             rv = ogs_app_config_parse_sockopt(&iter, &option);
              if (rv != OGS_OK) {
                  ogs_debug("ogs_app_config_parse_sockopt() failed");
                  return rv;
              }
-	     */
+             */
              is_option = true;
-	} else if (sbi_key == "tls") {
-	    Open5GSYamlIter tls_iter(iter);
+        } else if (sbi_key == "tls") {
+            Open5GSYamlIter tls_iter(iter);
             while (tls_iter.next()) {
-	      std::string tls_key(tls_iter.key());
+              std::string tls_key(tls_iter.key());
               if (tls_key == "key") {
                    //key = tls_iter.value();
                } else if (tls_key == "pem") {
@@ -247,7 +256,7 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
                } else
                    ogs_warn("unknown key `%s`", tls_key.c_str());
             }
-	} else
+        } else
             ogs_warn("unknown key `%s`", sbi_key.c_str());
 
     }
@@ -269,12 +278,12 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
             ogs_socknode_add(&list, AF_INET, addr, NULL);
         if (ogs_app()->parameter.no_ipv6 == 0)
             ogs_socknode_add(&list6, AF_INET6, addr, NULL);
-	ogs_freeaddrinfo(addr);
+        ogs_freeaddrinfo(addr);
     }
 
     if (dev) {
         rv = ogs_socknode_probe(
-			ogs_app()->parameter.no_ipv4 ? NULL : &list,
+                        ogs_app()->parameter.no_ipv4 ? NULL : &list,
                                     ogs_app()->parameter.no_ipv6 ? NULL : &list6,
                                     dev, port, NULL);
         ogs_assert(rv == OGS_OK);
@@ -290,31 +299,7 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
     if (node) {
         int matches = 0;
         //ogs_sbi_server_t *server;
-	matches = checkForAddr(node);
-
-	if(!matches) {
-	    std::shared_ptr<Open5GSSBIServer> newServer;
-            newServer.reset(new Open5GSSBIServer(node, is_option ? &option : nullptr));
-            newServer->ogsSBIServerAdvertise(addr);
-
-            if (pc_key == "distSessionAPI") {
-	        servers[SERVER_DISTRIBUTION_SESSION].push_back(newServer);
-            } else if (pc_key == "httpPushIngest") {
-		 servers[SERVER_OBJECT_PUSH].push_back(newServer);
-	    } else if (pc_key == "rtpIngest") {
-		servers[SERVER_RTP].push_back(newServer);
-            }
-
-            /*
-                if (key) server->tls.key = key;
-                if (pem) server->tls.pem = pem;
-            */
-        }
-    }
-    node6 = (ogs_socknode_t *)ogs_list_first(&list6);
-    if (node6) {
-        int matches = 0;
-	matches = checkForAddr(node);
+        matches = checkForAddr(node);
 
         if(!matches) {
             std::shared_ptr<Open5GSSBIServer> newServer;
@@ -328,7 +313,31 @@ void Context::parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter)   {
             } else if (pc_key == "rtpIngest") {
                 servers[SERVER_RTP].push_back(newServer);
             }
-	}
+
+            /*
+                if (key) server->tls.key = key;
+                if (pem) server->tls.pem = pem;
+            */
+        }
+    }
+    node6 = (ogs_socknode_t *)ogs_list_first(&list6);
+    if (node6) {
+        int matches = 0;
+        matches = checkForAddr(node);
+
+        if(!matches) {
+            std::shared_ptr<Open5GSSBIServer> newServer;
+            newServer.reset(new Open5GSSBIServer(node, is_option ? &option : nullptr));
+            newServer->ogsSBIServerAdvertise(addr);
+
+            if (pc_key == "distSessionAPI") {
+                servers[SERVER_DISTRIBUTION_SESSION].push_back(newServer);
+            } else if (pc_key == "httpPushIngest") {
+                 servers[SERVER_OBJECT_PUSH].push_back(newServer);
+            } else if (pc_key == "rtpIngest") {
+                servers[SERVER_RTP].push_back(newServer);
+            }
+        }
     }
 
     if (addr) ogs_freeaddrinfo(addr);

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -55,11 +55,12 @@ public:
 */
     void addDistributionSession(const std::shared_ptr<DistributionSession> &DistributionSession);
     void deleteDistributionSession(const std::string &distributionSessionid);
+    const std::shared_ptr<DistributionSession> &findDistributionSession(const std::string &distributionSessionid);
 
     enum ServerType {
-	SERVER_DISTRIBUTION_SESSION,
+        SERVER_DISTRIBUTION_SESSION,
         SERVER_OBJECT_PUSH,
-	SERVER_RTP,
+        SERVER_RTP,
         SERVER_MAX_NUM
     };
 

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_CONTEXT_HH_
 #define _MBS_TF_CONTEXT_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: MBSTF Context
+ * 5G-MAG Reference Tools: MBS Transport Function: MBSTF Context
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Controller.cc
+++ b/src/mbstf/Controller.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Controller
+ * 5G-MAG Reference Tools: MBS Transport Function: Controller
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Controller.hh
+++ b/src/mbstf/Controller.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_CONTROLLER_HH_
 #define _MBS_TF_CONTROLLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Session Controller Base
+ * 5G-MAG Reference Tools: MBS Transport Function: Session Controller Base
  ******************************************************************************
  * Copyright: (C)2024-2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ControllerFactory.cc
+++ b/src/mbstf/ControllerFactory.cc
@@ -48,13 +48,13 @@ Controller *ControllerFactory::makeController(DistributionSession &distributionS
     for (const auto &cc : constructors()) {
         try {
             return cc->makeController(distributionSession);
-	} catch (const std::runtime_error& e) {
+        } catch (const std::runtime_error& e) {
             // Handle runtime_error specifically
             throw;
         } catch (const std::logic_error &e) {
             // That controller couldn't handle that DistributionSession, let's try the next
         }
-	catch (std::exception &ex) {
+        catch (std::exception &ex) {
             // That controller couldn't handle that DistributionSession, let's try the next
         }
     }

--- a/src/mbstf/ControllerFactory.cc
+++ b/src/mbstf/ControllerFactory.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Session Controller Factory
+ * 5G-MAG Reference Tools: MBS Transport Function: Session Controller Factory
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/ControllerFactory.hh
+++ b/src/mbstf/ControllerFactory.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_CONTROLLER_FACTORY_HH_
 #define _MBS_TF_CONTROLLER_FACTORY_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Session Controller Factory
+ * 5G-MAG Reference Tools: MBS Transport Function: Session Controller Factory
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Curl.cc
+++ b/src/mbstf/Curl.cc
@@ -76,8 +76,10 @@ Curl::~Curl() {
 
 long Curl::__get(const std::string& url, std::chrono::milliseconds timeout, const std::map<std::string, std::string> &request_headers)
 {
-    m_etag.clear(); // Clear the ETag before making a new request
-    m_receivedData.clear(); // Clear the received data before making a new request
+    m_etag.clear();                              // Clear the ETag before making a new request
+    m_receivedData.clear();                      // Clear the received data before making a new request
+    m_lastModified = decltype(m_lastModified){}; // Reset the last modified date-time to the epoch before making a new request
+    m_age = 0;                                   // Zero the current object age before making a new request
 
     if (m_curl) {
         curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());

--- a/src/mbstf/Curl.cc
+++ b/src/mbstf/Curl.cc
@@ -84,10 +84,10 @@ long Curl::__get(const std::string& url, std::chrono::milliseconds timeout, cons
     if (m_curl) {
         curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(m_curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2);
-	curl_easy_setopt(m_curl, CURLOPT_CONNECTTIMEOUT_MS, 500l);
+        curl_easy_setopt(m_curl, CURLOPT_CONNECTTIMEOUT_MS, 500l);
         curl_easy_setopt(m_curl, CURLOPT_TIMEOUT_MS, timeout.count());
         curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, 1L);
-	curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, this);
+        curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, this);
         curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, headerCallback);
         curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &m_receivedData);
         curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, writeCallback);
@@ -115,15 +115,15 @@ long Curl::__get(const std::string& url, std::chrono::milliseconds timeout, cons
             hdrs_list = nullptr;
         }
         if (res == CURLE_OK) {
-	    struct curl_header *type;
+            struct curl_header *type;
             CURLHcode h;
 
             h = curl_easy_header(m_curl, "ETag", 0, CURLH_HEADER, -1, &type);
             if (h == CURLHE_OK && type) {
                 m_etag = std::string(type->value);
-		ogs_debug("ETag: %s", m_etag.c_str());
+                ogs_debug("ETag: %s", m_etag.c_str());
             } else {
-		ogs_debug("ETag header not found.");
+                ogs_debug("ETag header not found.");
             }
 
             h = curl_easy_header(m_curl, "Last-Modified", 0, CURLH_HEADER, -1, &type);
@@ -144,11 +144,11 @@ long Curl::__get(const std::string& url, std::chrono::milliseconds timeout, cons
             }
 
             // Get the Content-Type header
-	    char *ct = NULL;
-	    res = curl_easy_getinfo(m_curl, CURLINFO_CONTENT_TYPE, &ct);
-	    if (!res && ct) {
-	        m_contentType = std::string(ct);
-	    }
+            char *ct = NULL;
+            res = curl_easy_getinfo(m_curl, CURLINFO_CONTENT_TYPE, &ct);
+            if (!res && ct) {
+                m_contentType = std::string(ct);
+            }
 
             char *redir_url = NULL;
             res = curl_easy_getinfo(m_curl, CURLINFO_EFFECTIVE_URL, &redir_url);
@@ -220,7 +220,7 @@ unsigned long Curl::getCacheControlMaxAge() const
     return m_cacheControlMaxAge;
 }
 
-unsigned long Curl::getAge() const 
+unsigned long Curl::getAge() const
 {
     return m_age;
 }
@@ -285,9 +285,9 @@ void Curl::processHeaderLine(std::string_view &header_line)
 
             // Look for the "max-age=" directive within the header line.
             auto pos = header_line.find("max-age=");
-	    if (pos == std::string_view::npos) {
-	        pos = header_line.find("Max-age=");
-	    }
+            if (pos == std::string_view::npos) {
+                pos = header_line.find("Max-age=");
+            }
             if (pos != std::string_view::npos) {
                 pos += 8; // Move past "max-age="
                 // Find where the numeric value ends (comma, space, or end-of-line)

--- a/src/mbstf/Curl.cc
+++ b/src/mbstf/Curl.cc
@@ -49,12 +49,14 @@ Curl::Curl()
     ,m_receivedData()
     ,m_etag()
     ,m_contentType()
+    ,m_lastModified()
     ,m_effectiveUrl()
     ,m_userAgent()
     ,m_protocol()
     ,m_statusCode(0)
     ,m_permanentRedirectUrl()
     ,m_cacheControlMaxAge(0)
+    ,m_age(0)
 {
     // Ensure curl_global_init is called only once
     static std::once_flag init_flag;
@@ -113,12 +115,30 @@ long Curl::__get(const std::string& url, std::chrono::milliseconds timeout, cons
         if (res == CURLE_OK) {
 	    struct curl_header *type;
             CURLHcode h;
+
             h = curl_easy_header(m_curl, "ETag", 0, CURLH_HEADER, -1, &type);
             if (h == CURLHE_OK && type) {
                 m_etag = std::string(type->value);
-		ogs_info("ETag: %s", m_etag.c_str());
+		ogs_debug("ETag: %s", m_etag.c_str());
             } else {
-		ogs_info("ETag header not found.");
+		ogs_debug("ETag header not found.");
+            }
+
+            h = curl_easy_header(m_curl, "Last-Modified", 0, CURLH_HEADER, -1, &type);
+            if (h == CURLHE_OK && type) {
+                m_lastModified = http_datetime_str_to_time_point(std::string(type->value));
+                ogs_debug("%s", std::format("Last-Modified: {}", m_lastModified).c_str());
+            } else {
+                ogs_debug("Last-Modified header not found.");
+            }
+
+            h = curl_easy_header(m_curl, "Age", 0, CURLH_HEADER, -1, &type);
+            if (h == CURLHE_OK && type) {
+                try {
+                    m_age = std::stoul(type->value);
+                    ogs_debug("%s", std::format("Age: %lu", m_age).c_str());
+                } catch (const std::exception&) {
+                }
             }
 
             // Get the Content-Type header
@@ -177,6 +197,11 @@ const std::string& Curl::getContentType() const
     return m_contentType;
 }
 
+const Curl::date_time_type &Curl::getLastModified() const
+{
+    return m_lastModified;
+}
+
 const std::string &Curl::getEffectiveUrl() const
 {
     return m_effectiveUrl;
@@ -187,11 +212,20 @@ const std::string &Curl::getPermanentRedirectUrl() const
     return m_permanentRedirectUrl;
 }
 
-const unsigned long Curl::getCacheControlMaxAge() const
+unsigned long Curl::getCacheControlMaxAge() const
 {
     return m_cacheControlMaxAge;
 }
 
+unsigned long Curl::getAge() const 
+{
+    return m_age;
+}
+
+int Curl::getResponseCode() const
+{
+    return m_statusCode;
+}
 
 bool Curl::extractProtocolAndStatusCode(std::string_view &header_line)
 {

--- a/src/mbstf/Curl.cc
+++ b/src/mbstf/Curl.cc
@@ -170,8 +170,9 @@ long Curl::get(const std::string& url, std::chrono::milliseconds timeout, const 
     std::map<std::string, std::string> req_hdrs;
 
     if (etag) {
-        req_hdrs.insert(std::make_pair(std::string("If-Not-Exist"), std::string(etag.value())));
-    } else if (last_modified) {
+        req_hdrs.insert(std::make_pair(std::string("If-None-Match"), std::string(etag.value())));
+    }
+    if (last_modified) {
         req_hdrs.insert(std::make_pair(std::string("If-Modified-Since"), time_point_to_http_datetime_str(last_modified.value())));
     }
     return __get(url, timeout, req_hdrs);

--- a/src/mbstf/Curl.cc
+++ b/src/mbstf/Curl.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: cURL requests
+ * 5G-MAG Reference Tools: MBS Transport Function: cURL requests
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/Curl.hh
+++ b/src/mbstf/Curl.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_CURL_HH_
 #define _MBS_TF_CURL_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: cURL client
+ * 5G-MAG Reference Tools: MBS Transport Function: cURL client
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/Curl.hh
+++ b/src/mbstf/Curl.hh
@@ -38,10 +38,12 @@ public:
     const std::vector<unsigned char> &getData() const;
     const std::string &getEtag() const;
     const std::string &getContentType() const;
+    const date_time_type &getLastModified() const;
     const std::string &getEffectiveUrl() const;
     const std::string &getPermanentRedirectUrl() const;
-    const unsigned long getCacheControlMaxAge() const;
-
+    unsigned long getCacheControlMaxAge() const;
+    unsigned long getAge() const;
+    int getResponseCode() const;
 
     Curl &setUserAgent(const std::string &user_agent);
 
@@ -57,12 +59,14 @@ private:
     std::vector<unsigned char> m_receivedData;
     std::string m_etag;
     std::string m_contentType;
+    date_time_type m_lastModified;
     std::string m_effectiveUrl;
     std::string m_userAgent;
     std::string m_protocol;
     int m_statusCode;
     std::string m_permanentRedirectUrl;
     unsigned long m_cacheControlMaxAge;
+    unsigned long m_age;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DASHManifestHandler.cc
+++ b/src/mbstf/DASHManifestHandler.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: DASH Manifest Handler class
+ * 5G-MAG Reference Tools: MBS Transport Function: DASH Manifest Handler class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/DASHManifestHandler.cc
+++ b/src/mbstf/DASHManifestHandler.cc
@@ -47,13 +47,13 @@ MBSTF_NAMESPACE_START
 
 using time_type = std::chrono::system_clock::time_point;
 
-static LIBMPDPP_NAMESPACE_CLASS(MPD) ingest_manifest(const ObjectStore::Object &new_manifest);
+static LIBMPDPP_NAMESPACE_CLASS(MPD) ingest_manifest(const std::shared_ptr<ObjectStore::Object> &new_manifest);
 
-DASHManifestHandler::DASHManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution)
+DASHManifestHandler::DASHManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller, bool pull_distribution)
     :ManifestHandler(controller, pull_distribution)
     ,m_mpdMutex()
     ,m_mpd(ingest_manifest(object))
-    ,m_manifest(&object)
+    ,m_manifest(object)
     ,m_refreshMpd(false)
 {
     std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
@@ -192,7 +192,7 @@ ManifestHandler::durn_type DASHManifestHandler::getDefaultDeadline()
     return 4s;
 }
 
-bool DASHManifestHandler::update(const ObjectStore::Object &new_manifest)
+bool DASHManifestHandler::update(const std::shared_ptr<ObjectStore::Object> &new_manifest)
 {
     // Process the new MPD and see what has changed, throw an exception of the Object is not understood or invalid
 
@@ -203,7 +203,7 @@ bool DASHManifestHandler::update(const ObjectStore::Object &new_manifest)
         if (m_mpd != new_mpd) {
             ogs_debug("New MPD update, changing MPD");
             m_mpd = new_mpd;
-            m_manifest = &new_manifest;
+            m_manifest = new_manifest;
             m_mpd.selectAllRepresentations();
             //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
             m_extraPullObjects = m_mpd.selectedInitializationSegments();
@@ -216,12 +216,12 @@ bool DASHManifestHandler::update(const ObjectStore::Object &new_manifest)
 
 static bool g_registered = ManifestHandlerFactory::registerManifestHandler("application/dash+xml", new ManifestHandlerConstructorClass<DASHManifestHandler>());
 
-static LIBMPDPP_NAMESPACE_CLASS(MPD) ingest_manifest(const ObjectStore::Object &new_manifest)
+static LIBMPDPP_NAMESPACE_CLASS(MPD) ingest_manifest(const std::shared_ptr<ObjectStore::Object> &new_manifest)
 {
-    if ( new_manifest.second.mediaType() != "application/dash+xml" ){
+    if ( new_manifest->second.mediaType() != "application/dash+xml" ){
          throw std::invalid_argument("Does not look like a DASH Manifest as the media type is invalid. Expected media type: application/dash+xml");
     }
-    return LIBMPDPP_NAMESPACE_CLASS(MPD) (new_manifest.first, new_manifest.second.getFetchedUrl());
+    return LIBMPDPP_NAMESPACE_CLASS(MPD) (new_manifest->first, new_manifest->second.getFetchedUrl());
 
 
 }

--- a/src/mbstf/DASHManifestHandler.cc
+++ b/src/mbstf/DASHManifestHandler.cc
@@ -92,7 +92,7 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
     media_segments.insert(media_segments.end(), m_extraPullObjects.begin(), m_extraPullObjects.end());
     for (auto &ms: media_segments) {
         if(ms.availabilityStartTime() < current_time)
-	    ms.availabilityStartTime(current_time);
+            ms.availabilityStartTime(current_time);
     }
     ogs_debug("MEDIA SEGS: %zu", media_segments.size());
     for (auto &sa : media_segments) {
@@ -106,7 +106,7 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
         media_segments.sort();
 
         ogs_debug("AVAILABLE SEGS: SORTED  %zu", media_segments.size());
-	for (auto &seg : media_segments) {
+        for (auto &seg : media_segments) {
             std::ostringstream oss;
             oss << seg;
             ogs_debug("    %s", oss.str().c_str());
@@ -130,11 +130,11 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
         }
         removeExtraPullObjectsEntry(first_media_segment);
 
-	try {
+        try {
             if (first_media_segment.segmentURL() == manifest_url) m_refreshMpd = true;
         } catch (std::domain_error &err) {
             ogs_error("Invalid Segment URL: %s", err.what());
-	    throw;
+            throw;
         }
         auto it = media_segments.begin();
         // Iterate from second element to find ones with the same availabilityStartTime() as the first and add them to result.
@@ -142,7 +142,7 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
             if (it->availabilityStartTime() != fetch_time) break;
             segment_url = it->segmentURL();
             existing_obj = object_store.findMetadataByURL(segment_url);
-	    removeExtraPullObjectsEntry(*it);
+            removeExtraPullObjectsEntry(*it);
             if (existing_obj) {
                 ingest_items.emplace_back(*existing_obj, it->availabilityEndTime());
             } else {

--- a/src/mbstf/DASHManifestHandler.hh
+++ b/src/mbstf/DASHManifestHandler.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_DASH_MANIFEST_HANDLER_HH_
 #define _MBS_TF_DASH_MANIFEST_HANDLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: DASH Manifest Handler class
+ * 5G-MAG Reference Tools: MBS Transport Function: DASH Manifest Handler class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/DASHManifestHandler.hh
+++ b/src/mbstf/DASHManifestHandler.hh
@@ -28,7 +28,7 @@ MBSTF_NAMESPACE_START
 class DASHManifestHandler : public ManifestHandler {
 public:
     DASHManifestHandler() = delete;
-    DASHManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution);
+    DASHManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller, bool pull_distribution);
     DASHManifestHandler(const DASHManifestHandler &) = delete;
     DASHManifestHandler(DASHManifestHandler &&) = delete;
 
@@ -39,22 +39,21 @@ public:
 
     virtual std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> nextIngestItems();
     virtual ManifestHandler::durn_type getDefaultDeadline();
-    virtual bool update(const ObjectStore::Object &new_manifest);
+    virtual bool update(const std::shared_ptr<ObjectStore::Object> &new_manifest);
     virtual std::string nextObjectId();
     static unsigned int factoryPriority() { return 100; };
 
 private:
-  std::string generateUUID();
-  void addMPDRefreshToExtraPullObjects();
-  void removeExtraPullObjectsEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &segment);
+    std::string generateUUID();
+    void addMPDRefreshToExtraPullObjects();
+    void removeExtraPullObjectsEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &segment);
 
-  std::recursive_mutex m_mpdMutex;
-  LIBMPDPP_NAMESPACE_CLASS(MPD)  m_mpd;
-  const ObjectStore::Object *m_manifest;
-  bool m_refreshMpd;
-  ManifestHandler::time_type m_mpdReceivedTime;
-  std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> m_extraPullObjects;
-
+    std::recursive_mutex m_mpdMutex;
+    LIBMPDPP_NAMESPACE_CLASS(MPD)  m_mpd;
+    std::shared_ptr<ObjectStore::Object> m_manifest;
+    bool m_refreshMpd;
+    ManifestHandler::time_type m_mpdReceivedTime;
+    std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> m_extraPullObjects;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -302,7 +302,7 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                                             } else if (method == OGS_SBI_HTTP_METHOD_PATCH) {
                                                 dist_session->_apiSubscriptionPatch(*dist_sess_subsc, stream, message, request, api, app_meta);
                                             } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
-                                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, /*OGS_SBI_HTTP_METHOD_PATCH ", " OGS_SBI_HTTP_METHOD_DELETE ", " */ OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
+                                                std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, OGS_SBI_HTTP_METHOD_PATCH ", " OGS_SBI_HTTP_METHOD_DELETE ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
                                                 NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
                                                 ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
                                             } else {
@@ -358,13 +358,13 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                                 } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
                                     std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(
                                                     std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0,
-                                                    OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
+                                                    OGS_SBI_HTTP_METHOD_GET ", " OGS_SBI_HTTP_METHOD_PATCH ", " OGS_SBI_HTTP_METHOD_DELETE ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
                                     NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
                                     ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
                                 } else {
                                     std::ostringstream err;
                                     err << "Distribution Session [" << ptr_resource1 << "], method [" << method
-                                        << "] is not allowed for a Distribution Session"; 
+                                        << "] is not allowed for a Distribution Session";
                                     ogs_error("%s", err.str().c_str());
                                     ogs_assert(true == NfServer::sendError(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED,
                                                                         2, message, app_meta, api, std::nullopt, err.str()));
@@ -378,7 +378,7 @@ bool DistributionSession::processEvent(Open5GSEvent &event)
                                 DistributionSession::_apiSessionCreate(stream, message, request, api, app_meta);
                             } else if (method == OGS_SBI_HTTP_METHOD_OPTIONS) {
                                 std::shared_ptr<Open5GSSBIResponse> response(NfServer::newResponse(
-                                                    std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0, 
+                                                    std::nullopt, std::nullopt, std::nullopt, std::nullopt, 0,
                                                     OGS_SBI_HTTP_METHOD_POST ", " OGS_SBI_HTTP_METHOD_OPTIONS, api, app_meta));
                                 NfServer::populateResponse(response, "", OGS_SBI_HTTP_STATUS_NO_CONTENT);
                                 ogs_assert(true == Open5GSSBIServer::sendResponse(stream, *response));
@@ -1003,6 +1003,13 @@ void DistributionSession::_apiSessionCreate(Open5GSSBIStream &stream, Open5GSSBI
     std::shared_ptr<DistributionSession> distributionSession;
     try {
         distributionSession.reset(new DistributionSession(distSession, true));
+
+        /* check this isn't a duplicate */
+        const auto &existing = App::self().context()->findDistributionSession(distributionSession->distributionSessionId());
+        if (existing) {
+            throw ModelException("MBSTF Distribution Session already exists", "DistributionSession", "distSessionId", ProblemCause::MANDATORY_IE_INCORRECT);
+        }
+
         /* If a subscription came with the create request, add the subscription */
         const auto &dist_session = distributionSession->distributionSessionReqData()->getDistSession();
         const auto &opt_subsc = dist_session->getDistSessionSubscription();
@@ -1038,6 +1045,7 @@ void DistributionSession::_apiSessionCreate(Open5GSSBIStream &stream, Open5GSSBI
     } catch (ModelException &err) {
         send_model_error(err, stream, 1, message, app_meta, api, "Bad Request",
                             "Error while populating MBSTF Distribution Session");
+        return;
     } catch (std::exception &err) {
         ogs_error("Error while populating MBSTF Distribution Session: %s", err.what());
         char *error = ogs_msprintf("Invalid ObjDistributionData parameters [%s]", err.what());
@@ -1345,7 +1353,7 @@ static void send_model_params_error(const ModelParamsException &err, Open5GSSBIS
     }
 
     const std::string &error = error_oss.str();
-    
+
     if (err.cause) {
         auto cause = err.cause.value();
         oss << cause.reason() << ": " << error;

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -728,12 +728,20 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     }
 
     /* Make sure we are in the right state */
-    auto new_state = new_dist_session->getDistSessionState()->getValue();
-    if (new_state == DistSessionState::VAL_INACTIVE || new_state == DistSessionState::VAL_DEACTIVATING) {
+    const auto &old_state = old_dist_session->getDistSessionState();
+    const auto &new_state = new_dist_session->getDistSessionState();
+    auto new_state_enum = new_state->getValue();
+    if (new_state_enum == DistSessionState::VAL_INACTIVE || new_state_enum == DistSessionState::VAL_DEACTIVATING) {
         /* If you request deactivating or inactive, make sure no more files are packaged */
         m_controller->flushPackagerQueue();
     }
-    _transitionTo(new_state);
+    try {
+        _transitionTo(new_state_enum);
+    } catch (std::runtime_error &exc) {
+        // bad state transition
+        ex.addInvalidParameter("distSession.distSessionState", exc.what());
+        throw ex;
+    }
 
     /* Update the last-used and hash values to reflect the new CreateReqData */
     _setLastUsed();
@@ -826,7 +834,7 @@ void DistributionSession::_inactiveState(const DistributionSession::Action &acti
                 _changeState(&DistributionSession::_establishedState);
                 break;
             case DistSessionState::VAL_DEACTIVATING:
-                throw std::runtime_error("Invalid state transition in DistSession");
+                throw std::runtime_error("Invalid state transition from INACTIVE to DEACTIVATING in DistSession");
             default:
                 throw std::runtime_error("Request for unhandled state in DistSession");
             }
@@ -861,7 +869,7 @@ void DistributionSession::_establishedState(const DistributionSession::Action &a
                 _changeState(&DistributionSession::_activeState);
                 break;
             case DistSessionState::VAL_DEACTIVATING:
-                throw std::runtime_error("Invalid state transition in DistSession");
+                throw std::runtime_error("Invalid state transition from ESTABLISHED to DEACTIVATING in DistSession");
             default:
                 throw std::runtime_error("Request for unhandled state in DistSession");
             }
@@ -891,7 +899,7 @@ void DistributionSession::_activeState(const DistributionSession::Action &action
                 _changeState(&DistributionSession::_deactivatingState);
                 break;
             case DistSessionState::VAL_ESTABLISHED:
-                throw std::runtime_error("Invalid state transition in DistSession");
+                throw std::runtime_error("Invalid state transition from ACTIVE to ESTABLISHED in DistSession");
             case DistSessionState::VAL_ACTIVE:
                 break;
             default:

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -54,6 +54,7 @@
 #include "Open5GSTimer.hh"
 #include "Open5GSYamlDocument.hh"
 #include "Open5GSNetworkFunction.hh"
+#include "SsmPort.hh"
 #include "openapi/model/CreateReqData.h"
 #include "openapi/model/CreateRspData.h"
 #include "openapi/model/DistSession.h"
@@ -82,12 +83,13 @@ using reftools::mbstf::DistSessionEventReportList;
 using reftools::mbstf::DistSessionSubscription;
 using reftools::mbstf::IpAddr;
 using reftools::mbstf::ObjDistributionData;
-using reftools::mbstf::UpTrafficFlowInfo;
 using reftools::mbstf::ObjAcquisitionMethod;
 using reftools::mbstf::ObjDistributionOperatingMode;
+using reftools::mbstf::PktDistributionOperatingMode;
 using reftools::mbstf::StatusSubscribeReqData;
 using reftools::mbstf::StatusSubscribeRspData;
 using reftools::mbstf::TunnelAddress;
+using reftools::mbstf::UpTrafficFlowInfo;
 
 MBSTF_NAMESPACE_START
 
@@ -104,6 +106,7 @@ static void send_model_params_error(const ModelParamsException &err, Open5GSSBIS
                                     Open5GSSBIMessage &message, const NfServer::AppMetadata &app_meta,
                                     const std::optional<NfServer::InterfaceMetadata> &api, const std::string &no_cause_reason,
                                     const std::string &log_prefix);
+static void _validate(const std::shared_ptr<DistSession> &dist_session);
 
 /**** public: ****/
 
@@ -122,12 +125,13 @@ DistributionSession::DistributionSession(CJson &json, bool as_request)
     ,m_subscriptionLocation()
 {
 
-    std::shared_ptr<DistSession> distSession = m_createReqData->getDistSession();
+    std::shared_ptr<DistSession> dist_session = m_createReqData->getDistSession();
 
+    _validate(dist_session);
     _setLastUsed();
     m_generated = m_lastUsed;
     _setHash();
-    m_distributionSessionId = distSession->getDistSessionId();
+    m_distributionSessionId = dist_session->getDistSessionId();
     _changeState(&DistributionSession::_constructedState);
 }
 
@@ -471,21 +475,28 @@ const ObjDistributionData::ObjAcquisitionIdsPullType &DistributionSession::getOb
     }
 }
 
-const std::optional<std::string> &DistributionSession::getDestIpAddr() const
+const SsmPort DistributionSession::getSsmPort() const
 {
-    std::shared_ptr<CreateReqData> create_req_data = distributionSessionReqData();
-    std::shared_ptr<DistSession> dist_session = create_req_data->getDistSession();
-    const std::optional<std::shared_ptr< UpTrafficFlowInfo > > &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
-    if (up_traffic_flow_info.has_value()) {
-        std::shared_ptr<UpTrafficFlowInfo> up_traffic_flow = up_traffic_flow_info.value();
-        const std::shared_ptr<IpAddr> ipAddr = up_traffic_flow->getDestIpAddr();
-        if (ipAddr) {
-            return ipAddr->getIpv4Addr();
-        }
-    }
+    const auto &create_req_data = distributionSessionReqData();
+    if (!create_req_data) return SsmPort();
+    const auto &dist_session = create_req_data->getDistSession();
+    if (!dist_session) return SsmPort();
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (!up_traffic_flow_info || !up_traffic_flow_info.value()) return SsmPort();
+    return SsmPort(up_traffic_flow_info.value());
+}
 
-    static const std::optional<std::string> empty = std::nullopt;
-    return empty;
+uint64_t DistributionSession::getTSI() const
+{
+    const auto &create_req_data = distributionSessionReqData();
+    if (!create_req_data) return 0;
+    const auto &dist_session = create_req_data->getDistSession();
+    if (!dist_session) return 0;
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (!up_traffic_flow_info || !up_traffic_flow_info.value()) return 0;
+    const auto &tsi = up_traffic_flow_info.value()->getTransportSessionId();
+    if (!tsi) return 0;
+    return static_cast<uint32_t>(tsi.value());
 }
 
 const std::optional<std::string> &DistributionSession::getTunnelAddr() const
@@ -499,19 +510,6 @@ const std::optional<std::string> &DistributionSession::getTunnelAddr() const
 
     static const std::optional<std::string> empty = std::nullopt;
     return empty;
-}
-
-in_port_t DistributionSession::getPortNumber() const
-{
-    in_port_t port_number = 0;
-    std::shared_ptr<CreateReqData> create_req_data = distributionSessionReqData();
-    std::shared_ptr<DistSession> dist_session = create_req_data->getDistSession();
-    std::optional<std::shared_ptr<UpTrafficFlowInfo> > up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
-    if (up_traffic_flow_info.has_value()) {
-        std::shared_ptr<UpTrafficFlowInfo> up_traffic_flow = up_traffic_flow_info.value();
-        port_number = static_cast<in_port_t>(up_traffic_flow->getPortNumber());
-    }
-    return port_number;
 }
 
 in_port_t DistributionSession::getTunnelPortNumber() const
@@ -1365,6 +1363,70 @@ static void send_model_params_error(const ModelParamsException &err, Open5GSSBIS
                                                error));
     }
     ogs_error("%s: %s", log_prefix.c_str(), oss.str().c_str());
+}
+
+static void _validate(const std::shared_ptr<DistSession> &dist_session)
+{
+    /* check for DistSession irregularities that are not caught by the OpenAPI model classes */
+
+    if (!dist_session) {
+        throw ModelException("No distSession in CreateReqData", "DistributionSession", "distSession",
+                             ProblemCause::MANDATORY_IE_MISSING);
+    }
+
+    const auto &obj_distr_data = dist_session->getObjDistributionData();
+    const auto &pkt_distr_data = dist_session->getPktDistributionData();
+    if ((!obj_distr_data && !pkt_distr_data) || (obj_distr_data && pkt_distr_data)) {
+        throw ModelException("DistSession must have one of pktDistributionData or objDistributionData", "DistributionSession",
+                             "distSession", ProblemCause::MANDATORY_IE_MISSING);
+    }
+
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (obj_distr_data) {
+        if (!up_traffic_flow_info) {
+            throw ModelException("upTrafficFlowInfo must be present if objDistributionData is present", "DistributionSession",
+                                 "distSession.upTrafficFlowInfo", ProblemCause::MANDATORY_IE_MISSING);
+        } else {
+            const auto &src_ip = up_traffic_flow_info.value()->getSrcIpAddr();
+            if (!src_ip) {
+                throw ModelException("upTrafficFlowInfo.srcIpAddr must be present if objDistributionData is present",
+                                     "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                     ProblemCause::MANDATORY_IE_MISSING);
+            }
+            const auto &tsi = up_traffic_flow_info.value()->getTransportSessionId();
+            if (!tsi) {
+                throw ModelException("upTrafficFlowInfo.transportSessionId must be present if objDistributionData is present",
+                                     "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                     ProblemCause::MANDATORY_IE_MISSING);
+            }
+        }
+    } else {
+        const auto &pkt_distr_mode = pkt_distr_data.value()->getPktDistributionOperatingMode();
+        if (up_traffic_flow_info) {
+            const auto &src_ip = up_traffic_flow_info.value()->getSrcIpAddr();
+            if (*pkt_distr_mode == PktDistributionOperatingMode::VAL_PACKET_FORWARD_ONLY) {
+                if (src_ip) {
+                    throw ModelException("upTrafficFlowInfo cannot contain srcIpAddr if pktDistributionData is present and "
+                                         "pktDistributionData.pktDistributionOperatingMode is PACKET_FORWARD_ONLY",
+                                         "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                         ProblemCause::OPTIONAL_IE_INCORRECT);
+                }
+            } else {
+                if (!src_ip) {
+                      throw ModelException("upTrafficFlowInfo.srcIpAddr must be present if "
+                                           "pktDistributionData.pktDistributionOperatingMode is not PACKET_FORWARD_ONLY",
+                                           "DistributionSession", "distSession.upTrafficFlowInfo.srcIpAddr",
+                                           ProblemCause::MANDATORY_IE_MISSING);
+                }
+            }
+        } else {
+            if (*pkt_distr_mode == PktDistributionOperatingMode::VAL_PACKET_PROXY) {
+                throw ModelException("upTrafficFlowInfo must be present if pktDistributionData is present and "
+                                     "pktDistributionData.pktDistributionOperatingMode is PACKET_PROXY", "DistributionSession",
+                                     "distSession.upTrafficFlowInfo", ProblemCause::MANDATORY_IE_MISSING);
+            }
+        }
+    }
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session class
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session class
  ******************************************************************************
- * Copyright: (C)2024 British Broadcasting Corporation
+ * Copyright: (C)2024-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * Licensed under the License terms and conditions for use, reproduction, and
@@ -43,6 +44,7 @@
 #include "ModelParamsException.hh"
 #include "NfServer.hh"
 #include "ObjectIngester.hh"
+#include "ObjectPackager.hh"
 #include "Open5GSEvent.hh"
 #include "Open5GSSBIMessage.hh"
 #include "Open5GSSBIRequest.hh"
@@ -174,6 +176,9 @@ void DistributionSession::processEvent(Event &event, SubscriptionService &event_
     if (event.eventName() == ObjectIngester::IngestFailedEvent::event_name) {
         //ObjectIngester::IngestFailedEvent &ingest_failed_event = dynamic_cast<ObjectIngester::IngestFailedEvent&>(event);
         _registerEvent(DistributionSessionEvents::DATA_INGEST_FAILURE);
+    } else if (event.eventName() == ObjectPackager::PackagingFailedEvent::event_name) {
+        //ObjectPackager::PackagingFailedEvent &packaging_failed_event = dynamic_cast<ObjectPackager::PackagingFailedEvent&>(event);
+        _registerEvent(DistributionSessionEvents::SERVICE_MANAGEMENT_FAILURE);
     }
 }
 
@@ -1047,7 +1052,7 @@ void DistributionSession::_apiSessionCreate(Open5GSSBIStream &stream, Open5GSSBI
     App::self().context()->addDistributionSession(distributionSession);
 
     // Subscribe to Events from the Controller - to be forwarded to DistributionSessionSubscriptions
-    distributionSession->subscribeTo({ObjectIngester::IngestFailedEvent::event_name}, *distributionSession->m_controller);
+    distributionSession->subscribeTo({ObjectIngester::IngestFailedEvent::event_name, ObjectPackager::PackagingFailedEvent::event_name}, *distributionSession->m_controller);
     distributionSession->_sendSubscriptionNotifications();
 
     CJson create_rsp_data_json(distributionSession->json(false, true));

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -101,7 +101,7 @@ public:
     const DistributionSessionSubscription &getSubscription(const std::string &subscription_id) const;
     void updateSubscription(const std::string &subscription_id, fiveg_mag_reftools::CJson &json, bool as_request=true);
     void removeSubscription(const std::string &subscription_id);
-    
+
     const DistributionSessionEvents &eventTimestamps() const { return m_eventTimestamps; };
 
     void haveEmptyQueue();

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_DISTRIBUTION_SESSION_HH_
 #define _MBS_TF_DISTRIBUTION_SESSION_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session class
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session class
  ******************************************************************************
  * Copyright: (C)2024-2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -51,6 +51,7 @@ class Open5GSSBIStream;
 class Open5GSSBIMessage;
 class Open5GSSBIRequest;
 class Controller;
+class SsmPort;
 
 class DistributionSession : public std::enable_shared_from_this<DistributionSession>, public Subscriber {
 public:
@@ -83,9 +84,9 @@ public:
     DistributionSession &setState(const reftools::mbstf::DistSessionState &state);
     const reftools::mbstf::ObjDistributionData::ObjAcquisitionIdsPullType &getObjectAcquisitionPullUrls() const;
     const std::string &getObjectDistributionOperatingMode() const;
-    const std::optional<std::string> &getDestIpAddr() const;
+    const SsmPort getSsmPort() const;
+    uint64_t getTSI() const;
     const std::optional<std::string> &getTunnelAddr() const;
-    in_port_t getPortNumber() const;
     in_port_t getTunnelPortNumber() const;
     uint32_t getRateLimit() const;
     std::optional<BitRate> getMbr() const;

--- a/src/mbstf/DistributionSessionEvents.cc
+++ b/src/mbstf/DistributionSessionEvents.cc
@@ -58,7 +58,7 @@ DistributionSessionEvents::DistributionSessionEvents(DistributionSessionEvents &
     ,dataIngestSessionTerminated(std::move(other.dataIngestSessionTerminated))
 {
 }
-    
+
 DistributionSessionEvents::~DistributionSessionEvents()
 {
 }

--- a/src/mbstf/DistributionSessionEvents.cc
+++ b/src/mbstf/DistributionSessionEvents.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Events
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session Events
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/DistributionSessionEvents.hh
+++ b/src/mbstf/DistributionSessionEvents.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_DISTRIBUTION_SESSION_EVENTS_HH_
 #define _MBS_TF_DISTRIBUTION_SESSION_EVENTS_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Event Timestamps class
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session Event Timestamps class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/DistributionSessionEvents.hh
+++ b/src/mbstf/DistributionSessionEvents.hh
@@ -52,7 +52,7 @@ public:
     DistributionSessionEvents();
     DistributionSessionEvents(const DistributionSessionEvents &other);
     DistributionSessionEvents(DistributionSessionEvents &&other);
-    
+
     virtual ~DistributionSessionEvents();
 
     /* operators */

--- a/src/mbstf/DistributionSessionNotificationEvent.cc
+++ b/src/mbstf/DistributionSessionNotificationEvent.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Notification Event
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session Notification Event
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/DistributionSessionNotificationEvent.hh
+++ b/src/mbstf/DistributionSessionNotificationEvent.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_DISTRIBUTION_SESSION_NOTIFICATION_EVENT_HH_
 #define _MBS_TF_DISTRIBUTION_SESSION_NOTIFICATION_EVENT_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Notification Event
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session Notification Event
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/DistributionSessionSubscription.cc
+++ b/src/mbstf/DistributionSessionSubscription.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Subscription class
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session Subscription class
  ******************************************************************************
  * Copyright: (C)2024-2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/DistributionSessionSubscription.hh
+++ b/src/mbstf/DistributionSessionSubscription.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_DISTRIBUTION_SESSION_SUBSCRIPTION_HH_
 #define _MBS_TF_DISTRIBUTION_SESSION_SUBSCRIPTION_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Distribution Session Subscription class
+ * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session Subscription class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/DistributionSessionSubscription.hh
+++ b/src/mbstf/DistributionSessionSubscription.hh
@@ -98,7 +98,7 @@ private:
     void _setSubscriptionId();
 
     std::weak_ptr<DistributionSession> m_distributionSession; /* Parent distribution session */
-    
+
     std::string m_subscriptionId;
     int m_eventTypes; /* ORed EventTypeBitMask */
     reftools::mbstf::DistSessionSubscription m_distSessionSubscription;

--- a/src/mbstf/Event.cc
+++ b/src/mbstf/Event.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Subscription Event base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Subscription Event base class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Event.hh
+++ b/src/mbstf/Event.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_EVENT_HH_
 #define _MBS_TF_EVENT_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Subscription Event base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Subscription Event base class
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/EventHandler.hh
+++ b/src/mbstf/EventHandler.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_EVENT_HANDLER_HH_
 #define _MBS_TF_EVENT_HANDLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS Event Handler abstract
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS Event Handler abstract
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/LocalEvents.hh
+++ b/src/mbstf/LocalEvents.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_LOCAL_EVENTS_HH_
 #define _MBS_TF_LOCAL_EVENTS_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Local Events
+ * 5G-MAG Reference Tools: MBS Transport Function: Local Events
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/MBSTFEventHandler.cc
+++ b/src/mbstf/MBSTFEventHandler.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: MBSTF Open5GS Event Handler
+ * 5G-MAG Reference Tools: MBS Transport Function: MBSTF Open5GS Event Handler
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/MBSTFEventHandler.hh
+++ b/src/mbstf/MBSTFEventHandler.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_MBSTF_EVENT_HANDLER_HH_
 #define _MBS_TF_MBSTF_EVENT_HANDLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: MBSTF Open5GS Event Handler
+ * 5G-MAG Reference Tools: MBS Transport Function: MBSTF Open5GS Event Handler
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/MBSTFNetworkFunction.hh
+++ b/src/mbstf/MBSTFNetworkFunction.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_MBSTF_NETWORK_FUNCTION_HH_
 #define _MBS_TF_MBSTF_NETWORK_FUNCTION_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: MBSTF Network Function class
+ * 5G-MAG Reference Tools: MBS Transport Function: MBSTF Network Function class
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/ManifestHandler.hh
+++ b/src/mbstf/ManifestHandler.hh
@@ -61,7 +61,7 @@ public:
 
     virtual std::pair<time_type, ingest_list> nextIngestItems() = 0;
     virtual durn_type getDefaultDeadline() = 0;
-    virtual bool update(const ObjectStore::Object &new_manifest) = 0;
+    virtual bool update(const std::shared_ptr<ObjectStore::Object> &new_manifest) = 0;
     virtual void startedFetch(const PullObjectIngester::IngestItem &item) {};
 
 protected:

--- a/src/mbstf/ManifestHandler.hh
+++ b/src/mbstf/ManifestHandler.hh
@@ -1,9 +1,9 @@
 #ifndef _MBS_TF_MANIFEST_HANDLER_HH_
 #define _MBS_TF_MANIFEST_HANDLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Manifest Handler Factory
+ * 5G-MAG Reference Tools: MBS Transport Function: Manifest Handler Factory
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
@@ -22,7 +22,7 @@ MBSTF_NAMESPACE_START
 
 class ObjectController;
 
-class ManifestHandler {
+class ManifestHandler : public SubscriptionService {
 public:
     using time_type = std::chrono::system_clock::time_point;
     using durn_type = std::chrono::system_clock::duration;
@@ -30,25 +30,30 @@ public:
 
     ManifestHandler() = delete;
     ManifestHandler(ObjectController *controller, bool pull_distribution)
-        :m_controller(controller)
+        :SubscriptionService()
+        ,m_controller(controller)
         ,m_pullDistribution(pull_distribution)
     {};
     ManifestHandler(const ManifestHandler &other)
-        :m_controller(other.m_controller)
+        :SubscriptionService()
+        ,m_controller(other.m_controller)
         ,m_pullDistribution(other.m_pullDistribution)
     {};
     ManifestHandler(ManifestHandler &&other)
-        :m_controller(other.m_controller)
+        :SubscriptionService()
+        ,m_controller(other.m_controller)
         ,m_pullDistribution(other.m_pullDistribution)
     {};
     virtual ~ManifestHandler() {};
     ManifestHandler &operator=(const ManifestHandler &other) {
+        SubscriptionService::operator=(other);
         m_controller = other.m_controller;
         m_pullDistribution = other.m_pullDistribution;
         return *this;
     };
 
     ManifestHandler &operator=(ManifestHandler &&other) {
+        SubscriptionService::operator=(std::move(other));
         m_controller = other.m_controller;
         m_pullDistribution = other.m_pullDistribution;
         return *this;
@@ -57,6 +62,7 @@ public:
     virtual std::pair<time_type, ingest_list> nextIngestItems() = 0;
     virtual durn_type getDefaultDeadline() = 0;
     virtual bool update(const ObjectStore::Object &new_manifest) = 0;
+    virtual void startedFetch(const PullObjectIngester::IngestItem &item) {};
 
 protected:
    ObjectController *m_controller;

--- a/src/mbstf/ManifestHandlerFactory.cc
+++ b/src/mbstf/ManifestHandlerFactory.cc
@@ -49,9 +49,9 @@ bool ManifestHandlerFactory::registerManifestHandler(const std::string &content_
     return true;
 }
 
-ManifestHandler *ManifestHandlerFactory::makeManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution)
+ManifestHandler *ManifestHandlerFactory::makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller, bool pull_distribution)
 {
-    std::string media_type = object.second.mediaType();
+    std::string media_type = object->second.mediaType();
     ogs_debug("Looking for manifest handler for \"%s\" media", media_type.c_str());
     // Try manifest handlers for the media type of the object, fallback to any media type (empty string)
     while (true) {

--- a/src/mbstf/ManifestHandlerFactory.cc
+++ b/src/mbstf/ManifestHandlerFactory.cc
@@ -1,7 +1,7 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Manifest Handler Factory
+ * 5G-MAG Reference Tools: MBS Transport Function: Manifest Handler Factory
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
@@ -52,11 +52,13 @@ bool ManifestHandlerFactory::registerManifestHandler(const std::string &content_
 ManifestHandler *ManifestHandlerFactory::makeManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution)
 {
     std::string media_type = object.second.mediaType();
+    ogs_debug("Looking for manifest handler for \"%s\" media", media_type.c_str());
     // Try manifest handlers for the media type of the object, fallback to any media type (empty string)
     while (true) {
         auto it = constructorsByContentType().find(media_type);
         if (it != constructorsByContentType().end()) {
             std::list<std::unique_ptr<ManifestHandlerConstructor> > &list = it->second;
+            ogs_debug("Trying %zi manifest handlers", list.size());
             for (const auto &mhc : list) {
                 try {
                     return mhc->makeManifestHandler(object, controller, pull_distribution);

--- a/src/mbstf/ManifestHandlerFactory.hh
+++ b/src/mbstf/ManifestHandlerFactory.hh
@@ -23,7 +23,7 @@ class ObjectController;
 class ManifestHandlerConstructor {
 public:
     virtual unsigned int priority() = 0;
-    virtual ManifestHandler *makeManifestHandler(const ObjectStore::Object &object, ObjectController *controller,
+    virtual ManifestHandler *makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller,
                                                  bool pull_distribution) = 0;
 };
 
@@ -33,7 +33,7 @@ public:
     using manifest_handler = H;
 
     virtual unsigned int priority() { return manifest_handler::factoryPriority(); };
-    virtual ManifestHandler *makeManifestHandler(const ObjectStore::Object &object, ObjectController *controller,
+    virtual ManifestHandler *makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller,
                                                  bool pull_distribution) {
         return new manifest_handler(object, controller, pull_distribution);
     }
@@ -42,7 +42,7 @@ public:
 class ManifestHandlerFactory {
 public:
     static bool registerManifestHandler(const std::string &content_type, ManifestHandlerConstructor *manifest_handler_constructor);
-    static ManifestHandler *makeManifestHandler(const ObjectStore::Object &object, ObjectController *controller,
+    static ManifestHandler *makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller,
                                                 bool pull_distribution);
 };
 

--- a/src/mbstf/ManifestHandlerFactory.hh
+++ b/src/mbstf/ManifestHandlerFactory.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_MANIFEST_HANDLER_FACTORY_HH_
 #define _MBS_TF_MANIFEST_HANDLER_FACTORY_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Manifest Handler Factory
+ * 5G-MAG Reference Tools: MBS Transport Function: Manifest Handler Factory
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/ModelParamsException.hh
+++ b/src/mbstf/ModelParamsException.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_MODEL_PARAMS_EXCEPTION_HH_
 #define _MBS_TF_MODEL_PARAMS_EXCEPTION_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Model Exception with Invalid Params
+ * 5G-MAG Reference Tools: MBS Transport Function: Model Exception with Invalid Params
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/NfServer.cc
+++ b/src/mbstf/NfServer.cc
@@ -145,8 +145,8 @@ bool NfServer::__sendError(Open5GSSBIStream &stream, int status, const std::opti
         cJSON *copy_impl(copy.exportCJSON());
         problem_details = OpenAPI_problem_details_parseFromJSON(copy_impl);
         problem->invalid_params = problem_details->invalid_params;
-	problem_details->invalid_params = NULL;
-	OpenAPI_problem_details_free(problem_details);
+        problem_details->invalid_params = NULL;
+        OpenAPI_problem_details_free(problem_details);
         cJSON_Delete(copy_impl);
     }
 
@@ -155,7 +155,7 @@ bool NfServer::__sendError(Open5GSSBIStream &stream, int status, const std::opti
     }
 
     if (message) {
-	if (problem_type) {
+        if (problem_type) {
             problem->type = ogs_strdup(problem_type.value().c_str());
             ogs_expect(problem->type);
         }

--- a/src/mbstf/NfServer.cc
+++ b/src/mbstf/NfServer.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Network Function Server
+ * 5G-MAG Reference Tools: MBS Transport Function: Network Function Server
  ******************************************************************************
  * Copyright: (C) 2024 British Broadcasting Corporation
  * Author: David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -35,6 +35,7 @@
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
@@ -72,13 +73,12 @@ ObjectCarouselController::~ObjectCarouselController()
 
 void ObjectCarouselController::setObjectPackager()
 {
-    const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+    auto ssm_port = distributionSession().getSsmPort();
     const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
-    packager(new ObjectCarouselPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    packager(new ObjectCarouselPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     auto pkgr = getObjectCarouselPackager();
     subscribeToService(*pkgr);
     startWorker();
@@ -172,14 +172,13 @@ void ObjectCarouselController::reconfigureObjectPackager()
     if (distributionSession().getState() == DistSessionState::VAL_ACTIVE) {
         auto packager = getObjectCarouselPackager();
         if (packager) {
-            const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+            auto ssm_port = distributionSession().getSsmPort();
             const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
             uint32_t rate_limit = distributionSession().getRateLimit();
-            in_port_t port = distributionSession().getPortNumber();
             in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
 
-            if (dest_ip_addr) {
-                packager->updateFluteInfo(dest_ip_addr.value(), port, rate_limit, tunnel_addr, tunnel_port);
+            if (ssm_port) {
+                packager->updateFluteInfo(ssm_port, rate_limit, tunnel_addr, tunnel_port);
             }
         }
     }

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -39,11 +39,14 @@
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
 #include "openapi/model/Object.h"
+#include "openapi/model/ProblemCause.hh"
 
 #include "ObjectCarouselController.hh"
 
 using reftools::mbstf::DistSessionState;
 using reftools::mbstf::Object;
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
 
 MBSTF_NAMESPACE_START
 
@@ -111,36 +114,39 @@ void ObjectCarouselController::processEvent(Event &event, SubscriptionService &e
         ObjectStore::ObjectChangedEvent &obj_added_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
         std::string object_id = obj_added_event.objectId();
         ogs_debug("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
-        const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
-        ogs_debug("Object location: %s", object->second.getFetchedUrl().c_str());
-        object->second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
-	if(check_if_object_added_is_manifest(object, getManifestUrl())) {
-	    if(manifestHandler()) {
-	        try {
-	            if(!manifestHandler()->update(object)) {
-		        ogs_error("Failed to update Manifest");
-			unsetObjectListPackager();
-			event.stopProcessing();
-			return;
-		    }
-		    startWorker();
-	        } catch (std::exception &ex) {
-                    ogs_error("Invalid Manifest update: %s", ex.what());
-		    unsetObjectListPackager();
-		    event.stopProcessing();
-		    return;
+        try {
+            const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
+            ogs_debug("Object location: %s", object->second.getFetchedUrl().c_str());
+            object->second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
+            if (check_if_object_added_is_manifest(object, getManifestUrl())) {
+                if (manifestHandler()) {
+                    try {
+                        if (!manifestHandler()->update(object)) {
+                            ogs_error("Failed to update Manifest");
+                            unsetObjectListPackager();
+                            event.stopProcessing();
+                            return;
+                        }
+                        startWorker();
+                    } catch (std::exception &ex) {
+                        ogs_error("Invalid Manifest update: %s", ex.what());
+                        unsetObjectListPackager();
+                        event.stopProcessing();
+                        return;
+                    }
+                } else {
+                    std::shared_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
+                    if (!manifest_handler) {
+                        throw std::runtime_error("Could not find suitable manifest handler");
+                    }
+                    manifestHandler(std::move(manifest_handler));
                 }
-
-	    } else {
-		std::shared_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
-                if (!manifest_handler) {
-                    throw std::runtime_error("Could not find suitable manifest handler");
-                }
-                manifestHandler(std::move(manifest_handler));
+            } else if (check_if_object_is_active_in_manifest(object, manifestHandler())) {
+                finish_request_in_manifest_handler(object, manifestHandler());
+                sendToPackager(object_id);
             }
-	} else if (check_if_object_is_active_in_manifest(object, manifestHandler())) {
-            finish_request_in_manifest_handler(object, manifestHandler());
-            sendToPackager(object_id);
+        } catch (std::out_of_range &ex) {
+            ogs_error("Object %s is not in the ObjectStore", object_id.c_str());
         }
     }
     ObjectManifestController::processEvent(event, event_service);
@@ -236,6 +242,7 @@ static void validate_distribution_session(DistributionSession &distribution_sess
     if (distribution_session.getObjectDistributionOperatingMode() != "CAROUSEL") {
         throw std::logic_error("Expected objDistributionOperatingMode to be set to CAROUSEL.");
     }
+    ObjectController::validateDistributionSession(distribution_session);
 }
 
 static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, std::string &manifest_url)

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -48,9 +48,9 @@ using reftools::mbstf::Object;
 MBSTF_NAMESPACE_START
 
 static void validate_distribution_session(DistributionSession &distribution_session);
-static bool check_if_object_added_is_manifest(const ObjectStore::Object &object, std::string &manifest_url);
-static bool check_if_object_is_active_in_manifest(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
-static void finish_request_in_manifest_handler(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
+static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, std::string &manifest_url);
+static bool check_if_object_is_active_in_manifest(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
+static void finish_request_in_manifest_handler(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
 
 ObjectCarouselController::ObjectCarouselController(DistributionSession &distribution_session)
     :ObjectManifestController(distribution_session)
@@ -105,13 +105,15 @@ std::shared_ptr<ObjectCarouselPackager> ObjectCarouselController::getObjectCarou
 
 void ObjectCarouselController::processEvent(Event &event, SubscriptionService &event_service)
 {
-    if (event.eventName() == "ObjectAdded") {
-        ObjectStore::ObjectAddedEvent &obj_added_event = dynamic_cast<ObjectStore::ObjectAddedEvent&>(event);
+    if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
+        event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
+
+        ObjectStore::ObjectChangedEvent &obj_added_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
         std::string object_id = obj_added_event.objectId();
-        ogs_info("Object added with ID: %s", object_id.c_str());
-        ObjectStore::Object &object = objectStore()[object_id];
-        ogs_info("Object arrived from: %s", object.second.getFetchedUrl().c_str());
-        object.second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
+        ogs_debug("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
+        const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
+        ogs_debug("Object location: %s", object->second.getFetchedUrl().c_str());
+        object->second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
 	if(check_if_object_added_is_manifest(object, getManifestUrl())) {
 	    if(manifestHandler()) {
 	        try {
@@ -236,21 +238,22 @@ static void validate_distribution_session(DistributionSession &distribution_sess
     }
 }
 
-static bool check_if_object_added_is_manifest(const ObjectStore::Object &object, std::string &manifest_url)
+static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, std::string &manifest_url)
 {
-    return (object.second.getOriginalUrl() == manifest_url || object.second.getFetchedUrl() == manifest_url);
+    auto &metadata = object->second;
+    return (metadata.getOriginalUrl() == manifest_url || metadata.getFetchedUrl() == manifest_url);
 }
 
-static bool check_if_object_is_active_in_manifest(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
+static bool check_if_object_is_active_in_manifest(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
 {
     const auto object_manifest_hndlr = std::dynamic_pointer_cast<const ObjectManifestHandler>(manifest_handler);
-    return object_manifest_hndlr->isObjectURLActive(object.second.getOriginalUrl());
+    return object_manifest_hndlr->isObjectURLActive(object->second.getOriginalUrl());
 }
 
-static void finish_request_in_manifest_handler(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
+static void finish_request_in_manifest_handler(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
 {
     auto object_manifest_hndlr = std::dynamic_pointer_cast<ObjectManifestHandler>(manifest_handler);
-    object_manifest_hndlr->finishRequest(object.second.getOriginalUrl());
+    object_manifest_hndlr->finishRequest(object->second.getOriginalUrl());
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -1,0 +1,259 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectCarouselController class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <exception>
+#include <iostream>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <netinet/in.h>
+
+#include <uuid/uuid.h>
+
+#include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
+
+#include "common.hh"
+#include "ControllerFactory.hh"
+#include "DistributionSession.hh"
+#include "Event.hh"
+#include "ManifestHandlerFactory.hh"
+#include "ObjectCarouselPackager.hh"
+#include "ObjectController.hh"
+#include "ObjectManifestHandler.hh"
+#include "ObjectStore.hh"
+#include "PullObjectIngester.hh"
+#include "PushObjectIngester.hh"
+#include "SubscriptionService.hh"
+#include "utilities.hh"
+#include "openapi/model/DistSessionState.h"
+#include "openapi/model/Object.h"
+
+#include "ObjectCarouselController.hh"
+
+using reftools::mbstf::DistSessionState;
+using reftools::mbstf::Object;
+
+MBSTF_NAMESPACE_START
+
+static void validate_distribution_session(DistributionSession &distribution_session);
+static bool check_if_object_added_is_manifest(const ObjectStore::Object &object, std::string &manifest_url);
+static bool check_if_object_is_active_in_manifest(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
+static void finish_request_in_manifest_handler(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
+
+ObjectCarouselController::ObjectCarouselController(DistributionSession &distribution_session)
+    :ObjectManifestController(distribution_session)
+{
+    ogs_debug("ObjectCarouselController validating DistributionSession");
+    validate_distribution_session(distribution_session);
+    ogs_debug("ObjectCarouselController subscribe to ObjectStore");
+    subscribeToService(objectStore());
+    ogs_debug("ObjectCarouselController active");
+}
+
+ObjectCarouselController::~ObjectCarouselController()
+{
+    abort();
+}
+
+void ObjectCarouselController::setObjectPackager()
+{
+    const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+    const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
+    uint32_t rate_limit = distributionSession().getRateLimit();
+    in_port_t port = distributionSession().getPortNumber();
+    in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
+    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    packager(new ObjectCarouselPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    auto pkgr = getObjectCarouselPackager();
+    subscribeToService(*pkgr);
+    startWorker();
+    updateCarousel();
+}
+
+void ObjectCarouselController::unsetObjectPackager()
+{
+    packager(nullptr);
+}
+
+void ObjectCarouselController::activateObjectPackager() {
+    packager()->activate();
+    startWorker();
+}
+
+void ObjectCarouselController::deactivateObjectPackager() {
+    if (packager()->deactivate()) {
+        distributionSession().haveEmptyQueue();
+    }
+}
+
+std::shared_ptr<ObjectCarouselPackager> ObjectCarouselController::getObjectCarouselPackager() const
+{
+    return std::dynamic_pointer_cast<ObjectCarouselPackager>(packager());
+}
+
+void ObjectCarouselController::processEvent(Event &event, SubscriptionService &event_service)
+{
+    if (event.eventName() == "ObjectAdded") {
+        ObjectStore::ObjectAddedEvent &obj_added_event = dynamic_cast<ObjectStore::ObjectAddedEvent&>(event);
+        std::string object_id = obj_added_event.objectId();
+        ogs_info("Object added with ID: %s", object_id.c_str());
+        ObjectStore::Object &object = objectStore()[object_id];
+        ogs_info("Object arrived from: %s", object.second.getFetchedUrl().c_str());
+        object.second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
+	if(check_if_object_added_is_manifest(object, getManifestUrl())) {
+	    if(manifestHandler()) {
+	        try {
+	            if(!manifestHandler()->update(object)) {
+		        ogs_error("Failed to update Manifest");
+			unsetObjectListPackager();
+			event.stopProcessing();
+			return;
+		    }
+		    startWorker();
+	        } catch (std::exception &ex) {
+                    ogs_error("Invalid Manifest update: %s", ex.what());
+		    unsetObjectListPackager();
+		    event.stopProcessing();
+		    return;
+                }
+
+	    } else {
+		std::shared_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
+                if (!manifest_handler) {
+                    throw std::runtime_error("Could not find suitable manifest handler");
+                }
+                manifestHandler(std::move(manifest_handler));
+            }
+	} else if (check_if_object_is_active_in_manifest(object, manifestHandler())) {
+            finish_request_in_manifest_handler(object, manifestHandler());
+            sendToPackager(object_id);
+        }
+    }
+    ObjectManifestController::processEvent(event, event_service);
+}
+
+void ObjectCarouselController::sendToPackager(const std::string &object_id)
+{
+    auto packager = getObjectCarouselPackager();
+    if (packager) {
+        auto manifest_manager = std::dynamic_pointer_cast<ObjectManifestHandler>(manifestHandler());
+        auto &object = objectStore()[object_id];
+        ObjectCarouselPackager::PackageItem item(object, manifest_manager);
+        packager->add(item);
+    }
+}
+
+const std::optional<std::string> &ObjectCarouselController::getObjectDistributionBaseUrl() const {
+    return distributionSession().objectDistributionBaseUrl();
+}
+
+void ObjectCarouselController::reconfigureObjectPackager()
+{
+    if (distributionSession().getState() == DistSessionState::VAL_ACTIVE) {
+        auto packager = getObjectCarouselPackager();
+        if (packager) {
+            const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+            const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
+            uint32_t rate_limit = distributionSession().getRateLimit();
+            in_port_t port = distributionSession().getPortNumber();
+            in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
+
+            if (dest_ip_addr) {
+                packager->updateFluteInfo(dest_ip_addr.value(), port, rate_limit, tunnel_addr, tunnel_port);
+            }
+        }
+    }
+}
+
+void ObjectCarouselController::updateCarousel()
+{
+    /* get the list of current carousel objects from manifest handler */
+    auto object_manifest_hndlr = std::dynamic_pointer_cast<const ObjectManifestHandler>(manifestHandler());
+    if (!object_manifest_hndlr) return;
+    const auto &manifest_objects = object_manifest_hndlr->getObjects();
+
+    /* get a local copy of the list of objects currently in the packager */
+    const auto &packager = getObjectCarouselPackager();
+    auto packager_items = packager->getPackageItems();
+
+    /* for each object from the manifest list */
+    for (const auto &obj : manifest_objects) {
+        if (obj && obj.value()) {
+            /* if the object is already added to the packager */
+            bool found = false;
+            for (auto it = packager_items.begin(); it != packager_items.end(); it++) {
+                const auto &pkg_item = *it;
+                if (pkg_item == obj.value()) {
+                    /* remove from local packager objects list */
+                    packager_items.erase(it);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                /* else (if the object is not added to the packager */
+                const auto &obj_metadata = objectStore().findMetadataByURL(obj.value()->getLocator());
+                if (obj_metadata) {
+                    /* if it is found in the ObjectStore, add it to the packager */
+                    packager->add(ObjectCarouselPackager::PackageItem(objectStore()[obj_metadata->objectId()],
+                                                                      object_manifest_hndlr));
+                }
+            }
+        }
+    }
+
+    /* for each object left in the packager list */
+    for (const auto &pkg_item : packager_items) {
+        /* this object is no longer in the carousel, so remove it */
+        packager->remove(pkg_item);
+    }
+}
+
+namespace {
+static const struct init {
+    init() {
+        ControllerFactory::registerController(new ControllerConstructor<ObjectCarouselController>);
+    };
+} g_init;
+}
+
+static void validate_distribution_session(DistributionSession &distribution_session)
+{
+    if (distribution_session.getObjectDistributionOperatingMode() != "CAROUSEL") {
+        throw std::logic_error("Expected objDistributionOperatingMode to be set to CAROUSEL.");
+    }
+}
+
+static bool check_if_object_added_is_manifest(const ObjectStore::Object &object, std::string &manifest_url)
+{
+    return (object.second.getOriginalUrl() == manifest_url || object.second.getFetchedUrl() == manifest_url);
+}
+
+static bool check_if_object_is_active_in_manifest(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
+{
+    const auto object_manifest_hndlr = std::dynamic_pointer_cast<const ObjectManifestHandler>(manifest_handler);
+    return object_manifest_hndlr->isObjectURLActive(object.second.getOriginalUrl());
+}
+
+static void finish_request_in_manifest_handler(const ObjectStore::Object &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
+{
+    auto object_manifest_hndlr = std::dynamic_pointer_cast<ObjectManifestHandler>(manifest_handler);
+    object_manifest_hndlr->finishRequest(object.second.getOriginalUrl());
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/ObjectCarouselController.hh
+++ b/src/mbstf/ObjectCarouselController.hh
@@ -1,0 +1,82 @@
+#ifndef _MBS_TF_OBJECT_CAROUSEL_CONTROLLER_HH_
+#define _MBS_TF_OBJECT_CAROUSEL_CONTROLLER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Carousel Controller class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "common.hh"
+#include "openapi/model/ObjDistributionData.h"
+#include "ObjectManifestController.hh"
+
+MBSTF_NAMESPACE_START
+
+class DistributionSession;
+class Event;
+class ObjectCarouselPackager;
+class PullObjectIngester;
+class SubscriptionService;
+class ObjectManifestController;
+
+class ObjectCarouselController : public ObjectManifestController {
+public:
+    ObjectCarouselController() = delete;
+    ObjectCarouselController(DistributionSession&);
+    ObjectCarouselController(const ObjectCarouselController&) = delete;
+    ObjectCarouselController(ObjectCarouselController&&) = delete;
+
+    virtual ~ObjectCarouselController();
+
+    ObjectCarouselController &operator=(const ObjectCarouselController&) = delete;
+    ObjectCarouselController &operator=(ObjectCarouselController&&) = delete;
+
+    std::shared_ptr<ObjectCarouselPackager> getObjectCarouselPackager() const;
+    const std::optional<std::string> &getObjectDistributionBaseUrl() const;
+    //virtual std::string nextObjectId();
+
+    static unsigned int factoryPriority() { return 50; };
+
+    // Subscriber virtual methods
+    virtual void processEvent(Event &event, SubscriptionService &event_service);
+
+    // Optional: virtual void subscriberRemoved(SubscriptionService &event_service);
+    std::string reprString() const {
+                std::ostringstream os;
+                os << "ObjectCarouselController(controller =" << this << ")";
+                return os.str();
+    }
+
+    void unsetObjectListPackager() {
+        // Reset the shared pointer to release ownership.
+        packager(nullptr);
+    };
+
+    virtual void reconfigureObjectPackager();
+
+protected:
+    virtual void setObjectPackager();
+    virtual void unsetObjectPackager();
+    virtual void activateObjectPackager();
+    virtual void deactivateObjectPackager();
+
+private:
+    void sendToPackager(const std::string &object_id);
+    void updateCarousel();
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_OBJECT_CAROUSEL_CONTROLLER_HH_ */

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -275,14 +275,23 @@ void ObjectCarouselPackager::flushQueue()
 
 bool ObjectCarouselPackager::deactivate()
 {
-    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
     m_deactivating = true;
-    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
-    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+    bool queue_empty;
+    {
+        std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+        if (!m_transmitter) {
+            queue_empty = (m_packageItems.size() == 0);
+        } else {
+            queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+        }
+    }
     if (queue_empty) {
         ogs_debug("Deactivating FLUTE stream, no files to purge");
         abort();
-        m_transmitter->deactivate();
+        {
+            std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+            if (m_transmitter) m_transmitter->deactivate();
+        }
         m_deactivating = false;
         return true;
     }
@@ -293,7 +302,11 @@ bool ObjectCarouselPackager::streamsAllocateToi(const std::function<std::pair<ui
 {
     std::lock_guard<decltype(m_streamsMutex)::element_type> lock(*m_streamsMutex);
     if (m_streams.size() < m_maxStreams) {
-        m_streams.insert(get_toi_fn());
+        try {
+            m_streams.insert(get_toi_fn());
+        } catch (std::runtime_error &ex) {
+            ogs_error("Unable to schedule carousel stream: %s", ex.what());
+        }
         return true;
     }
     return false;
@@ -439,8 +452,19 @@ void ObjectCarouselPackager::scheduleCarousel()
                         file_desc->set_content(pkg_item.object()->first);
                     }
                 }
+                /* update Cache expiry time */
+                LibFlute::Transmitter::FileDescription::date_time_type default_expiry(LibFlute::Transmitter::FileDescription::date_time_type::clock::now() + 60s);
+                file_desc->set_expiry_time(pkg_item.object()->second.cacheExpires().value_or(std::move(default_expiry)));
+
+                /* update Content-Type */
+                file_desc->set_content_type(pkg_item.object()->second.mediaType());
+
+                /* update ETag */
+                file_desc->set_etag(pkg_item.object()->second.entityTag().value_or(std::string{}));
+
                 /* add PackageItem to the FLUTE Transmitter as a current file */
                 m_transmitter->send(file_desc);
+
                 /* Return TOI to set in stream */
                 return std::make_pair(pkg_item.toi(), pkg_item.object());
             })) {

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -109,9 +109,9 @@ void ObjectCarouselPackager::PackageItem::startedTransmission(const ObjectCarous
 
 ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
                                        const std::list<ObjectCarouselPackager::PackageItem> &objects_to_package,
-                                       const std::optional<std::string> &address,
-                                       uint32_t rate_limit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+                                       const SsmPort &ssm_port, uint32_t rate_limit, unsigned short mtu,
+                                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(objects_to_package)
     ,m_packagingUpdateCondVar()
@@ -131,9 +131,9 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
 }
 
 ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                                       std::list<PackageItem> &&objects_to_package, const std::optional<std::string> &address,
-                                       uint32_t rate_limit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+                                       std::list<PackageItem> &&objects_to_package, const SsmPort &ssm_port,
+                                       uint32_t rate_limit, unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(std::move(objects_to_package))
     ,m_packagingUpdateCondVar()
@@ -153,9 +153,9 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
 }
 
 ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                                       const std::optional<std::string> &address, uint32_t rate_limit, unsigned short mtu,
-                                       in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+                                       const SsmPort &ssm_port, uint32_t rate_limit, unsigned short mtu,
+                                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems()
     ,m_packagingUpdateCondVar()
@@ -206,8 +206,7 @@ bool ObjectCarouselPackager::remove(const PackageItem &item) {
     return true;
 }
 
-bool ObjectCarouselPackager::updateFluteInfo(const std::string &address, in_port_t port,
-                                             uint32_t rate_limit,
+bool ObjectCarouselPackager::updateFluteInfo(const SsmPort &ssm_port, uint32_t rate_limit,
                                              const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
 {
     std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
@@ -215,10 +214,18 @@ bool ObjectCarouselPackager::updateFluteInfo(const std::string &address, in_port
     /* Do nothing if we don't have a Transmitter */
     if (!m_transmitter) return false;
 
-    /* set destination endpoint address if it has changed */
-    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(address), port);
+    /* set SSM address if it has changed */
+    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(ssm_port.destinationAddress()), ssm_port.port());
     if (dest_addr != m_transmitter->endpoint()) {
         m_transmitter->endpoint(dest_addr);
+    }
+    const auto &source_addr = ssm_port.sourceAddress();
+    std::optional<boost::asio::ip::address> src_addr;
+    if (source_addr) {
+        src_addr = boost::asio::ip::make_address(source_addr.value());
+    }
+    if (src_addr != m_transmitter->source_address()) {
+        m_transmitter->source_address(src_addr);
     }
 
     /* set new MBR if it has changed */
@@ -249,10 +256,12 @@ void ObjectCarouselPackager::ensureTransmitter()
 {
     std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
     if (!m_transmitter) {
-        std::optional<std::string> destAddr = destIpAddr();
-        if (!destAddr) return;
-        m_transmitter.reset(new LibFlute::Transmitter(destAddr.value(), static_cast<short>(port()), 0, mtu(), rateLimit(), m_io,
-                                                  m_tunnelEndpoint, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
+        const auto &ssm_port = ssmPort();
+        if (!ssm_port) return;
+        m_transmitter.reset(new LibFlute::Transmitter(ssm_port.destinationAddress(), static_cast<short>(ssm_port.port()), tsi(), mtu(),
+                                                      rateLimit(), m_io, m_tunnelEndpoint,
+                                                      LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005, true,
+                                                      ssm_port.sourceAddress()));
         m_transmitter->register_completion_callback(
             [this](uint32_t toi) {
                 ogs_debug("Object with TOI %d completed", toi);

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -45,16 +45,17 @@ MBSTF_NAMESPACE_START
 
 // ObjectCarouselPackager::PackageItem
 
-ObjectCarouselPackager::PackageItem::PackageItem(ObjectStore::Object &object, const std::shared_ptr<const ObjectManifestHandler> &manifest_handler)
-    :m_object(&object)
-    ,m_repetitionInterval(manifest_handler->getRepetitionIntervalForUrl(object.second.getOriginalUrl()))
+ObjectCarouselPackager::PackageItem::PackageItem(const std::shared_ptr<ObjectStore::Object> &object,
+                                                 const std::shared_ptr<const ObjectManifestHandler> &manifest_handler)
+    :m_object(object)
+    ,m_repetitionInterval(manifest_handler->getRepetitionIntervalForUrl(object->second.getOriginalUrl()))
     ,m_nextTransmissionStart(ObjectCarouselPackager::time_type::clock::now())
 {
 }
 
-ObjectCarouselPackager::PackageItem::PackageItem(ObjectStore::Object &object,
+ObjectCarouselPackager::PackageItem::PackageItem(const std::shared_ptr<ObjectStore::Object> &object,
                                                  const ObjectCarouselPackager::duration_type &repetition_interval)
-    :m_object(&object)
+    :m_object(object)
     ,m_repetitionInterval(repetition_interval)
     ,m_nextTransmissionStart(time_type::clock::now())
 {
@@ -68,7 +69,7 @@ ObjectCarouselPackager::PackageItem::PackageItem(const PackageItem &other)
 }
 
 ObjectCarouselPackager::PackageItem::PackageItem(PackageItem &&other)
-    :m_object(other.m_object)
+    :m_object(std::move(other.m_object))
     ,m_repetitionInterval(std::move(other.m_repetitionInterval))
     ,m_nextTransmissionStart(std::move(other.m_nextTransmissionStart))
 {
@@ -115,8 +116,8 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
     ,m_packageItems(objects_to_package)
     ,m_packagingUpdateCondVar()
     ,m_tunnelEndpoint()
-    ,m_streamToisMutex(new decltype(m_streamToisMutex)::element_type)
-    ,m_streamTois()
+    ,m_streamsMutex(new decltype(m_streamsMutex)::element_type)
+    ,m_streams()
     ,m_schedulingThread()
     ,m_schedulingRunning(false)
     ,m_schedulingCancel(false)
@@ -137,8 +138,8 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
     ,m_packageItems(std::move(objects_to_package))
     ,m_packagingUpdateCondVar()
     ,m_tunnelEndpoint()
-    ,m_streamToisMutex(new decltype(m_streamToisMutex)::element_type)
-    ,m_streamTois()
+    ,m_streamsMutex(new decltype(m_streamsMutex)::element_type)
+    ,m_streams()
     ,m_schedulingThread()
     ,m_schedulingRunning(false)
     ,m_schedulingCancel(false)
@@ -159,8 +160,8 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
     ,m_packageItems()
     ,m_packagingUpdateCondVar()
     ,m_tunnelEndpoint()
-    ,m_streamToisMutex(new decltype(m_streamToisMutex)::element_type)
-    ,m_streamTois()
+    ,m_streamsMutex(new decltype(m_streamsMutex)::element_type)
+    ,m_streams()
     ,m_schedulingThread()
     ,m_schedulingRunning(false)
     ,m_schedulingCancel(false)
@@ -182,7 +183,7 @@ bool ObjectCarouselPackager::add(const PackageItem &item) {
     ogs_debug("ObjectCarouselPackager::add(): deactivating=%s", m_deactivating?"true":"false");
     if (m_deactivating) return false;
     std::lock_guard<decltype(m_packageItemsMutex)::element_type> lock(*m_packageItemsMutex);
-    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object().second.objectId() == pkg_item.object().second.objectId(); });
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object()->second.objectId() == pkg_item.object()->second.objectId(); });
     m_packageItems.push_back(item);
     m_packagingUpdateCondVar.notify_all();
     return true;
@@ -192,7 +193,7 @@ bool ObjectCarouselPackager::add(PackageItem &&item) {
     ogs_debug("ObjectCarouselPackager::add(): deactivating=%s", m_deactivating?"true":"false");
     if (m_deactivating) return false;
     std::lock_guard<decltype(m_packageItemsMutex)::element_type> lock(*m_packageItemsMutex);
-    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object().second.objectId() == pkg_item.object().second.objectId(); });
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object()->second.objectId() == pkg_item.object()->second.objectId(); });
     m_packageItems.push_back(std::move(item));
     m_packagingUpdateCondVar.notify_all();
     return true;
@@ -200,7 +201,7 @@ bool ObjectCarouselPackager::add(PackageItem &&item) {
 
 bool ObjectCarouselPackager::remove(const PackageItem &item) {
     std::lock_guard<decltype(m_packageItemsMutex)::element_type> lock(*m_packageItemsMutex);
-    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object().second.objectId() == pkg_item.object().second.objectId(); });
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object()->second.objectId() == pkg_item.object()->second.objectId(); });
     m_packagingUpdateCondVar.notify_all();
     return true;
 }
@@ -288,37 +289,24 @@ bool ObjectCarouselPackager::deactivate()
     return false;
 }
 
-bool ObjectCarouselPackager::streamsAllocateToi(const std::function<uint32_t()> &get_toi_fn)
+bool ObjectCarouselPackager::streamsAllocateToi(const std::function<std::pair<uint32_t, std::shared_ptr<ObjectStore::Object> >()> &get_toi_fn)
 {
-    std::lock_guard<decltype(m_streamToisMutex)::element_type> lock(*m_streamToisMutex);
-    for (size_t i=0; i<m_maxStreams; i++) {
-        if (i >= m_streamTois.size()) {
-            m_streamTois.push_back(get_toi_fn());
-            return true;
-        }
-        if (m_streamTois[i] == 0) {
-            m_streamTois[i] = get_toi_fn();
-            return true;
-        }
+    std::lock_guard<decltype(m_streamsMutex)::element_type> lock(*m_streamsMutex);
+    if (m_streams.size() < m_maxStreams) {
+        m_streams.insert(get_toi_fn());
+        return true;
     }
     return false;
 }
 
 void ObjectCarouselPackager::streamsRemoveToi(uint32_t toi)
 {
-    std::lock_guard<decltype(m_streamToisMutex)::element_type> lock(*m_streamToisMutex);
-
-    auto tois_size = m_streamTois.size();
-    for (size_t i = 0; i < tois_size; i++) {
-        if (toi == m_streamTois[i]) {
-            if (i < tois_size - 1) {
-                m_streamTois[i] = m_streamTois[tois_size - 1];
-            }
-            m_streamTois.pop_back();
-            break;
-        }
+    std::lock_guard<decltype(m_streamsMutex)::element_type> lock(*m_streamsMutex);
+    auto it = m_streams.find(toi);
+    if (it != m_streams.end()) {
+        m_streams.erase(it);
+        m_packagingUpdateCondVar.notify_all();
     }
-    m_packagingUpdateCondVar.notify_all();
 }
 
 void ObjectCarouselPackager::scheduleCarousel()
@@ -332,14 +320,14 @@ void ObjectCarouselPackager::scheduleCarousel()
     }
 
     /* copy the package items list to filter for items to schedule */
-    auto package_items = m_packageItems;
+    std::list<PackageItem> package_items(m_packageItems);
 
     /* fix repetition rates where unknown by allocating unknown items to the remaining bit rate */
     double known_bit_rate = 0.0;
     size_t unknown_rate_bits = 0;
     for (const auto &pkg_item : package_items) {
         double rep_interval = pkg_item.repetitionInterval().count();
-        size_t obj_bit_size = pkg_item.object().first.size()*sizeof(*pkg_item.object().first.data())*8;
+        size_t obj_bit_size = pkg_item.object()->first.size()*sizeof(*pkg_item.object()->first.data())*8;
         if (!std::isnan(rep_interval)) {
             known_bit_rate += obj_bit_size / rep_interval;
         } else {
@@ -363,7 +351,7 @@ void ObjectCarouselPackager::scheduleCarousel()
     double total_bit_rate = 0.0;
     for (const auto &pkg_item : package_items) {
         const auto &object = pkg_item.object();
-        size_t obj_bit_size = object.first.size()*sizeof(*object.first.data())*8;
+        size_t obj_bit_size = object->first.size()*sizeof(*object->first.data())*8;
         double obj_bit_rate = obj_bit_size / pkg_item.repetitionInterval().count();
         //ogs_debug("%s", std::format("Object {} of {} bits repeats every {}s: bitrate = {}", object.second.getFetchedUrl(), obj_bit_size, pkg_item.repetitionInterval().count(), obj_bit_rate).c_str());
         if (obj_bit_rate > max_obj_bit_rate) max_obj_bit_rate = obj_bit_rate;
@@ -385,10 +373,13 @@ void ObjectCarouselPackager::scheduleCarousel()
     std::optional<time_type> next_start;
     std::erase_if(package_items, [this, &now, &next_start, avail_bitrate](const auto &item) -> bool {
             auto [start_min, start_deadline] = item.nextTransmitStartWindow(avail_bitrate);
-            //ogs_debug("%s", std::format("Item {} to start transmission between {} and {}", item.object().second.getFetchedUrl(), start_min, start_deadline).c_str());
-            if (std::find(m_streamTois.begin(), m_streamTois.end(), item.toi()) != m_streamTois.end()) {
-                //ogs_debug("Item already being sent");
-                return true;
+            //ogs_debug("%s", std::format("Item {} to start transmission between {} and {}", item.object()->second.getFetchedUrl(), start_min, start_deadline).c_str());
+            {
+                std::lock_guard<decltype(m_streamsMutex)::element_type> lock(*m_streamsMutex);
+                if (m_streams.find(item.toi()) != m_streams.end()) {
+                    //ogs_debug("Item already being sent");
+                    return true;
+                }
             }
             if (start_min > now) {
                 //ogs_debug("Item not due for transmission yet");
@@ -421,34 +412,42 @@ void ObjectCarouselPackager::scheduleCarousel()
 
     /* iterate through list allocating package items to streams until no streams left or no package items left */
     for (auto &pkg_item : package_items) {
-        //ogs_debug("%s", std::format("Attempting to schedule {}", pkg_item.object().second.getFetchedUrl()).c_str());
-        if (streamsAllocateToi([this,&pkg_item]() -> uint32_t {
+        //ogs_debug("%s", std::format("Attempting to schedule {}", pkg_item.object()->second.getFetchedUrl()).c_str());
+        if (streamsAllocateToi([this,&pkg_item]() -> std::pair<uint32_t, std::shared_ptr<ObjectStore::Object> > {
                 std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
                 ensureTransmitter();
-                auto &metadata = pkg_item.object().second;
+                auto &metadata = pkg_item.object()->second;
                 auto &file_desc = metadata.fluteFileDescription();
+                std::string location;
+                std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
+                std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
+                if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
+                    metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
+                    location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
+                } else {
+                    // Just use the fetched URL
+                    location = metadata.getFetchedUrl();
+                }
                 if (!file_desc) {
-                    std::string location;
-                    std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
-                    std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
-                    if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
-                        metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
-                        location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
-                    } else {
-                        // Just use the fetched URL
-                        location = metadata.getFetchedUrl();
+                    pkg_item.object()->second.fluteFileDescription(new LibFlute::Transmitter::FileDescription(location, pkg_item.object()->first));
+                } else {
+                    /* reset file description information if it's changed */
+                    if (file_desc->file_entry().content_location != location) {
+                        file_desc->set_content_location(location);
                     }
-                    pkg_item.object().second.fluteFileDescription(new LibFlute::Transmitter::FileDescription(location, pkg_item.object().first));
+                    if (file_desc->data() != reinterpret_cast<const char*>(pkg_item.object()->first.data())) {
+                        file_desc->set_content(pkg_item.object()->first);
+                    }
                 }
                 /* add PackageItem to the FLUTE Transmitter as a current file */
                 m_transmitter->send(file_desc);
                 /* Return TOI to set in stream */
-                return pkg_item.toi();
+                return std::make_pair(pkg_item.toi(), pkg_item.object());
             })) {
             /* mark as transmission started to shift to next repeat window */
-            ogs_debug("%s", std::format("Item {} scheduled at {} to be repeated after {}s", pkg_item.object().second.getFetchedUrl(), time_type::clock::now(), pkg_item.repetitionInterval().count()).c_str());
+            ogs_debug("%s", std::format("Item {} scheduled at {} to be repeated after {}s", pkg_item.object()->second.getFetchedUrl(), time_type::clock::now(), pkg_item.repetitionInterval().count()).c_str());
             for (auto &item : m_packageItems) {
-                if (item.object().second.objectId() == pkg_item.object().second.objectId()) {
+                if (item.object()->second.objectId() == pkg_item.object()->second.objectId()) {
                     item.startedTransmission(pkg_item.repetitionInterval());
                     break;
                 }

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -492,6 +492,7 @@ void ObjectCarouselPackager::startScheduler()
 void ObjectCarouselPackager::abortScheduler()
 {
     m_schedulingCancel = true;
+    m_packagingUpdateCondVar.notify_all();
     if (m_schedulingThread.get_id() != std::this_thread::get_id() && m_schedulingThread.joinable()) {
         m_schedulingThread.join();
     }

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -1,0 +1,504 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectCarouselPackager class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <chrono>
+#include <exception>
+#include <iostream>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <netinet/in.h>
+
+#include "ogs-app.h" // ogs_error(), ogs_info()
+#include "ogs-sbi.h"
+#include "Transmitter.h" // LibFlute
+
+#include "common.hh"
+#include "DistributionSession.hh"
+#include "ObjectController.hh"
+#include "ObjectCarouselController.hh"
+#include "ObjectManifestHandler.hh"
+#include "ObjectPackager.hh"
+#include "ObjectStore.hh"
+#include "openapi/model/Object.h"
+
+#include "ObjectCarouselPackager.hh"
+
+using namespace std::literals::chrono_literals;
+using ApiObject = reftools::mbstf::Object;
+
+MBSTF_NAMESPACE_START
+
+// ObjectCarouselPackager::PackageItem
+
+ObjectCarouselPackager::PackageItem::PackageItem(ObjectStore::Object &object, const std::shared_ptr<const ObjectManifestHandler> &manifest_handler)
+    :m_object(&object)
+    ,m_repetitionInterval(manifest_handler->getRepetitionIntervalForUrl(object.second.getOriginalUrl()))
+    ,m_nextTransmissionStart(ObjectCarouselPackager::time_type::clock::now())
+{
+}
+
+ObjectCarouselPackager::PackageItem::PackageItem(ObjectStore::Object &object,
+                                                 const ObjectCarouselPackager::duration_type &repetition_interval)
+    :m_object(&object)
+    ,m_repetitionInterval(repetition_interval)
+    ,m_nextTransmissionStart(time_type::clock::now())
+{
+}
+
+ObjectCarouselPackager::PackageItem::PackageItem(const PackageItem &other)
+    :m_object(other.m_object)
+    ,m_repetitionInterval(other.m_repetitionInterval)
+    ,m_nextTransmissionStart(other.m_nextTransmissionStart)
+{
+}
+
+ObjectCarouselPackager::PackageItem::PackageItem(PackageItem &&other)
+    :m_object(other.m_object)
+    ,m_repetitionInterval(std::move(other.m_repetitionInterval))
+    ,m_nextTransmissionStart(std::move(other.m_nextTransmissionStart))
+{
+}
+
+bool ObjectCarouselPackager::PackageItem::operator==(const std::shared_ptr<ApiObject> &obj) const
+{
+    if (!obj && !m_object) return true;
+    if (!obj || !m_object) return false;
+    const auto &locator = obj->getLocator();
+    return locator == m_object->second.getFetchedUrl() ||
+           locator == m_object->second.getOriginalUrl() ||
+           locator == m_object->second.acquisitionId();
+}
+
+std::pair<ObjectCarouselPackager::time_type, ObjectCarouselPackager::time_type> ObjectCarouselPackager::PackageItem::nextTransmitStartWindow(double available_bit_rate) const
+{
+    auto obj_bit_size = m_object->first.size() * sizeof(ObjectStore::ObjectData::value_type) * 8;
+    auto window_start = m_nextTransmissionStart;
+    auto window_end = window_start;
+    if (!std::isnan(m_repetitionInterval.count())) {
+        window_end += std::chrono::duration_cast<time_type::duration>(m_repetitionInterval - duration_type(obj_bit_size/available_bit_rate));
+    }
+    return std::make_pair(window_start, window_end);
+}
+
+void ObjectCarouselPackager::PackageItem::startedTransmission(const ObjectCarouselPackager::duration_type &repetition_interval)
+{
+    auto now = time_type::clock::now();
+    /* skip the transmission window start forward by m_repeatIntervals until we find the next start after now */
+    while (m_nextTransmissionStart < now) {
+        m_nextTransmissionStart += std::chrono::duration_cast<time_type::duration>(repetition_interval);
+    }
+}
+
+// ObjectCarouselPackager
+
+ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+                                       const std::list<ObjectCarouselPackager::PackageItem> &objects_to_package,
+                                       const std::optional<std::string> &address,
+                                       uint32_t rate_limit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+    ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
+    ,m_packageItems(objects_to_package)
+    ,m_packagingUpdateCondVar()
+    ,m_tunnelEndpoint()
+    ,m_streamToisMutex(new decltype(m_streamToisMutex)::element_type)
+    ,m_streamTois()
+    ,m_schedulingThread()
+    ,m_schedulingRunning(false)
+    ,m_schedulingCancel(false)
+    ,m_maxStreams(0)
+{
+    if (tunnel_address) {
+        m_tunnelEndpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(tunnel_address.value()), tunnel_port);
+    }
+    startWorker();
+    startScheduler();
+}
+
+ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+                                       std::list<PackageItem> &&objects_to_package, const std::optional<std::string> &address,
+                                       uint32_t rate_limit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+    ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
+    ,m_packageItems(std::move(objects_to_package))
+    ,m_packagingUpdateCondVar()
+    ,m_tunnelEndpoint()
+    ,m_streamToisMutex(new decltype(m_streamToisMutex)::element_type)
+    ,m_streamTois()
+    ,m_schedulingThread()
+    ,m_schedulingRunning(false)
+    ,m_schedulingCancel(false)
+    ,m_maxStreams(0)
+{
+    if (tunnel_address) {
+        m_tunnelEndpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(tunnel_address.value()), tunnel_port);
+    }
+    startWorker();
+    startScheduler();
+}
+
+ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+                                       const std::optional<std::string> &address, uint32_t rate_limit, unsigned short mtu,
+                                       in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, address, rate_limit, mtu, port, tunnel_address, tunnel_port)
+    ,m_packageItemsMutex(new decltype(m_packageItemsMutex)::element_type)
+    ,m_packageItems()
+    ,m_packagingUpdateCondVar()
+    ,m_tunnelEndpoint()
+    ,m_streamToisMutex(new decltype(m_streamToisMutex)::element_type)
+    ,m_streamTois()
+    ,m_schedulingThread()
+    ,m_schedulingRunning(false)
+    ,m_schedulingCancel(false)
+    ,m_maxStreams(0)
+{
+    if (tunnel_address) {
+        m_tunnelEndpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(tunnel_address.value()), tunnel_port);
+    }
+    startWorker();
+    startScheduler();
+}
+
+ObjectCarouselPackager::~ObjectCarouselPackager() {
+    abort();
+    abortScheduler();
+}
+
+bool ObjectCarouselPackager::add(const PackageItem &item) {
+    ogs_debug("ObjectCarouselPackager::add(): deactivating=%s", m_deactivating?"true":"false");
+    if (m_deactivating) return false;
+    std::lock_guard<decltype(m_packageItemsMutex)::element_type> lock(*m_packageItemsMutex);
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object().second.objectId() == pkg_item.object().second.objectId(); });
+    m_packageItems.push_back(item);
+    m_packagingUpdateCondVar.notify_all();
+    return true;
+}
+
+bool ObjectCarouselPackager::add(PackageItem &&item) {
+    ogs_debug("ObjectCarouselPackager::add(): deactivating=%s", m_deactivating?"true":"false");
+    if (m_deactivating) return false;
+    std::lock_guard<decltype(m_packageItemsMutex)::element_type> lock(*m_packageItemsMutex);
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object().second.objectId() == pkg_item.object().second.objectId(); });
+    m_packageItems.push_back(std::move(item));
+    m_packagingUpdateCondVar.notify_all();
+    return true;
+}
+
+bool ObjectCarouselPackager::remove(const PackageItem &item) {
+    std::lock_guard<decltype(m_packageItemsMutex)::element_type> lock(*m_packageItemsMutex);
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object().second.objectId() == pkg_item.object().second.objectId(); });
+    m_packagingUpdateCondVar.notify_all();
+    return true;
+}
+
+bool ObjectCarouselPackager::updateFluteInfo(const std::string &address, in_port_t port,
+                                             uint32_t rate_limit,
+                                             const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+{
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+
+    /* Do nothing if we don't have a Transmitter */
+    if (!m_transmitter) return false;
+
+    /* set destination endpoint address if it has changed */
+    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(address), port);
+    if (dest_addr != m_transmitter->endpoint()) {
+        m_transmitter->endpoint(dest_addr);
+    }
+
+    /* set new MBR if it has changed */
+    if (rate_limit != m_transmitter->rate_limit()) {
+        m_transmitter->rate_limit(rate_limit);
+    }
+
+    /* set new tunnel address if it has changed */
+    auto curr_tun_addr = m_transmitter->udp_tunnel_address();
+    if (tunnel_address) {
+        m_tunnelEndpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(tunnel_address.value()), tunnel_port);
+    } else {
+        m_tunnelEndpoint = std::nullopt;
+    }
+    if (curr_tun_addr != m_tunnelEndpoint) {
+        m_transmitter->udp_tunnel_address(m_tunnelEndpoint);
+    }
+
+    return true;
+}
+
+void ObjectCarouselPackager::doObjectPackage() {
+    ensureTransmitter();
+    m_io.run_one();
+}
+
+void ObjectCarouselPackager::ensureTransmitter()
+{
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+    if (!m_transmitter) {
+        std::optional<std::string> destAddr = destIpAddr();
+        if (!destAddr) return;
+        m_transmitter.reset(new LibFlute::Transmitter(destAddr.value(), static_cast<short>(port()), 0, mtu(), rateLimit(), m_io,
+                                                  m_tunnelEndpoint, LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
+        m_transmitter->register_completion_callback(
+            [this](uint32_t toi) {
+                ogs_debug("Object with TOI %d completed", toi);
+                try {
+                    /* find stream containing current object with toi */
+                    streamsRemoveToi(toi);
+                } catch (std::out_of_range &ex) {
+                    errorInCarousel(ex.what(), ObjectPackager::PackagingFailedEvent::RESOURCE_NOT_AVAILABLE);
+                }
+            }
+        );
+    }
+}
+
+void ObjectCarouselPackager::flushQueue()
+{
+    std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
+    m_packageItems.clear();
+}
+
+bool ObjectCarouselPackager::deactivate()
+{
+    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+    m_deactivating = true;
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+    if (queue_empty) {
+        ogs_debug("Deactivating FLUTE stream, no files to purge");
+        abort();
+        m_transmitter->deactivate();
+        m_deactivating = false;
+        return true;
+    }
+    return false;
+}
+
+bool ObjectCarouselPackager::streamsAllocateToi(const std::function<uint32_t()> &get_toi_fn)
+{
+    std::lock_guard<decltype(m_streamToisMutex)::element_type> lock(*m_streamToisMutex);
+    for (size_t i=0; i<m_maxStreams; i++) {
+        if (i >= m_streamTois.size()) {
+            m_streamTois.push_back(get_toi_fn());
+            return true;
+        }
+        if (m_streamTois[i] == 0) {
+            m_streamTois[i] = get_toi_fn();
+            return true;
+        }
+    }
+    return false;
+}
+
+void ObjectCarouselPackager::streamsRemoveToi(uint32_t toi)
+{
+    std::lock_guard<decltype(m_streamToisMutex)::element_type> lock(*m_streamToisMutex);
+
+    auto tois_size = m_streamTois.size();
+    for (size_t i = 0; i < tois_size; i++) {
+        if (toi == m_streamTois[i]) {
+            if (i < tois_size - 1) {
+                m_streamTois[i] = m_streamTois[tois_size - 1];
+            }
+            m_streamTois.pop_back();
+            break;
+        }
+    }
+    m_packagingUpdateCondVar.notify_all();
+}
+
+void ObjectCarouselPackager::scheduleCarousel()
+{
+    /* copy list of package items */
+    std::lock_guard<decltype(m_packageItemsMutex)::element_type> pkg_lock(*m_packageItemsMutex);
+    if (m_packageItems.empty()) {
+        ogs_debug("Empty schedule, wait for change");
+        m_packagingUpdateCondVar.wait(*m_packageItemsMutex);
+        return;
+    }
+
+    /* copy the package items list to filter for items to schedule */
+    auto package_items = m_packageItems;
+
+    /* fix repetition rates where unknown by allocating unknown items to the remaining bit rate */
+    double known_bit_rate = 0.0;
+    size_t unknown_rate_bits = 0;
+    for (const auto &pkg_item : package_items) {
+        double rep_interval = pkg_item.repetitionInterval().count();
+        size_t obj_bit_size = pkg_item.object().first.size()*sizeof(*pkg_item.object().first.data())*8;
+        if (!std::isnan(rep_interval)) {
+            known_bit_rate += obj_bit_size / rep_interval;
+        } else {
+            unknown_rate_bits += obj_bit_size;
+        }
+    }
+    double unknown_rep_interval = 0.0;
+    double mbr = rateLimit()*1000.0;
+    if (unknown_rate_bits) {
+        unknown_rep_interval = unknown_rate_bits / (mbr - known_bit_rate);
+    }
+    for (auto &pkg_item : package_items) {
+        double rep_interval = pkg_item.repetitionInterval().count();
+        if (std::isnan(rep_interval)) {
+            pkg_item.repetitionInterval(duration_type(unknown_rep_interval));
+        }
+    }
+
+    /* find largest bitrate item and check total bit rate requirement */
+    double max_obj_bit_rate = 0.0;
+    double total_bit_rate = 0.0;
+    for (const auto &pkg_item : package_items) {
+        const auto &object = pkg_item.object();
+        size_t obj_bit_size = object.first.size()*sizeof(*object.first.data())*8;
+        double obj_bit_rate = obj_bit_size / pkg_item.repetitionInterval().count();
+        //ogs_debug("%s", std::format("Object {} of {} bits repeats every {}s: bitrate = {}", object.second.getFetchedUrl(), obj_bit_size, pkg_item.repetitionInterval().count(), obj_bit_rate).c_str());
+        if (obj_bit_rate > max_obj_bit_rate) max_obj_bit_rate = obj_bit_rate;
+        total_bit_rate += obj_bit_rate;
+    }
+    if (total_bit_rate > mbr) {
+        errorInCarousel(std::format("Carousel maximum bit rate exceeded: allocated {} bps, requires {} bps", mbr, total_bit_rate), ObjectPackager::PackagingFailedEvent::BIT_RATE_OVERFLOW);
+        return;
+    }
+
+    /* calculate the maximum number of concurrently transmitted objects the maximim bit rate object will allow */
+    m_maxStreams = static_cast<size_t>(mbr / max_obj_bit_rate);
+    double avail_bitrate = mbr / m_maxStreams;
+
+    //ogs_debug("%s", std::format("Highest Object bit rate = {}, Max concurrent objects = {}, Available bitrate per concurrent stream = {}", max_obj_bit_rate, m_maxStreams, avail_bitrate).c_str());
+
+    /* remove any items currently being transmitted or not due for send until after now */
+    auto now = time_type::clock::now();
+    std::optional<time_type> next_start;
+    std::erase_if(package_items, [this, &now, &next_start, avail_bitrate](const auto &item) -> bool {
+            auto [start_min, start_deadline] = item.nextTransmitStartWindow(avail_bitrate);
+            //ogs_debug("%s", std::format("Item {} to start transmission between {} and {}", item.object().second.getFetchedUrl(), start_min, start_deadline).c_str());
+            if (std::find(m_streamTois.begin(), m_streamTois.end(), item.toi()) != m_streamTois.end()) {
+                //ogs_debug("Item already being sent");
+                return true;
+            }
+            if (start_min > now) {
+                //ogs_debug("Item not due for transmission yet");
+                if (!next_start || start_min < next_start.value()) {
+                    next_start = start_min;
+                }
+                return true;
+            }
+            return false;
+        });
+
+    //ogs_debug("%s", std::format("There remains {} items awaiting scheduling", package_items.size()).c_str());
+
+    /* If there are no items in the remaining list end scheduling now */
+    if (package_items.empty()) {
+        if (next_start) {
+            //ogs_debug("%s", std::format("Nothing to schedule, sleeping until {} or scheduling change", next_start.value()).c_str());
+            m_packagingUpdateCondVar.wait_until(*m_packageItemsMutex, next_start.value());
+        } else {
+            //ogs_debug("Nothing to schedule, waiting for scheduling change");
+            m_packagingUpdateCondVar.wait(*m_packageItemsMutex);
+        }
+        return;
+    }
+
+    /* sort list of package items into order from earliest deadline to latest */
+    package_items.sort([avail_bitrate](const auto &a, const auto &b) -> bool {
+                     return a.nextTransmitStartWindow(avail_bitrate).second < b.nextTransmitStartWindow(avail_bitrate).second;
+              });
+
+    /* iterate through list allocating package items to streams until no streams left or no package items left */
+    for (auto &pkg_item : package_items) {
+        //ogs_debug("%s", std::format("Attempting to schedule {}", pkg_item.object().second.getFetchedUrl()).c_str());
+        if (streamsAllocateToi([this,&pkg_item]() -> uint32_t {
+                std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+                ensureTransmitter();
+                auto &metadata = pkg_item.object().second;
+                auto &file_desc = metadata.fluteFileDescription();
+                if (!file_desc) {
+                    std::string location;
+                    std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
+                    std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
+                    if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
+                        metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
+                        location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
+                    } else {
+                        // Just use the fetched URL
+                        location = metadata.getFetchedUrl();
+                    }
+                    pkg_item.object().second.fluteFileDescription(new LibFlute::Transmitter::FileDescription(location, pkg_item.object().first));
+                }
+                /* add PackageItem to the FLUTE Transmitter as a current file */
+                m_transmitter->send(file_desc);
+                /* Return TOI to set in stream */
+                return pkg_item.toi();
+            })) {
+            /* mark as transmission started to shift to next repeat window */
+            ogs_debug("%s", std::format("Item {} scheduled at {} to be repeated after {}s", pkg_item.object().second.getFetchedUrl(), time_type::clock::now(), pkg_item.repetitionInterval().count()).c_str());
+            for (auto &item : m_packageItems) {
+                if (item.object().second.objectId() == pkg_item.object().second.objectId()) {
+                    item.startedTransmission(pkg_item.repetitionInterval());
+                    break;
+                }
+            }
+        } else {
+            /* no more free streams, stop scheduling */
+            //ogs_debug("No more streams available, waiting for scheduling change");
+            m_packagingUpdateCondVar.wait(*m_packageItemsMutex);
+            break;
+        }
+    }
+}
+
+void ObjectCarouselPackager::errorInCarousel(const std::string &reason, ObjectPackager::PackagingFailedEvent::FailureType fail_type)
+{
+    /* log error */
+    ogs_error("Error in Carousel: (%i) %s", fail_type, reason.c_str());
+
+    ObjectPackager::PackagingFailedEvent packaging_failed(reason, fail_type);
+    sendEventSynchronous(packaging_failed);
+}
+
+void ObjectCarouselPackager::startScheduler()
+{
+    if (!!m_schedulingRunning) return;
+    if (!!m_schedulingCancel) return;
+    if (m_schedulingThread.joinable()) m_schedulingThread.detach();
+    m_schedulingThread = std::thread([this](void *dummy) -> void {
+            m_schedulingRunning = true;
+            ensureTransmitter();
+            while (!m_schedulingCancel) {
+                try {
+                    scheduleCarousel();
+                } catch (std::overflow_error &ex) {
+                    errorInCarousel(ex.what(), ObjectPackager::PackagingFailedEvent::BIT_RATE_OVERFLOW);
+                }
+            }
+            m_schedulingRunning = false;
+        }, nullptr);
+}
+
+void ObjectCarouselPackager::abortScheduler()
+{
+    m_schedulingCancel = true;
+    if (m_schedulingThread.get_id() != std::this_thread::get_id() && m_schedulingThread.joinable()) {
+        m_schedulingThread.join();
+    }
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/ObjectCarouselPackager.hh
+++ b/src/mbstf/ObjectCarouselPackager.hh
@@ -44,8 +44,8 @@ public:
     class PackageItem {
     public:
         PackageItem() = delete;
-        PackageItem(ObjectStore::Object &object, const std::shared_ptr<const ObjectManifestHandler> &manifest_handler);
-        PackageItem(ObjectStore::Object &object, const duration_type &repetition_interval);
+        PackageItem(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<const ObjectManifestHandler> &manifest_handler);
+        PackageItem(const std::shared_ptr<ObjectStore::Object> &object, const duration_type &repetition_interval);
         PackageItem(const PackageItem &other);
         PackageItem(PackageItem &&other);
         virtual ~PackageItem() {};
@@ -55,9 +55,10 @@ public:
 
         bool operator==(const std::shared_ptr<reftools::mbstf::Object> &obj) const;
 
-        ObjectStore::Object &object() { return *m_object; };
-        const ObjectStore::Object &object() const { return *m_object; };
-        PackageItem &object(ObjectStore::Object &object) { m_object = &object; return *this; };
+        const std::shared_ptr<ObjectStore::Object> &object() { return m_object; };
+        std::shared_ptr<const ObjectStore::Object> object() const { return m_object; };
+        PackageItem &object(const std::shared_ptr<ObjectStore::Object> &object) { m_object = object; return *this; };
+        PackageItem &object(std::shared_ptr<ObjectStore::Object> &&object) { m_object = std::move(object); return *this; };
 
         const duration_type &repetitionInterval() const { return m_repetitionInterval; };
         PackageItem &repetitionInterval(const duration_type &repetition_interval) {
@@ -74,7 +75,7 @@ public:
         uint32_t toi() const { const auto &fd = m_object->second.fluteFileDescription(); return fd?fd->toi():0; };
 
     private:
-        ObjectStore::Object *m_object;
+        std::shared_ptr<ObjectStore::Object> m_object;
         duration_type m_repetitionInterval;
         time_type m_nextTransmissionStart;
     };
@@ -108,7 +109,7 @@ protected:
     virtual void doObjectPackage();
 
 private:
-    bool streamsAllocateToi(const std::function<uint32_t()> &get_toi_fn); // returns true if the TOI could be allocated to an empty stream
+    bool streamsAllocateToi(const std::function<std::pair<uint32_t, std::shared_ptr<ObjectStore::Object> >()> &get_toi_fn);
     void streamsRemoveToi(uint32_t toi);
     void scheduleCarousel();
     void ensureTransmitter();
@@ -121,8 +122,8 @@ private:
     std::list<PackageItem> m_packageItems;
     std::condition_variable_any m_packagingUpdateCondVar;
     std::optional<boost::asio::ip::udp::endpoint> m_tunnelEndpoint;
-    std::unique_ptr<std::recursive_mutex> m_streamToisMutex;
-    std::vector<uint32_t> m_streamTois;
+    std::unique_ptr<std::recursive_mutex> m_streamsMutex;
+    std::map<uint32_t, std::shared_ptr<ObjectStore::Object> > m_streams;
     std::thread m_schedulingThread;
     std::atomic_bool m_schedulingRunning;
     std::atomic_bool m_schedulingCancel;

--- a/src/mbstf/ObjectCarouselPackager.hh
+++ b/src/mbstf/ObjectCarouselPackager.hh
@@ -82,14 +82,14 @@ public:
 
     ObjectCarouselPackager() = delete;
     ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                       const std::list<PackageItem> &objects_to_package, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const std::list<PackageItem> &objects_to_package, const SsmPort &ssm_port,
+                       uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&objects_to_package,
-                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
+    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, const SsmPort &ssm_port,
+                       uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     virtual ~ObjectCarouselPackager();
 
@@ -98,9 +98,8 @@ public:
     bool remove(const PackageItem &item);
     const std::list<PackageItem> &getPackageItems() const { return m_packageItems; };
 
-    bool updateFluteInfo(const std::string &address, in_port_t port,
-                         uint32_t rateLimit,
-                         const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    bool updateFluteInfo(const SsmPort &ssm_port, uint32_t rateLimit, const std::optional<std::string> &tunnel_address,
+                         in_port_t tunnel_port);
 
     virtual bool deactivate();
     virtual void flushQueue();

--- a/src/mbstf/ObjectCarouselPackager.hh
+++ b/src/mbstf/ObjectCarouselPackager.hh
@@ -1,0 +1,137 @@
+#ifndef _MBS_TF_OBJECT_CAROUSEL_PACKAGER_HH_
+#define _MBS_TF_OBJECT_CAROUSEL_PACKAGER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Carousel Packager class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <chrono>
+#include <functional>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <netinet/in.h>
+
+#include <boost/asio.hpp>
+
+#include "common.hh"
+#include "ObjectPackager.hh"
+#include "ObjectStore.hh"
+
+namespace reftools::mbstf {
+    class Object;
+}
+
+MBSTF_NAMESPACE_START
+
+class ObjectController;
+class ObjectManifestHandler;
+
+class ObjectCarouselPackager : public ObjectPackager {
+public:
+    using duration_type = std::chrono::duration<double>;
+    using time_type = std::chrono::system_clock::time_point;
+
+    class PackageItem {
+    public:
+        PackageItem() = delete;
+        PackageItem(ObjectStore::Object &object, const std::shared_ptr<const ObjectManifestHandler> &manifest_handler);
+        PackageItem(ObjectStore::Object &object, const duration_type &repetition_interval);
+        PackageItem(const PackageItem &other);
+        PackageItem(PackageItem &&other);
+        virtual ~PackageItem() {};
+
+        PackageItem &operator=(const PackageItem &other);
+        PackageItem &operator=(PackageItem &&other);
+
+        bool operator==(const std::shared_ptr<reftools::mbstf::Object> &obj) const;
+
+        ObjectStore::Object &object() { return *m_object; };
+        const ObjectStore::Object &object() const { return *m_object; };
+        PackageItem &object(ObjectStore::Object &object) { m_object = &object; return *this; };
+
+        const duration_type &repetitionInterval() const { return m_repetitionInterval; };
+        PackageItem &repetitionInterval(const duration_type &repetition_interval) {
+            m_repetitionInterval = repetition_interval;
+            return *this;
+        };
+        PackageItem &repetitionInterval(duration_type &&repetition_interval) {
+            m_repetitionInterval = std::move(repetition_interval);
+            return *this;
+        };
+
+        std::pair<time_type, time_type> nextTransmitStartWindow(double available_bit_rate) const;
+        void startedTransmission(const duration_type &used_rep_interval);
+        uint32_t toi() const { const auto &fd = m_object->second.fluteFileDescription(); return fd?fd->toi():0; };
+
+    private:
+        ObjectStore::Object *m_object;
+        duration_type m_repetitionInterval;
+        time_type m_nextTransmissionStart;
+    };
+
+    ObjectCarouselPackager() = delete;
+    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+                       const std::list<PackageItem> &objects_to_package, const std::optional<std::string> &address,
+                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&objects_to_package,
+                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, const std::optional<std::string> &address,
+                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    virtual ~ObjectCarouselPackager();
+
+    bool add(const PackageItem &item);
+    bool add(PackageItem &&item);
+    bool remove(const PackageItem &item);
+    const std::list<PackageItem> &getPackageItems() const { return m_packageItems; };
+
+    bool updateFluteInfo(const std::string &address, in_port_t port,
+                         uint32_t rateLimit,
+                         const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+
+    virtual bool deactivate();
+    virtual void flushQueue();
+
+protected:
+    virtual void doObjectPackage();
+
+private:
+    bool streamsAllocateToi(const std::function<uint32_t()> &get_toi_fn); // returns true if the TOI could be allocated to an empty stream
+    void streamsRemoveToi(uint32_t toi);
+    void scheduleCarousel();
+    void ensureTransmitter();
+    void errorInCarousel(const std::string &reason, ObjectPackager::PackagingFailedEvent::FailureType fail_type);
+    void objectSendCompletion(std::string &object_id, bool queue_empty);
+    void startScheduler();
+    void abortScheduler();
+
+    std::unique_ptr<std::recursive_mutex> m_packageItemsMutex;
+    std::list<PackageItem> m_packageItems;
+    std::condition_variable_any m_packagingUpdateCondVar;
+    std::optional<boost::asio::ip::udp::endpoint> m_tunnelEndpoint;
+    std::unique_ptr<std::recursive_mutex> m_streamToisMutex;
+    std::vector<uint32_t> m_streamTois;
+    std::thread m_schedulingThread;
+    std::atomic_bool m_schedulingRunning;
+    std::atomic_bool m_schedulingCancel;
+    size_t m_maxStreams;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* _MBS_TF_OBJECT_CAROUSEL_PACKAGER_HH_ */

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -107,8 +107,9 @@ void ObjectController::processEvent(Event &event, SubscriptionService &event_ser
         DistSessionState inactive_state;
         inactive_state = DistSessionState::VAL_INACTIVE;
         distributionSession().setState(inactive_state);
-    } else if (event.eventName() == "ObjectAdded") {
-        /* object successfully added to the object store */
+    } else if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
+               event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
+        /* object successfully added/updated to the object store */
         m_consecutiveIngestFailures = 0;
     }
 }

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -1,7 +1,7 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: ObjectController class
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectController class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
@@ -100,6 +100,13 @@ void ObjectController::processEvent(Event &event, SubscriptionService &event_ser
             inactive_state = DistSessionState::VAL_INACTIVE;
             distributionSession().setState(inactive_state);
         }
+    } else if (event.eventName() == ObjectPackager::PackagingFailedEvent::event_name) {
+        ObjectPackager::PackagingFailedEvent &packaging_failed_event = dynamic_cast<ObjectPackager::PackagingFailedEvent&>(event);
+        ogs_debug("Object packaging failed: reason = (%i) %s", packaging_failed_event.failureType(), packaging_failed_event.reason().c_str());
+        sendEventSynchronous(event); /* repeat packaging failure event to subscribers of this ObjectController */
+        DistSessionState inactive_state;
+        inactive_state = DistSessionState::VAL_INACTIVE;
+        distributionSession().setState(inactive_state);
     } else if (event.eventName() == "ObjectAdded") {
         /* object successfully added to the object store */
         m_consecutiveIngestFailures = 0;
@@ -117,7 +124,7 @@ std::string ObjectController::nextObjectId()
 const std::shared_ptr<ObjectPackager> &ObjectController::packager(ObjectPackager *packager)
 {
     m_packager.reset(packager);
-    subscribeTo({"ObjectSendCompleted"}, *m_packager.get());
+    subscribeTo({ObjectPackager::ObjectSendCompleted::event_name, ObjectPackager::PackagingFailedEvent::event_name}, *m_packager.get());
     return m_packager;
 }
 

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -23,11 +23,14 @@
 #include "ObjectPackager.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "openapi/model/CreateReqData.h"
 #include "openapi/model/DistSessionState.h"
 
 #include "ObjectController.hh"
 
 using reftools::mbstf::DistSessionState;
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
 
 MBSTF_NAMESPACE_START
 
@@ -73,18 +76,18 @@ const std::shared_ptr<PushObjectIngester> &ObjectController::pushObjectIngester(
 void ObjectController::processEvent(Event &event, SubscriptionService &event_service)
 {
     if (event.eventName() == "ObjectSendCompleted") {
-	ObjectPackager::ObjectSendCompleted &objSendEvent = dynamic_cast<ObjectPackager::ObjectSendCompleted&>(event);
+        ObjectPackager::ObjectSendCompleted &objSendEvent = dynamic_cast<ObjectPackager::ObjectSendCompleted&>(event);
         std::string object_id = objSendEvent.objectId();
         ogs_info("Object [%s] sent", object_id.c_str());
 
-	const ObjectStore::Metadata &metadata = objectStore().getMetadata(object_id);
+        const ObjectStore::Metadata &metadata = objectStore().getMetadata(object_id);
 
-	if(!metadata.keepAfterSend()) {
+        if(!metadata.keepAfterSend()) {
 
-	    objectStore().deleteObject(object_id);
-	} else {
+            objectStore().deleteObject(object_id);
+        } else {
             ogs_debug("Keeping object [%s] in object store after sending...", object_id.c_str());
-	}
+        }
 
         if (objSendEvent.queueEmpty()) {
             distributionSession().haveEmptyQueue();
@@ -167,6 +170,26 @@ void ObjectController::deactivateOutput()
 void ObjectController::flushPackagerQueue()
 {
     if (m_packager) m_packager->flushQueue();
+}
+
+void ObjectController::validateDistributionSession(DistributionSession &distribution_session)
+{
+    const auto &create_req_data = distribution_session.distributionSessionReqData();
+    if (!create_req_data) {
+        throw ModelException("CreateReqData missing", "ObjectController", std::string(), ProblemCause::MANDATORY_IE_MISSING);
+    }
+    const auto &dist_session = create_req_data->getDistSession();
+    if (!dist_session) {
+        throw ModelException("distSession missing", "ObjectController", "distSession", ProblemCause::MANDATORY_IE_MISSING);
+    }
+    const auto &up_traffic_flow_info = dist_session->getUpTrafficFlowInfo();
+    if (!up_traffic_flow_info || !up_traffic_flow_info.value()) {
+        throw ModelException("Object distribution operating mode requires upTrafficFlowInfo", "ObjectController", "distSession.upTrafficFlowInfo", ProblemCause::MANDATORY_IE_MISSING);
+    }
+    const auto &obj_distr_data = dist_session->getObjDistributionData();
+    if (!obj_distr_data || !obj_distr_data.value()) {
+        throw ModelException("Object distribution operating mode requires objDistributionData", "ObjectController", "distSession.objDistributionData", ProblemCause::MANDATORY_IE_MISSING);
+    }
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OBJECT_CONTROLLER_HH_
 #define _MBS_TF_OBJECT_CONTROLLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Controller base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Controller base class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -35,7 +35,7 @@ public:
     ObjectController() = delete;
     ObjectController(DistributionSession &distributionSession)
         :Controller(distributionSession)
-	,Subscriber()
+        ,Subscriber()
         ,m_objectStore(new ObjectStore(*this))
         ,m_pullIngesters()
         ,m_pushIngester()
@@ -84,6 +84,8 @@ public:
     virtual void activateOutput();          /* Active state for DistSession */
     virtual void deactivateOutput();        /* Deactivating state for DistSession */
     virtual void flushPackagerQueue();      /* Ensure there are no objects queued for packaging */
+
+    static void validateDistributionSession(DistributionSession &distribution_session);
 
 protected:
     const std::shared_ptr<PullObjectIngester> &addPullObjectIngester(const std::shared_ptr<PullObjectIngester> &pull_obj_ingester);

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -46,7 +46,13 @@ public:
     ObjectController(const ObjectController &) = delete;
     ObjectController(ObjectController &&) = delete;
 
-    virtual ~ObjectController() {};
+    virtual ~ObjectController() {
+        m_pushIngester.reset();
+        std::lock_guard<decltype(m_pullObjectIngestersMutex)> lock(m_pullObjectIngestersMutex);
+        m_pullIngesters.clear();
+        m_packager.reset();
+        m_objectStore.reset();
+    };
 
     ObjectController &operator=(const ObjectController &) = delete;
     ObjectController &operator=(ObjectController &&) = delete;

--- a/src/mbstf/ObjectIngester.cc
+++ b/src/mbstf/ObjectIngester.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Ingester base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Ingester base class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectIngester.hh
+++ b/src/mbstf/ObjectIngester.hh
@@ -69,6 +69,7 @@ public:
 
     void abort() {
 	m_workerCancel = true;
+        cancelWorker();
         if (m_workerThread.get_id() != std::this_thread::get_id() && m_workerThread.joinable()) {
 	    m_workerThread.join();
         }
@@ -88,6 +89,7 @@ protected:
     void startWorker(){m_workerThread = std::thread(workerLoop, this);};
 
     virtual void doObjectIngest() = 0;
+    virtual void cancelWorker() {};
 
     /* subscription events */
     void emitObjectIngestFailedEvent(const std::string &url, IngestFailedEvent::FailureType fail_type);

--- a/src/mbstf/ObjectIngester.hh
+++ b/src/mbstf/ObjectIngester.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OBJECT_INGESTER_HH_
 #define _MBS_TF_OBJECT_INGESTER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Ingester base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Ingester base class
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectIngester.hh
+++ b/src/mbstf/ObjectIngester.hh
@@ -68,15 +68,15 @@ public:
         : SubscriptionService(), m_objectStore(objectStore), m_controller(controller), m_workerThread(), m_workerCancel(false) {}
 
     void abort() {
-	m_workerCancel = true;
+        m_workerCancel = true;
         cancelWorker();
         if (m_workerThread.get_id() != std::this_thread::get_id() && m_workerThread.joinable()) {
-	    m_workerThread.join();
+            m_workerThread.join();
         }
     }
 
     virtual ~ObjectIngester() {
-	abort();
+        abort();
     }
 
     bool workerCancelled() const { return m_workerCancel; };

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: ObjectListController class
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectListController class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -33,6 +33,7 @@
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
@@ -69,14 +70,13 @@ ObjectListController::~ObjectListController()
 }
 
 void ObjectListController::setObjectPackager() {
-    std::optional<std::string> dest_ip_addr = distributionSession().getDestIpAddr();
+    auto ssm_port = distributionSession().getSsmPort();
     std::optional<std::string> tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
     const auto &obj_list = objectStore().getObjects();
-    packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore
     for (const auto &[obj_id, object] : obj_list) {
         sendToPackager(object);

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -36,10 +36,13 @@
 #include "SubscriptionService.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
+#include "openapi/model/ProblemCause.hh"
 
 #include "ObjectListController.hh"
 
 using reftools::mbstf::DistSessionState;
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
 
 MBSTF_NAMESPACE_START
 
@@ -76,15 +79,15 @@ void ObjectListController::setObjectPackager() {
     packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore
     for (const auto &[obj_id, object] : obj_list) {
-        sendToPackager(obj_id);
+        sendToPackager(object);
     }
 }
 
-void ObjectListController::sendToPackager(const std::string &objectId)
+void ObjectListController::sendToPackager(const std::shared_ptr<ObjectStore::Object> &object)
 {
-    ObjectListPackager::PackageItem item(objectId);
     auto packager = getObjectListPackager();
     if (packager) {
+        ObjectListPackager::PackageItem item(object);
         packager->add(item);
     }
 }
@@ -116,7 +119,7 @@ void ObjectListController::processEvent(Event &event, SubscriptionService &event
         std::string object_id = obj_changed_event.objectId();
         ogs_info("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
 
-        sendToPackager(object_id);
+        sendToPackager(objectStore()[object_id]);
     } else if (event.eventName() == "ObjectPushStart") {
         PushObjectIngester::ObjectPushEvent &obj_push_event = dynamic_cast<PushObjectIngester::ObjectPushEvent&>(event);
         const PushObjectIngester::Request &request(obj_push_event.request());
@@ -255,35 +258,36 @@ namespace {
 static const struct init { init() {ControllerFactory::registerController(new ControllerConstructor<ObjectListController>);};} g_init;
 }
 
-static bool validate_push_url(DistributionSession &distributionSession, const std::string &url)
+static bool validate_push_url(DistributionSession &distribution_session, const std::string &url)
 {
-    std::optional<std::string> object_acquisition_push_id = distributionSession.getObjectAcquisitionPushId();
+    std::optional<std::string> object_acquisition_push_id = distribution_session.getObjectAcquisitionPushId();
     if (object_acquisition_push_id.has_value()) {
-	std::string push_id = object_acquisition_push_id.value();
-	std::string url_path(url);
-	if ((push_id.front() == '/' && url_path.front() != '/')) {
-	    url_path = '/' + url_path;
-	} else if ((url_path.front() == '/' && push_id.front() != '/')) {
-	    push_id = '/' + push_id;
-	}
-	if(push_id == url_path) {
-	    return true;
-	} else {
-	    return false;
-	}
+        std::string push_id = object_acquisition_push_id.value();
+        std::string url_path(url);
+        if ((push_id.front() == '/' && url_path.front() != '/')) {
+            url_path = '/' + url_path;
+        } else if ((url_path.front() == '/' && push_id.front() != '/')) {
+            push_id = '/' + push_id;
+        }
+        if(push_id == url_path) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     return true;
 }
 
-static int validate_distribution_session(DistributionSession &distributionSession)
+static int validate_distribution_session(DistributionSession &distribution_session)
 {
-    if (distributionSession.getObjectAcquisitionMethod() == "PUSH" && distributionSession.getObjectDistributionOperatingMode() == "SINGLE") {
-        std::optional<std::string> object_acquisition_push_id = distributionSession.getObjectAcquisitionPushId();
+    if (distribution_session.getObjectAcquisitionMethod() == "PUSH" && distribution_session.getObjectDistributionOperatingMode() == "SINGLE") {
+        std::optional<std::string> object_acquisition_push_id = distribution_session.getObjectAcquisitionPushId();
         if (object_acquisition_push_id.has_value()) {
             return 0;
         }
     }
+    ObjectController::validateDistributionSession(distribution_session);
 
     return 1;
 }

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -109,12 +109,14 @@ std::shared_ptr<ObjectListPackager> ObjectListController::getObjectListPackager(
 }
 
 void ObjectListController::processEvent(Event &event, SubscriptionService &event_service) {
-    if (event.eventName() == "ObjectAdded") {
-        ObjectStore::ObjectAddedEvent &objAddedEvent = dynamic_cast<ObjectStore::ObjectAddedEvent&>(event);
-        std::string objectId = objAddedEvent.objectId();
-        ogs_info("Object added with ID: %s", objectId.c_str());
+    if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
+        event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
 
-        sendToPackager(objectId);
+        ObjectStore::ObjectChangedEvent &obj_changed_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
+        std::string object_id = obj_changed_event.objectId();
+        ogs_info("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
+
+        sendToPackager(object_id);
     } else if (event.eventName() == "ObjectPushStart") {
         PushObjectIngester::ObjectPushEvent &obj_push_event = dynamic_cast<PushObjectIngester::ObjectPushEvent&>(event);
         const PushObjectIngester::Request &request(obj_push_event.request());

--- a/src/mbstf/ObjectListController.hh
+++ b/src/mbstf/ObjectListController.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OBJECT_LIST_CONTROLLER_HH_
 #define _MBS_TF_OBJECT_LIST_CONTROLLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object List Controller class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object List Controller class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectListController.hh
+++ b/src/mbstf/ObjectListController.hh
@@ -19,6 +19,7 @@
 #include "common.hh"
 #include "openapi/model/ObjDistributionData.h"
 #include "ObjectController.hh"
+#include "ObjectStore.hh"
 #include "Subscriber.hh"
 
 MBSTF_NAMESPACE_START
@@ -70,7 +71,7 @@ protected:
     virtual void deactivateObjectPackager();
 
 private:
-    void sendToPackager(const std::string &objectId);
+    void sendToPackager(const std::shared_ptr<ObjectStore::Object> &object);
 
     std::string generateUUID();
 };

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -39,22 +39,42 @@ MBSTF_NAMESPACE_START
 
 // ObjectListPackager::PackageItem
 
-ObjectListPackager::PackageItem::PackageItem(const std::string &object_id, const std::optional<time_type> &deadline)
-    :m_objectId(object_id)
+ObjectListPackager::PackageItem::PackageItem()
+    :m_object()
+    ,m_deadline()
+{
+}
+
+ObjectListPackager::PackageItem::PackageItem(const std::shared_ptr<ObjectStore::Object> &object, const std::optional<time_type> &deadline)
+    :m_object(object)
     ,m_deadline(deadline)
 {
 }
 
 ObjectListPackager::PackageItem::PackageItem(const PackageItem &other)
-    :m_objectId(other.m_objectId)
+    :m_object(other.m_object)
     ,m_deadline(other.m_deadline)
 {
 }
 
 ObjectListPackager::PackageItem::PackageItem(PackageItem &&other)
-    :m_objectId(std::move(other.m_objectId))
+    :m_object(std::move(other.m_object))
     ,m_deadline(std::move(other.m_deadline))
 {
+}
+
+ObjectListPackager::PackageItem &ObjectListPackager::PackageItem::operator=(const PackageItem &other)
+{
+    m_object = other.m_object;
+    m_deadline = other.m_deadline;
+    return *this;
+}
+
+ObjectListPackager::PackageItem &ObjectListPackager::PackageItem::operator=(PackageItem &&other)
+{
+    m_object = std::move(other.m_object);
+    m_deadline = std::move(other.m_deadline);
+    return *this;
 }
 
 // ObjectListPackager
@@ -64,9 +84,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
                                        const std::optional<std::string> &address,
                                        uint32_t rateLimit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+    ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(object_to_package)
     ,m_tunnelEndpoint()
-    ,m_packageItemsMutex (new std::recursive_mutex)
 {
     sortListByPolicy();
     if (tunnel_address) {
@@ -79,9 +99,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
                                        std::list<PackageItem> &&object_to_package, const std::optional<std::string> &address,
                                        uint32_t rateLimit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+    ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(std::move(object_to_package))
     ,m_tunnelEndpoint()
-    ,m_packageItemsMutex (new std::recursive_mutex)
 {
     sortListByPolicy();
     if (tunnel_address) {
@@ -94,9 +114,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
                                        const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu,
                                        in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+    ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems()
     ,m_tunnelEndpoint()
-    ,m_packageItemsMutex (new std::recursive_mutex)
 {
     if (tunnel_address) {
         m_tunnelEndpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(tunnel_address.value()), tunnel_port);
@@ -112,7 +132,7 @@ bool ObjectListPackager::add(const PackageItem &item) {
     ogs_debug("ObjectListPackager::add(): deactivating=%s", m_deactivating?"true":"false");
     if (m_deactivating) return false;
     std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
-    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.objectId() == pkg_item.objectId(); });
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object()->second.objectId() == pkg_item.object()->second.objectId(); });
     m_packageItems.push_back(item);
     sortListByPolicy();
     return true;
@@ -122,7 +142,7 @@ bool ObjectListPackager::add(PackageItem &&item) {
     ogs_debug("ObjectListPackager::add(): deactivating=%s", m_deactivating?"true":"false");
     if (m_deactivating) return false;
     std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
-    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.objectId() == pkg_item.objectId(); });
+    m_packageItems.remove_if([&item](const PackageItem &pkg_item) -> bool { return item.object()->second.objectId() == pkg_item.object()->second.objectId(); });
     m_packageItems.push_back(std::move(item));
     sortListByPolicy();
     return true;
@@ -167,73 +187,95 @@ void ObjectListPackager::doObjectPackage() {
 
     if (!destAddr) return;
 
-    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+    {
+        std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
 
-    if (!m_transmitter) {
-        m_transmitter.reset(new LibFlute::Transmitter(
-                destAddr.value(),
-                static_cast<short>(port()),
-                0,
-                mtu(),
-                rateLimit(),
-                m_io,
-                m_tunnelEndpoint,
-                LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
-        m_transmitter->register_completion_callback(
-                [this](uint32_t toi) {
-                    ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
-                    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
-                    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
-                    if (m_queuedToi == toi) {
-                        m_queued = false;
-                        objectSendCompletion(m_queuedObjectId, queue_empty);
-                        ogs_info("Transmitted: Object with TOI: %d", toi);
-                    } else {
-                        ogs_error("Unscheduled completion of Object with TOI: %d", toi);
-                    }
-                    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
-                    if (m_deactivating && queue_empty) {
-                        ogs_debug("Deactivating FLUTE stream on last file");
-                        m_transmitter->deactivate();
-                        abort();
-                        m_deactivating = false;
-                    }
-                });
+        if (!m_transmitter) {
+            m_transmitter.reset(new LibFlute::Transmitter(
+                    destAddr.value(),
+                    static_cast<short>(port()),
+                    0,
+                    mtu(),
+                    rateLimit(),
+                    m_io,
+                    m_tunnelEndpoint,
+                    LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
+            m_transmitter->register_completion_callback(
+                    [this](uint32_t toi) {
+                        ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+                        bool queue_empty;
+                        {
+                            std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+                            queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+                        }
+                        if (m_queuedToi == toi) {
+                            m_queued = false;
+                            m_currentObject.reset();
+                            objectSendCompletion(m_queuedObjectId, queue_empty);
+                            ogs_info("Transmitted: Object with TOI: %d", toi);
+                        } else {
+                            ogs_error("Unscheduled completion of Object with TOI: %d", toi);
+                        }
+                        if (m_deactivating && queue_empty) {
+                            ogs_debug("Deactivating FLUTE stream on last file");
+                            {
+                                std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+                                m_transmitter->deactivate();
+                            }
+                            abort();
+                            m_deactivating = false;
+                        }
+                    });
 
-        // emitFluteSessionStartedEvent();
+            // emitFluteSessionStartedEvent();
+        }
     }
+
+    PackageItem item;
 
     {
         std::lock_guard<std::recursive_mutex> lock(*m_packageItemsMutex);
 
         if (!m_packageItems.empty() && !m_queued) {
-            auto &item = m_packageItems.front();
-            m_packageItemsMutex->unlock();
-            std::string location;
-            m_queuedObjectId = item.objectId();
-            std::vector<unsigned char> &objData = objectStore().getObjectData(item.objectId());
-            ObjectStore::Metadata &metadata = objectStore().getMetadata(item.objectId());
-            std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
-            std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
+            item = m_packageItems.front();
+            m_packageItems.pop_front();
+        }
+    }
 
-            // If we need to substitute objIngestBaseUrl for objDistributionBaseUrl then do so
-            if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
-                metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
-                location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
-            } else {
-                // Just use the fetched URL
-                location = metadata.getFetchedUrl();
-            }
-            std::shared_ptr<LibFlute::Transmitter::FileDescription> file_desc(metadata.fluteFileDescription());
+    if (item) {
+        std::string location;
+        m_currentObject = item.object();
+        m_queuedObjectId = m_currentObject->second.objectId();
+        std::vector<unsigned char> &objData = m_currentObject->first;
+        ObjectStore::Metadata &metadata = m_currentObject->second;
+        std::string obj_ingest_base_url = metadata.objIngestBaseUrl().value_or(std::string());
+        std::string obj_distribution_base_url = metadata.objDistributionBaseUrl().value_or(std::string());
+
+        // If we need to substitute objIngestBaseUrl for objDistributionBaseUrl then do so
+        if (!obj_ingest_base_url.empty() && !obj_distribution_base_url.empty() &&
+            metadata.getFetchedUrl().starts_with(obj_ingest_base_url)) {
+            location = obj_distribution_base_url + metadata.getFetchedUrl().substr(obj_ingest_base_url.size());
+        } else {
+            // Just use the fetched URL
+            location = metadata.getFetchedUrl();
+        }
+        std::shared_ptr<LibFlute::Transmitter::FileDescription> file_desc(metadata.fluteFileDescription());
+        {
+            std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
             if (!file_desc) {
                 ogs_debug("New FileDescription(%s, ...)", location.c_str());
                 file_desc.reset(new LibFlute::Transmitter::FileDescription(location, objData));
                 metadata.fluteFileDescription(file_desc);
             } else {
                 ogs_debug("Existing FileDescription(%s, ...)", file_desc->file_entry().content_location.c_str());
-                file_desc->set_content_location(location);
-                ogs_debug("Set FileDescription location to %s", location.c_str());
-                file_desc->set_content(objData);
+                if (file_desc->file_entry().content_location != location) {
+                    file_desc->set_content_location(location);
+                    ogs_debug("Set FileDescription location to %s", location.c_str());
+                }
+                if (file_desc->data() != reinterpret_cast<const char*>(objData.data())) {
+                    file_desc->set_content(objData);
+                    ogs_debug("Set FileDescription object data");
+                }
             }
 
             m_queued = true;
@@ -253,13 +295,7 @@ void ObjectListPackager::doObjectPackage() {
                 file_desc->set_etag(entity_tag.value());
             }
 
-            {
-                std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
-                m_queuedToi = m_transmitter->send(file_desc);
-            }
-
-            m_packageItemsMutex->lock();
-            m_packageItems.pop_front();
+            m_queuedToi = m_transmitter->send(file_desc);
         }
     }
 
@@ -289,15 +325,20 @@ void ObjectListPackager::flushQueue()
 
 bool ObjectListPackager::deactivate()
 {
-    std::lock_guard<decltype(m_deactivateMutex)> guard(m_deactivateMutex);
     m_deactivating = true;
-    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
-    ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
-    bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+    bool queue_empty;
+    {
+        std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+        ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+        queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
+    }
     if (queue_empty) {
         ogs_debug("Deactivating FLUTE stream, no files to purge");
         abort();
-        m_transmitter->deactivate();
+        {
+            std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+            m_transmitter->deactivate();
+        }
         m_deactivating = false;
         return true;
     }

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -30,6 +30,7 @@
 #include "ObjectListController.hh"
 #include "ObjectPackager.hh"
 #include "ObjectStore.hh"
+#include "SsmPort.hh"
 
 #include "ObjectListPackager.hh"
 
@@ -80,10 +81,10 @@ ObjectListPackager::PackageItem &ObjectListPackager::PackageItem::operator=(Pack
 // ObjectListPackager
 
 ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                                       const std::list<PackageItem> &object_to_package,
-                                       const std::optional<std::string> &address,
-                                       uint32_t rateLimit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+                                       const std::list<PackageItem> &object_to_package, const SsmPort &ssm_port,
+                                       uint32_t rateLimit, unsigned short mtu, const std::optional<std::string> &tunnel_address,
+                                       in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(object_to_package)
     ,m_tunnelEndpoint()
@@ -96,9 +97,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
 }
 
 ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                                       std::list<PackageItem> &&object_to_package, const std::optional<std::string> &address,
-                                       uint32_t rateLimit, unsigned short mtu, in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+                                       std::list<PackageItem> &&object_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
+                                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems(std::move(object_to_package))
     ,m_tunnelEndpoint()
@@ -111,9 +112,9 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
 }
 
 ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu,
-                                       in_port_t port, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
-    :ObjectPackager(object_store, controller, address, rateLimit, mtu, port, tunnel_address, tunnel_port)
+                                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
+                                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
+    :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
     ,m_packageItemsMutex (new decltype(m_packageItemsMutex)::element_type)
     ,m_packageItems()
     ,m_tunnelEndpoint()
@@ -148,8 +149,7 @@ bool ObjectListPackager::add(PackageItem &&item) {
     return true;
 }
 
-bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t port,
-                                         uint32_t rateLimit,
+bool ObjectListPackager::updateFluteInfo(const SsmPort &ssm_port, uint32_t rateLimit,
                                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
 {
     std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
@@ -157,10 +157,18 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
     /* Do nothing if we don't have a Transmitter */
     if (!m_transmitter) return false;
 
-    /* set destination endpoint address if it has changed */
-    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(address), port);
+    /* set SSM address if it has changed */
+    boost::asio::ip::udp::endpoint dest_addr(boost::asio::ip::make_address(ssm_port.destinationAddress()), ssm_port.port());
     if (dest_addr != m_transmitter->endpoint()) {
         m_transmitter->endpoint(dest_addr);
+    }
+    const auto &source_addr = ssm_port.sourceAddress();
+    std::optional<boost::asio::ip::address> src_addr;
+    if (source_addr) {
+        src_addr = boost::asio::ip::make_address(source_addr.value());
+    }
+    if (src_addr != m_transmitter->source_address()) {
+        m_transmitter->source_address(src_addr);
     }
 
     /* set new MBR if it has changed */
@@ -183,23 +191,25 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
 }
 
 void ObjectListPackager::doObjectPackage() {
-    std::optional<std::string> destAddr = destIpAddr();
+    const SsmPort &ssm_port = ssmPort();
 
-    if (!destAddr) return;
+    if (!ssm_port) return;
 
     {
         std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
 
         if (!m_transmitter) {
             m_transmitter.reset(new LibFlute::Transmitter(
-                    destAddr.value(),
-                    static_cast<short>(port()),
-                    0,
+                    ssm_port.destinationAddress(),
+                    static_cast<short>(ssm_port.port()),
+                    tsi(),
                     mtu(),
                     rateLimit(),
                     m_io,
                     m_tunnelEndpoint,
-                    LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
+                    LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005,
+                    true,
+                    ssm_port.sourceAddress()));
             m_transmitter->register_completion_callback(
                     [this](uint32_t toi) {
                         ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: ObjectListPackager class
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectListPackager class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this
@@ -105,10 +106,6 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
 
 ObjectListPackager::~ObjectListPackager() {
     abort();
-    if (m_transmitter) {
-        delete m_transmitter;
-        m_transmitter = NULL;
-    }
 }
 
 bool ObjectListPackager::add(const PackageItem &item) {
@@ -135,6 +132,8 @@ bool ObjectListPackager::updateFluteInfo(const std::string &address, in_port_t p
                                          uint32_t rateLimit,
                                          const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
 {
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+
     /* Do nothing if we don't have a Transmitter */
     if (!m_transmitter) return false;
 
@@ -168,8 +167,10 @@ void ObjectListPackager::doObjectPackage() {
 
     if (!destAddr) return;
 
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+
     if (!m_transmitter) {
-        m_transmitter = new LibFlute::Transmitter(
+        m_transmitter.reset(new LibFlute::Transmitter(
                 destAddr.value(),
                 static_cast<short>(port()),
                 0,
@@ -177,10 +178,11 @@ void ObjectListPackager::doObjectPackage() {
                 rateLimit(),
                 m_io,
                 m_tunnelEndpoint,
-                LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005);
+                LibFlute::FileDeliveryTable::FDT_NS_DRAFT_2005));
         m_transmitter->register_completion_callback(
                 [this](uint32_t toi) {
                     ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
+                    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
                     bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
                     if (m_queuedToi == toi) {
                         m_queued = false;
@@ -251,7 +253,10 @@ void ObjectListPackager::doObjectPackage() {
                 file_desc->set_etag(entity_tag.value());
             }
 
-            m_queuedToi = m_transmitter->send(file_desc);
+            {
+                std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+                m_queuedToi = m_transmitter->send(file_desc);
+            }
 
             m_packageItemsMutex->lock();
             m_packageItems.pop_front();
@@ -284,8 +289,9 @@ void ObjectListPackager::flushQueue()
 
 bool ObjectListPackager::deactivate()
 {
-    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
+    std::lock_guard<decltype(m_deactivateMutex)> guard(m_deactivateMutex);
     m_deactivating = true;
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
     ogs_debug("FLUTE Transmitter has %zu files left, packager has %zu files left", m_transmitter->number_of_files(), m_packageItems.size());
     bool queue_empty = (m_transmitter->number_of_files() + m_packageItems.size() == 0);
     if (queue_empty) {

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -66,23 +66,20 @@ public:
 
     ObjectListPackager() = delete;
     ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
-                       const std::list<PackageItem> &object_to_package, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+                       const std::list<PackageItem> &object_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
+                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     ObjectListPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&object_to_package,
-                       const std::optional<std::string> &address, uint32_t rateLimit, unsigned short mtu, in_port_t port,
+                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectListPackager(ObjectStore &object_store, ObjectController &controller, const std::optional<std::string> &address,
-                       uint32_t rateLimit, unsigned short mtu, in_port_t port,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectListPackager(ObjectStore &object_store, ObjectController &controller, const SsmPort &ssm_port, uint32_t rateLimit,
+                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     virtual ~ObjectListPackager();
 
     bool add(const PackageItem &item);
     bool add(PackageItem &&item);
 
-    bool updateFluteInfo(const std::string &address, in_port_t port,
-                         uint32_t rateLimit,
-                         const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    bool updateFluteInfo(const SsmPort &ssm_port, uint32_t rateLimit, const std::optional<std::string> &tunnel_address,
+                         in_port_t tunnel_port);
 
     virtual bool deactivate();
     virtual void flushQueue();

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OBJECT_LIST_PACKAGER_HH_
 #define _MBS_TF_OBJECT_LIST_PACKAGER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object List Packager class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object List Packager class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -24,11 +24,11 @@
 
 #include "common.hh"
 #include "ObjectPackager.hh"
+#include "ObjectStore.hh"
 
 MBSTF_NAMESPACE_START
 
 class ObjectController;
-class ObjectStore;
 
 class ObjectListPackager : public ObjectPackager {
 public:
@@ -36,15 +36,21 @@ public:
 
     class PackageItem {
     public:
-        PackageItem() = delete;
-        PackageItem(const std::string &object_id, const std::optional<time_type> &deadline = std::nullopt);
+        PackageItem();
+        PackageItem(const std::shared_ptr<ObjectStore::Object> &object, const std::optional<time_type> &deadline = std::nullopt);
         PackageItem(const PackageItem &other);
         PackageItem(PackageItem &&other);
         virtual ~PackageItem() {};
 
-        const std::string &objectId() const { return m_objectId; }
-        PackageItem &objectId(const std::string &object_id) { m_objectId = object_id; return *this; }
-        PackageItem &objectId(std::string &&object_id) { m_objectId = std::move(object_id); return *this; }
+        PackageItem &operator=(const PackageItem &other);
+        PackageItem &operator=(PackageItem &&other);
+
+        operator bool() const { return !!m_object; };
+
+        const std::shared_ptr<ObjectStore::Object> &object() { return m_object; };
+        std::shared_ptr<const ObjectStore::Object> object() const { return m_object; };
+        PackageItem &object(const std::shared_ptr<ObjectStore::Object> &object) { m_object = object; return *this; };
+        PackageItem &object(std::shared_ptr<ObjectStore::Object> &&object) { m_object = std::move(object); return *this; };
 
         bool hasDeadline() const { return m_deadline.has_value(); }
         const std::optional<time_type> &deadline() const { return m_deadline; }
@@ -54,7 +60,7 @@ public:
         PackageItem &deadline(time_type &&deadline) { m_deadline = std::move(deadline); return *this; }
 
     private:
-        std::string m_objectId;
+        std::shared_ptr<ObjectStore::Object> m_object;
         std::optional<time_type> m_deadline;
     };
 
@@ -87,9 +93,11 @@ protected:
 private:
     void sortListByPolicy();
     void objectSendCompletion(std::string &object_id, bool queue_empty);
+
+    std::unique_ptr<std::recursive_mutex> m_packageItemsMutex;
     std::list<PackageItem> m_packageItems;
     std::optional<boost::asio::ip::udp::endpoint> m_tunnelEndpoint;
-    std::unique_ptr<std::recursive_mutex> m_packageItemsMutex;
+    std::shared_ptr<ObjectStore::Object> m_currentObject;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: ObjectManifestController class
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectManifestController class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this
@@ -26,6 +27,7 @@
 #include "DistributionSession.hh"
 #include "Event.hh"
 #include "ObjectController.hh"
+#include "ObjectManifestHandler.hh"
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
@@ -43,6 +45,8 @@ static bool validate_push_url(DistributionSession &distributionSession, const st
 static void validate_pull_acquisition_method(DistributionSession &distributionSession);
 static bool validate_push_acquisition_method(DistributionSession &distributionSession);
 
+/* ObjectManifestController public methods */
+
 ObjectManifestController::ObjectManifestController(DistributionSession &dist_session)
         :ObjectController(dist_session)
         ,m_manifestHandler(nullptr)
@@ -52,192 +56,6 @@ ObjectManifestController::ObjectManifestController(DistributionSession &dist_ses
     validate_pull_acquisition_method(dist_session);
     validate_push_acquisition_method(dist_session);
 };
-
-
-void ObjectManifestController::initPullObjectIngesters()
-{
-    const std::optional<std::string> &object_ingest_base_url = distributionSession().getObjectIngestBaseUrl();
-    const std::optional<std::string> &object_distribution_base_url = distributionSession().objectDistributionBaseUrl();
-
-    auto &pull_urls = distributionSession().getObjectAcquisitionPullUrls();
-    if (pull_urls.has_value()) {
-        std::list<PullObjectIngester::IngestItem> urls;
-
-        for (auto &url : pull_urls.value()) {
-            std::string obj_ingest_url;
-
-            if (url.has_value()) {
-                const std::string &url_str = url.value();
-                if (object_ingest_base_url.has_value()) {
-                    if (url_str.starts_with("https:") || url_str.starts_with("http:") || url_str.starts_with("//")) {
-                        ogs_error("Invalid objectAcquisitionPullUrl when objectIngestBaseUrl is set: %s", url.value().c_str());
-                        continue;
-                    } else {
-                        obj_ingest_url = object_ingest_base_url.value();
-                        if (!obj_ingest_url.ends_with("/")) obj_ingest_url += "/";
-                        obj_ingest_url += trim_slashes(url_str);
-                    }
-
-                }
-
-                const auto *metadata = objectStore().findMetadataByURL(obj_ingest_url);
-                if (metadata) {
-                    /* this is a refetch */
-                    urls.emplace_back(*metadata);
-                } else {
-                    /* this is a new URL */
-                    urls.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url);
-                }
-            }
-        }
-
-        addPullObjectIngester(new PullObjectIngester(objectStore(), *this, urls));
-    }
-}
-
-
-void ObjectManifestController::initPushObjectIngester()
-{
-    const std::string objIngestBaseUrl;
-
-    PushObjectIngester *push_ingester = new PushObjectIngester(objectStore(), *this);
-
-    distributionSession().setObjectIngestBaseUrl(push_ingester->getIngestServerPrefix());
-    subscribeTo({"ObjectPushStart"}, *push_ingester);
-    pushObjectIngester(push_ingester);
-}
-
-std::string ObjectManifestController::nextObjectId()
-{
-    return generateUUID();
-}
-
-std::string ObjectManifestController::generateUUID()
-{
-    uuid_t uuid;
-    uuid_generate_random(uuid);
-    char uuid_str[37];
-    uuid_unparse(uuid, uuid_str);
-    return std::string(uuid_str);
-}
-
-void ObjectManifestController::workerLoop(ObjectManifestController *controller)
-{
-    controller->m_scheduledPullRunning = true;
-    /* Don't process if the session is inactive or deactivating */
-    {
-        const auto &session_state = controller->distributionSession().getState();
-        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
-            controller->m_scheduledPullRunning = false;
-            return;
-        }
-    }
-
-    /* wait for a ManifestHandler to be created */
-    while (true) {
-        {
-            std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
-            if (controller->m_scheduledPullCancel || controller->m_manifestHandler != nullptr) {
-                break;
-            }
-            const auto &session_state = controller->distributionSession().getState();
-            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
-                controller->m_scheduledPullRunning = false;
-                return;
-            }
-        }
-        // Avoid a tight busy-loop: yield or sleep for a short time.
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-
-    if (controller->m_scheduledPullCancel) {
-        controller->m_scheduledPullRunning = false;
-        return;
-    }
-
-    {
-        const auto &session_state = controller->distributionSession().getState();
-        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
-            controller->m_scheduledPullRunning = false;
-            return;
-        }
-    }
-
-    while (!controller->m_scheduledPullCancel) {
-        {
-            const auto &session_state = controller->distributionSession().getState();
-            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
-                controller->m_scheduledPullRunning = false;
-                return;
-            }
-        }
-
-        std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> next_ingest_items;
-        ManifestHandler::durn_type default_deadline;
-        // Get the next ingest items
-	try {
-            std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
-            next_ingest_items = controller->manifestHandler()->nextIngestItems();
-            default_deadline = controller->manifestHandler()->getDefaultDeadline();
-	} catch ( std::domain_error &err) {
-	    ogs_error("Next Ingest Item: %s", err.what());
-	}
-
-	if (next_ingest_items.second.empty()) break;
-
-	auto fetch_time = next_ingest_items.first; // Get fetch_time using .first
-
-	std::list<PullObjectIngester::IngestItem> urls;
-
-        {
-            std::lock_guard<std::recursive_mutex> lock(controller->m_pullObjectIngestersMutex);
-            auto &ingesters = controller->getPullObjectIngesters();
-            while (ingesters.size() < next_ingest_items.second.size()) {
-	        controller->addPullObjectIngester(new PullObjectIngester(controller->objectStore(), *controller, urls));
-            }
-	}
-
-        // Wait until the fetch_time
-	{
-            std::ostringstream oss;
-	    oss << fetch_time ;
-	    ogs_debug("Sleeping until...%s", oss.str().c_str());
-	}
-	std::this_thread::sleep_until(fetch_time);
-        {
-            const auto &session_state = controller->distributionSession().getState();
-            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
-                controller->m_scheduledPullRunning = false;
-                return;
-            }
-        }
-
-        {
-            std::lock_guard<std::recursive_mutex> lock(controller->m_pullObjectIngestersMutex);
-            // Add the URLs to the PullObjectIngester instances
-            auto &ingesters = controller->getPullObjectIngesters();
-            for (auto ingester_it = ingesters.begin(); ingester_it!= ingesters.end(); ++ingester_it) {
-                if (next_ingest_items.second.empty()) break;
-                auto ingest_item = next_ingest_items.second.front();
-                next_ingest_items.second.pop_front();  // remove the item
-	        //ingest_item.deadline(std::nullopt);
-                ingest_item.deadline(std::chrono::system_clock::now() + default_deadline);
-                if (!(*ingester_it)->fetch(ingest_item)) {
-                    ogs_debug("Failed to fetch item: %s", ingest_item.url().c_str());
-                }
-            }
-	}
-    }
-    controller->m_scheduledPullRunning = false;
-}
-
-void ObjectManifestController::startWorker()
-{
-    if (!m_scheduledPullRunning) {
-        if (m_scheduledPullThread.joinable()) m_scheduledPullThread.detach();
-        m_scheduledPullThread = std::thread(&ObjectManifestController::workerLoop, this);
-    }
-}
 
 void ObjectManifestController::processEvent(Event &event, SubscriptionService &event_service)
 {
@@ -252,6 +70,8 @@ void ObjectManifestController::processEvent(Event &event, SubscriptionService &e
             event.preventDefault();
         }
         // event.preventDefault() if checks fail
+    } else if (event.eventName() == ObjectManifestHandler::ObjectManifestChangeEvent::event_name) {
+        m_manifestHandlerChange.notify_all();
     }
     ObjectController::processEvent(event, event_service);
 
@@ -262,7 +82,6 @@ std::string &ObjectManifestController::getManifestUrl()
     manifestUrl();
     return m_manifestUrl;
 }
-
 
 void ObjectManifestController::manifestUrl()
 {
@@ -329,6 +148,229 @@ void ObjectManifestController::reconfigurePullObjectIngesters()
         initPullObjectIngesters();
     }
 }
+
+/* ObjectManifestController protected */
+
+void ObjectManifestController::startWorker()
+{
+    if (!m_scheduledPullRunning) {
+        if (m_scheduledPullThread.joinable()) m_scheduledPullThread.detach();
+        m_scheduledPullThread = std::thread(&ObjectManifestController::workerLoop, this);
+    }
+}
+
+void ObjectManifestController::initPullObjectIngesters()
+{
+    const std::optional<std::string> &object_ingest_base_url = distributionSession().getObjectIngestBaseUrl();
+    const std::optional<std::string> &object_distribution_base_url = distributionSession().objectDistributionBaseUrl();
+
+    auto &pull_urls = distributionSession().getObjectAcquisitionPullUrls();
+    if (pull_urls.has_value()) {
+        std::list<PullObjectIngester::IngestItem> urls;
+
+        for (auto &url : pull_urls.value()) {
+            std::string obj_ingest_url;
+
+            if (url.has_value()) {
+                const std::string &url_str = url.value();
+                if (object_ingest_base_url.has_value()) {
+                    if (url_str.starts_with("https:") || url_str.starts_with("http:") || url_str.starts_with("//")) {
+                        ogs_error("Invalid objectAcquisitionPullUrl when objectIngestBaseUrl is set: %s", url.value().c_str());
+                        continue;
+                    } else {
+                        obj_ingest_url = object_ingest_base_url.value();
+                        if (!obj_ingest_url.ends_with("/")) obj_ingest_url += "/";
+                        obj_ingest_url += trim_slashes(url_str);
+                    }
+
+                }
+
+                const auto *metadata = objectStore().findMetadataByURL(obj_ingest_url);
+                if (metadata) {
+                    /* this is a refetch */
+                    urls.emplace_back(*metadata);
+                } else {
+                    /* this is a new URL */
+                    urls.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url);
+                }
+            }
+        }
+
+        addPullObjectIngester(new PullObjectIngester(objectStore(), *this, urls));
+    }
+}
+
+void ObjectManifestController::initPushObjectIngester()
+{
+    const std::string objIngestBaseUrl;
+
+    PushObjectIngester *push_ingester = new PushObjectIngester(objectStore(), *this);
+
+    distributionSession().setObjectIngestBaseUrl(push_ingester->getIngestServerPrefix());
+    subscribeTo({"ObjectPushStart"}, *push_ingester);
+    pushObjectIngester(push_ingester);
+}
+
+ObjectManifestController &ObjectManifestController::manifestHandler(std::shared_ptr<ManifestHandler> &&manifest_handler)
+{
+    std::lock_guard guard(m_manifestHandlerMutex);
+    m_manifestHandler = std::move(manifest_handler);
+    subscribeTo({ObjectManifestHandler::ObjectManifestChangeEvent::event_name}, *m_manifestHandler);
+    m_manifestHandlerChange.notify_all();
+    return *this;
+}
+
+const std::shared_ptr<ManifestHandler> &ObjectManifestController::manifestHandler() const
+{
+    std::lock_guard guard(m_manifestHandlerMutex);
+    return m_manifestHandler;
+}
+
+std::string ObjectManifestController::nextObjectId()
+{
+    return generateUUID();
+}
+
+/* ObjectManifestController private */
+
+void ObjectManifestController::workerLoop(ObjectManifestController *controller)
+{
+    controller->m_scheduledPullRunning = true;
+    /* Don't process if the session is inactive or deactivating */
+    {
+        const auto &session_state = controller->distributionSession().getState();
+        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+            controller->m_scheduledPullRunning = false;
+            return;
+        }
+    }
+
+    /* wait for a ManifestHandler to be created */
+    while (true) {
+        {
+            std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
+            if (controller->m_scheduledPullCancel || controller->m_manifestHandler) {
+                break;
+            }
+            const auto &session_state = controller->distributionSession().getState();
+            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+                controller->m_scheduledPullRunning = false;
+                return;
+            }
+        }
+        // Avoid a tight busy-loop: yield or sleep for a short time.
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    if (controller->m_scheduledPullCancel) {
+        controller->m_scheduledPullRunning = false;
+        return;
+    }
+
+    {
+        const auto &session_state = controller->distributionSession().getState();
+        if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+            controller->m_scheduledPullRunning = false;
+            return;
+        }
+    }
+
+    while (!controller->m_scheduledPullCancel) {
+        {
+            const auto &session_state = controller->distributionSession().getState();
+            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+                controller->m_scheduledPullRunning = false;
+                return;
+            }
+        }
+
+        std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> next_ingest_items;
+        ManifestHandler::durn_type default_deadline;
+        // Get the next ingest items
+	try {
+            std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
+            next_ingest_items = controller->manifestHandler()->nextIngestItems();
+            default_deadline = controller->manifestHandler()->getDefaultDeadline();
+	} catch ( std::domain_error &err) {
+	    ogs_error("While fetching next manifest ingest item: %s", err.what());
+	}
+
+	if (next_ingest_items.second.empty()) break;
+
+	auto fetch_time = next_ingest_items.first; // Get fetch_time using .first
+
+	std::list<PullObjectIngester::IngestItem> urls;
+
+        {
+            std::lock_guard<std::recursive_mutex> lock(controller->m_pullObjectIngestersMutex);
+            auto &ingesters = controller->getPullObjectIngesters();
+            while (ingesters.size() < next_ingest_items.second.size()) {
+	        controller->addPullObjectIngester(new PullObjectIngester(controller->objectStore(), *controller, urls));
+            }
+	}
+
+        // Wait until the fetch_time
+	{
+            std::ostringstream oss;
+	    oss << fetch_time ;
+	    ogs_debug("Sleeping until...%s", oss.str().c_str());
+	}
+
+        {
+            std::unique_lock<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
+            if (controller->m_manifestHandlerChange.wait_until(lock, fetch_time)
+                    == std::cv_status::no_timeout) {
+                /* ingest items updated before time of the next fetch, so go to next loop */
+                ogs_debug("Ingest list updated, reassessing next ingest items");
+                continue;
+            }
+        }
+
+        {
+            const auto &session_state = controller->distributionSession().getState();
+            if (session_state == DistSessionState::VAL_INACTIVE || session_state == DistSessionState::VAL_DEACTIVATING) {
+                controller->m_scheduledPullRunning = false;
+                return;
+            }
+        }
+
+        {
+            std::lock_guard<std::recursive_mutex> lock(controller->m_pullObjectIngestersMutex);
+            // Add the URLs to the PullObjectIngester instances
+            auto &ingesters = controller->getPullObjectIngesters();
+            for (auto ingester_it = ingesters.begin(); ingester_it!= ingesters.end(); ++ingester_it) {
+                if (next_ingest_items.second.empty()) break;
+                auto ingest_item = next_ingest_items.second.front();
+                next_ingest_items.second.pop_front();  // remove the item
+	        //ingest_item.deadline(std::nullopt);
+                if (!ingest_item.deadline()) {
+                    ingest_item.deadline(std::chrono::system_clock::now() + default_deadline);
+                }
+
+                {
+                    std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
+                    controller->manifestHandler()->startedFetch(ingest_item);
+                }
+
+                if (!(*ingester_it)->fetch(ingest_item)) {
+                    ogs_debug("Failed to fetch item: %s", ingest_item.url().c_str());
+                }
+            }
+	}
+    }
+    controller->m_scheduledPullRunning = false;
+}
+
+std::string ObjectManifestController::generateUUID()
+{
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    char uuid_str[37];
+    uuid_unparse(uuid, uuid_str);
+    return std::string(uuid_str);
+}
+
+/* local functions */
 
 static void validate_pull_acquisition_method(DistributionSession &distributionSession) {
     if (distributionSession.getObjectAcquisitionMethod() == "PULL") {

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -50,7 +50,7 @@ static bool validate_push_acquisition_method(DistributionSession &distributionSe
 ObjectManifestController::ObjectManifestController(DistributionSession &dist_session)
         :ObjectController(dist_session)
         ,m_manifestHandler(nullptr)
-	,m_scheduledPullCancel(false)
+        ,m_scheduledPullCancel(false)
 
 {
     validate_pull_acquisition_method(dist_session);
@@ -72,6 +72,24 @@ void ObjectManifestController::processEvent(Event &event, SubscriptionService &e
         // event.preventDefault() if checks fail
     } else if (event.eventName() == ObjectManifestHandler::ObjectManifestChangeEvent::event_name) {
         m_manifestHandlerChange.notify_all();
+    } else if (event.eventName() == ObjectIngester::IngestFailedEvent::event_name) {
+        ObjectIngester::IngestFailedEvent &ingest_failed_event = dynamic_cast<ObjectIngester::IngestFailedEvent&>(event);
+        ogs_debug("Failed ingest of %s, response code was %i", ingest_failed_event.url().c_str(), ingest_failed_event.failureType());
+        if (distributionSession().getObjectAcquisitionMethod() != "PUSH") {
+            // try fetch again
+            try {
+                PullObjectIngester::PullIngestFailedEvent &pull_ingest_failed_event = dynamic_cast<PullObjectIngester::PullIngestFailedEvent&>(event);
+                std::lock_guard<std::recursive_mutex> lock(m_pullObjectIngestersMutex);
+                auto &ingesters = getPullObjectIngesters();
+                if (!ingesters.empty()) {
+                    auto &ingester = ingesters.front();
+                    ingester->fetch(pull_ingest_failed_event.item());
+                }
+            } catch (std::bad_cast &ex) {
+                // Should never happen, but just incase
+                ogs_error("Unable to refetch failed non-PUSH ingest");
+            }
+        }
     }
     ObjectController::processEvent(event, event_service);
 
@@ -287,34 +305,34 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
         std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> next_ingest_items;
         ManifestHandler::durn_type default_deadline;
         // Get the next ingest items
-	try {
+        try {
             std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
             next_ingest_items = controller->manifestHandler()->nextIngestItems();
             default_deadline = controller->manifestHandler()->getDefaultDeadline();
-	} catch ( std::domain_error &err) {
-	    ogs_error("While fetching next manifest ingest item: %s", err.what());
-	}
+        } catch ( std::domain_error &err) {
+            ogs_error("While fetching next manifest ingest item: %s", err.what());
+        }
 
-	if (next_ingest_items.second.empty()) break;
+        if (next_ingest_items.second.empty()) break;
 
-	auto fetch_time = next_ingest_items.first; // Get fetch_time using .first
+        auto fetch_time = next_ingest_items.first; // Get fetch_time using .first
 
-	std::list<PullObjectIngester::IngestItem> urls;
+        std::list<PullObjectIngester::IngestItem> urls;
 
         {
             std::lock_guard<std::recursive_mutex> lock(controller->m_pullObjectIngestersMutex);
             auto &ingesters = controller->getPullObjectIngesters();
             while (ingesters.size() < next_ingest_items.second.size()) {
-	        controller->addPullObjectIngester(new PullObjectIngester(controller->objectStore(), *controller, urls));
+                controller->addPullObjectIngester(new PullObjectIngester(controller->objectStore(), *controller, urls));
             }
-	}
+        }
 
         // Wait until the fetch_time
-	{
+        {
             std::ostringstream oss;
-	    oss << fetch_time ;
-	    ogs_debug("Sleeping until...%s", oss.str().c_str());
-	}
+            oss << fetch_time ;
+            ogs_debug("Sleeping until...%s", oss.str().c_str());
+        }
 
         {
             std::unique_lock<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
@@ -342,7 +360,7 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
                 if (next_ingest_items.second.empty()) break;
                 auto ingest_item = next_ingest_items.second.front();
                 next_ingest_items.second.pop_front();  // remove the item
-	        //ingest_item.deadline(std::nullopt);
+                //ingest_item.deadline(std::nullopt);
                 if (!ingest_item.deadline()) {
                     ingest_item.deadline(std::chrono::system_clock::now() + default_deadline);
                 }
@@ -356,7 +374,7 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
                     ogs_debug("Failed to fetch item: %s", ingest_item.url().c_str());
                 }
             }
-	}
+        }
     }
     controller->m_scheduledPullRunning = false;
 }
@@ -397,7 +415,7 @@ static bool validate_push_acquisition_method(DistributionSession &distributionSe
                 std::optional<std::string> id = "manifest";
                 distributionSession.setObjectAcquisitionIdPush(id);
             }
-	    return true;
+            return true;
         }
     }
     return false;
@@ -407,18 +425,18 @@ static bool validate_push_url(DistributionSession &distributionSession, const st
 {
     std::optional<std::string> object_acquisition_push_id = distributionSession.getObjectAcquisitionPushId();
     if (object_acquisition_push_id.has_value()) {
-	std::string push_id = object_acquisition_push_id.value();
-	std::string url_path(url);
-	if ((push_id.front() == '/' && url_path.front() != '/')) {
-	    url_path = '/' + url_path;
-	} else if ((url_path.front() == '/' && push_id.front() != '/')) {
-	    push_id = '/' + push_id;
-	}
-	if(push_id == url_path) {
-	    return true;
-	} else {
-	    return false;
-	}
+        std::string push_id = object_acquisition_push_id.value();
+        std::string url_path(url);
+        if ((push_id.front() == '/' && url_path.front() != '/')) {
+            url_path = '/' + url_path;
+        } else if ((url_path.front() == '/' && push_id.front() != '/')) {
+            push_id = '/' + push_id;
+        }
+        if(push_id == url_path) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     return true;

--- a/src/mbstf/ObjectManifestController.hh
+++ b/src/mbstf/ObjectManifestController.hh
@@ -1,9 +1,9 @@
 #ifndef _MBS_TF_OBJECT_MANIFEST_CONTROLLER_HH_
 #define _MBS_TF_OBJECT_MANIFEST_CONTROLLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Manifest Controller base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Manifest Controller base class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
@@ -32,15 +32,6 @@ class ObjectManifestController : public ObjectController {
 public:
     ObjectManifestController() = delete;
     ObjectManifestController(DistributionSession &dist_session);
-
-    /*
-    ObjectManifestController(DistributionSession &dist_session)
-        :ObjectController(dist_session)
-	,Subscriber()
-        ,m_manifestHandler(nullptr)
-	,m_scheduledPullCancel(false)
-        {};
-	*/
     ObjectManifestController(const ObjectManifestController&) = delete;
     ObjectManifestController(ObjectManifestController&&) = delete;
 
@@ -70,18 +61,8 @@ protected:
     void startWorker();
     virtual void initPullObjectIngesters();
     virtual void initPushObjectIngester();
-
-    ObjectManifestController &manifestHandler(std::unique_ptr<ManifestHandler> manifest_handler) {
-        std::lock_guard guard(m_manifestHandlerMutex);
-        m_manifestHandler = std::move(manifest_handler);
-        m_manifestHandlerChange.notify_all();
-        return *this;
-    };
-    ManifestHandler *manifestHandler() const {
-        std::lock_guard guard(m_manifestHandlerMutex);
-        return m_manifestHandler.get();
-    };
-
+    ObjectManifestController &manifestHandler(std::shared_ptr<ManifestHandler> &&manifest_handler); 
+    const std::shared_ptr<ManifestHandler> &manifestHandler() const;
     virtual std::string nextObjectId();
 
 
@@ -90,7 +71,7 @@ private:
     std::string generateUUID();
 
     std::string m_manifestUrl;
-    std::unique_ptr<ManifestHandler> m_manifestHandler;
+    std::shared_ptr<ManifestHandler> m_manifestHandler;
     std::condition_variable_any m_manifestHandlerChange;
     mutable std::recursive_mutex m_manifestHandlerMutex;
     std::thread m_scheduledPullThread;

--- a/src/mbstf/ObjectManifestController.hh
+++ b/src/mbstf/ObjectManifestController.hh
@@ -44,7 +44,7 @@ public:
     }
 
     virtual ~ObjectManifestController() {
-	abort();
+        abort();
     };
 
     ObjectManifestController &operator=(const ObjectManifestController&) = delete;
@@ -61,7 +61,7 @@ protected:
     void startWorker();
     virtual void initPullObjectIngesters();
     virtual void initPushObjectIngester();
-    ObjectManifestController &manifestHandler(std::shared_ptr<ManifestHandler> &&manifest_handler); 
+    ObjectManifestController &manifestHandler(std::shared_ptr<ManifestHandler> &&manifest_handler);
     const std::shared_ptr<ManifestHandler> &manifestHandler() const;
     virtual std::string nextObjectId();
 

--- a/src/mbstf/ObjectManifestHandler.cc
+++ b/src/mbstf/ObjectManifestHandler.cc
@@ -1,0 +1,357 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Manifest Handler class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <list>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <uuid/uuid.h>
+
+#include "ogs-app.h"
+#include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
+
+#include <libmpd++/BaseURL.hh>
+#include <libmpd++/URI.hh>
+
+#include "common.hh"
+#include "DistributionSession.hh"
+#include "ManifestHandler.hh"
+#include "ManifestHandlerFactory.hh"
+#include "ObjectController.hh"
+#include "ObjectStore.hh"
+#include "PullObjectIngester.hh"
+#include "utilities.hh"
+#include "openapi/model/ObjectManifest.h"
+
+#include "ObjectManifestHandler.hh"
+
+using namespace std::literals::chrono_literals;
+using fiveg_mag_reftools::ModelException;
+using reftools::mbstf::ObjectManifest;
+using reftools::mbstf::Object;
+
+LIBMPDPP_NAMESPACE_USING(BaseURL);
+LIBMPDPP_NAMESPACE_USING(URI);
+
+MBSTF_NAMESPACE_START
+
+using time_type = std::chrono::system_clock::time_point;
+
+static ObjectManifest ingest_manifest(const ObjectStore::Object &new_manifest);
+
+ObjectManifestHandler::ObjectManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution)
+    :ManifestHandler(controller, pull_distribution)
+    ,m_objectManifestMutex(new decltype(m_objectManifestMutex)::element_type())
+    ,m_objectManifest(ingest_manifest(object))
+    ,m_objectMetadataCache()
+    ,m_manifestFile(&object)
+    ,m_refreshManifest(false)
+{
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    auto now = datetime_type::clock::now();
+    for (auto &obj : m_objectManifest.getObjects()) {
+        if (!obj || !obj.value()) continue;
+        auto fetch_time = now;
+        auto &lft = obj.value()->getLatestFetchTime();
+        if (lft && fetch_time >= iso8601_utc_str_to_time_point(lft.value())) continue;
+        auto &eft = obj.value()->getEarliestFetchTime();
+        if (eft) {
+            auto eft_dt = iso8601_utc_str_to_time_point(eft.value());
+            if (fetch_time < eft_dt) fetch_time = eft_dt;
+        }
+        m_objectMetadataCache.insert(std::make_pair(obj.value().get(), ObjectMetadataCache{fetch_time, false}));
+    }
+}
+
+ObjectManifestHandler::~ObjectManifestHandler()
+{
+}
+
+std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> ObjectManifestHandler::nextIngestItems()
+{
+    if (!m_manifestFile) {
+        ogs_debug("No ObjectManifest file");
+        return std::make_pair(ManifestHandler::time_type(), ManifestHandler::ingest_list());
+    }
+
+    ManifestHandler::time_type ingest_time;
+    ManifestHandler::ingest_list ingest_items;
+
+    auto current_time = std::chrono::system_clock::now();
+
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+
+    if (m_pullDistribution) {
+        auto &manifest_update_interval = m_objectManifest.getUpdateInterval();
+        if (manifest_update_interval && !m_refreshManifest) {
+            /* update manifest at last received time + update interval */
+            ingest_time = m_manifestFile->second.receivedTime() + std::chrono::seconds(manifest_update_interval.value());
+            ingest_items.push_back(PullObjectIngester::IngestItem(m_manifestFile->second));
+            ogs_debug("%s", std::format("Added manifest refresh at {}", ingest_time).c_str());
+        }
+    }
+
+    std::list<BaseURL> base_urls{BaseURL(m_manifestFile->second.getFetchedUrl())};
+
+    for (auto &obj : m_objectManifest.getObjects()) {
+        /* No object, then skip this entry */
+        if (!obj || !obj.value()) continue;
+
+        /* If we've past the latest fetch time then skip this entry */
+        auto &latest_fetch_time = obj.value()->getLatestFetchTime();
+        datetime_type latest_fetch_dt;
+        if (latest_fetch_time) {
+            latest_fetch_dt = iso8601_utc_str_to_time_point(latest_fetch_time.value());
+            if (latest_fetch_dt <= current_time) continue;
+        }
+
+        /* find the metadata entry for this object in the ObjectStore */
+        auto &object_store = m_controller->objectStore();
+        auto obj_locator = URI(obj.value()->getLocator()).resolveUsingBaseURLs(base_urls);
+
+        auto obj_metadata_ptr = object_store.findMetadataByURL(obj_locator.str());
+
+        auto it = m_objectMetadataCache.find(obj.value().get());
+        if (it != m_objectMetadataCache.end() && !it->second.beenRequested) {
+            ObjectStore::Metadata fetch_object_metadata;
+            ManifestHandler::time_type obj_fetch_time = it->second.nextFetchTime;
+
+            if (obj_metadata_ptr) {
+                fetch_object_metadata = *obj_metadata_ptr;
+                ogs_debug("%s", std::format("Object {} at {} to be refetched at {}", fetch_object_metadata.objectId(), obj_locator.str(), obj_fetch_time).c_str());
+            } else {
+                fetch_object_metadata = ObjectStore::Metadata(nextObjectId(), std::string(), obj_locator.str(), obj_locator.str(), obj.value()->getLocator(), ObjectStore::Metadata::datetime_type());
+                ogs_debug("%s", std::format("Object at {} to be fetched at {}", obj_locator.str(), obj_fetch_time).c_str());
+            }
+
+            if (obj_fetch_time < current_time) obj_fetch_time = current_time;
+            if (ingest_items.empty()) {
+                ingest_time = obj_fetch_time;
+            } else if (obj_fetch_time < ingest_time) {
+                ogs_debug("Reset ingest list to contain the object");
+                ingest_items.clear();
+                ingest_time = obj_fetch_time;
+            }
+            if (ingest_time == obj_fetch_time) {
+                ogs_debug("Adding object to ingest list");
+                ingest_items.push_back(PullObjectIngester::IngestItem(fetch_object_metadata));
+            }
+        }
+    }
+
+    ogs_debug("%s", std::format("Return {} items to be fetched at {}", ingest_items.size(), ingest_time).c_str());
+
+    return std::make_pair(ingest_time, ingest_items);
+}
+
+ManifestHandler::durn_type ObjectManifestHandler::getDefaultDeadline()
+{
+    return 10s; /* wait up to 10 seconds for objects in the manifest to arrive */
+}
+
+bool ObjectManifestHandler::update(const ObjectStore::Object &new_manifest)
+{
+    // Process the new ObjectManifest and see what has changed, throw an exception of the Object is not understood or invalid
+
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    m_objectManifest = ingest_manifest(new_manifest);
+    m_manifestFile = &new_manifest;
+    m_refreshManifest = false;
+    ObjectManifestChangeEvent evt;
+    sendEventSynchronous(evt);
+
+    return true; // update completed successfully
+}
+
+void ObjectManifestHandler::startedFetch(const PullObjectIngester::IngestItem &ingest_item)
+{
+    auto &api_objects = m_objectManifest.getObjects();
+    auto api_obj_it = std::find_if(api_objects.begin(), api_objects.end(), [&ingest_item](const auto &obj) -> bool {
+                            if (!obj || !obj.value()) return false;
+                            if (ingest_item.acquisitionId() == obj.value()->getLocator()) return true;
+                            return false;
+                        });
+    if (api_obj_it == api_objects.end()) {
+        /* if the ingest item is the manifest, set the refreshing flag */
+        if (ingest_item.objectId() == m_manifestFile->second.objectId()) {
+            m_refreshManifest = true;
+        }
+    } else if (*api_obj_it && api_obj_it->value()) {
+        auto obj_cache_it = m_objectMetadataCache.find(api_obj_it->value().get());
+        if (obj_cache_it != m_objectMetadataCache.end()) {
+            obj_cache_it->second.beenRequested = true;
+        }
+    }
+}
+
+std::string ObjectManifestHandler::nextObjectId()
+{
+    return generateUUID();
+}
+
+const ObjectManifest::ObjectsType &ObjectManifestHandler::getObjects() const
+{
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    return m_objectManifest.getObjects();
+}
+
+std::list<std::shared_ptr<Object> > ObjectManifestHandler::getActiveObjects() const
+{
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    std::list<std::shared_ptr<Object> > retval;
+
+    auto now = std::chrono::system_clock::now();
+
+    for (const auto &obj : m_objectManifest.getObjects()) {
+        if (!obj || !obj.value()) continue;
+        const auto &eft = obj.value()->getEarliestFetchTime();
+        if (eft && iso8601_utc_str_to_time_point(eft.value()) > now) continue;
+        const auto &lft = obj.value()->getLatestFetchTime();
+        if (lft && iso8601_utc_str_to_time_point(lft.value()) < now) continue;
+        retval.push_back(obj.value());
+    }
+
+    return retval;
+}
+
+double ObjectManifestHandler::getRepetitionIntervalForUrl(const std::string &url) const
+{
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    for (const auto &obj : m_objectManifest.getObjects()) {
+        if (!obj || !obj.value()) continue;
+        const auto &rep_interval = obj.value()->getRepetitionInterval();
+        auto locator = resolveLocator(obj.value()->getLocator());
+        if (locator == url) {
+            if (rep_interval) {
+                ogs_debug("Object %s has %lfs repetition interval", url.c_str(), static_cast<double>(rep_interval.value())/1000.0);
+                return static_cast<double>(rep_interval.value())/1000.0;
+            }
+            return NAN;
+        }
+    }
+    return NAN;
+}
+
+bool ObjectManifestHandler::isObjectURLActive(const std::string &url) const
+{
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    auto now = std::chrono::system_clock::now();
+    for (const auto &obj : m_objectManifest.getObjects()) {
+        if (!obj || !obj.value()) continue;
+        const auto &locator = obj.value()->getLocator();
+        if (locator == url) {
+            const auto &eft = obj.value()->getEarliestFetchTime();
+            if (eft && iso8601_utc_str_to_time_point(eft.value()) > now) return false;
+            const auto &lft = obj.value()->getLatestFetchTime();
+            if (lft && iso8601_utc_str_to_time_point(lft.value()) < now) return false;
+            return true;
+        }
+    }
+    return false;
+}
+
+void ObjectManifestHandler::finishRequest(const std::string &url)
+{
+    std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
+    auto &object_store = m_controller->objectStore();
+    for (const auto &obj : m_objectManifest.getObjects()) {
+        if (!obj || !obj.value()) continue;
+        std::string obj_locator = resolveLocator(obj.value()->getLocator());
+        if (obj_locator == url) {
+            auto obj_meta_it = m_objectMetadataCache.find(obj.value().get());
+            if (obj_meta_it != m_objectMetadataCache.end()) {
+                obj_meta_it->second.beenRequested = false;
+                auto obj_metadata_ptr = object_store.findMetadataByURL(obj_locator);
+                auto &keep_updated_interval = obj.value()->getKeepUpdatedInterval();
+                std::optional<datetime_type> next_fetch_time;
+                if (obj_metadata_ptr) {
+                    /* have the object so use cache expiry or keepUpdatedInterval, if available */
+                    next_fetch_time = obj_metadata_ptr->ExpiryTime();
+                    if (keep_updated_interval) {
+                        auto update_time = obj_meta_it->second.nextFetchTime + std::chrono::seconds(keep_updated_interval.value());
+                        if (update_time < next_fetch_time) next_fetch_time = update_time;
+                    }
+                } else {
+                    /* Use keepUpdatedInterval, if available */
+                    if (keep_updated_interval) {
+                        next_fetch_time = obj_meta_it->second.nextFetchTime + std::chrono::seconds(keep_updated_interval.value());
+                    }
+                }
+
+                if (next_fetch_time) {
+                    obj_meta_it->second.nextFetchTime = next_fetch_time.value();
+                } else {
+                    /* no next fetch time, so remove from updates */
+                    m_objectMetadataCache.erase(obj_meta_it);
+                }
+                ObjectManifestChangeEvent evt;
+                sendEventSynchronous(evt);
+            }
+        }
+    }
+}
+
+/* private: */
+
+std::string ObjectManifestHandler::resolveLocator(const std::string &relative_url) const
+{
+    if (!m_manifestFile) return relative_url;
+    std::list<BaseURL> base_urls{BaseURL(m_manifestFile->second.getFetchedUrl())};
+    return URI(relative_url).resolveUsingBaseURLs(base_urls).str();
+}
+
+std::string ObjectManifestHandler::generateUUID() {
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    char uuid_str[37];
+    uuid_unparse(uuid, uuid_str);
+    return std::string(uuid_str);
+}
+
+/* ManifestHandler registration */
+
+static bool g_registered1 = ManifestHandlerFactory::registerManifestHandler("application/3gpp-mbs-object-manifest+json", new ManifestHandlerConstructorClass<ObjectManifestHandler>());
+static bool g_registered2 = ManifestHandlerFactory::registerManifestHandler("application/3gpp-mbs-object-manifest+json;version=Rel17", new ManifestHandlerConstructorClass<ObjectManifestHandler>());
+static bool g_registered3 = ManifestHandlerFactory::registerManifestHandler("application/3gpp-mbs-object-manifest+json;version=\"Rel17\"", new ManifestHandlerConstructorClass<ObjectManifestHandler>());
+
+/* local functions */
+
+static ObjectManifest ingest_manifest(const ObjectStore::Object &new_manifest)
+{
+    ogs_debug("%s", std::format("ingest_manifest: mediaType() = {}", new_manifest.second.mediaType()).c_str());
+    if (new_manifest.second.mediaType() != "application/3gpp-mbs-object-manifest+json" &&
+        new_manifest.second.mediaType() != "application/3gpp-mbs-object-manifest+json;version=Rel17" &&
+        new_manifest.second.mediaType() != "application/3gpp-mbs-object-manifest+json;version=\"Rel17\""){
+         throw std::invalid_argument("Does not look like an ObjectManifest as the media type is invalid. Expected media type: application/3gpp-mbs-object-manifest+json;version=\"Rel17\"");
+    }
+    
+    try {
+        auto json = CJson::parse(std::string(reinterpret_cast<const char*>(new_manifest.first.data()), new_manifest.first.size()));
+        return ObjectManifest(json, true);
+    } catch (ModelException &ex) {
+        ogs_debug("%s", std::format("Does not look like an ObjectManifest: {}", ex.what()).c_str());
+        throw std::invalid_argument(std::format("Does not look like an ObjectManifest: {}", ex.what()));
+    }
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/ObjectManifestHandler.cc
+++ b/src/mbstf/ObjectManifestHandler.cc
@@ -109,8 +109,6 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> ObjectManife
         }
     }
 
-    std::list<BaseURL> base_urls{BaseURL(m_manifestFile->second.getFetchedUrl())};
-
     for (auto &obj : m_objectManifest.getObjects()) {
         /* No object, then skip this entry */
         if (!obj || !obj.value()) continue;
@@ -125,9 +123,8 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> ObjectManife
 
         /* find the metadata entry for this object in the ObjectStore */
         auto &object_store = m_controller->objectStore();
-        auto obj_locator = URI(obj.value()->getLocator()).resolveUsingBaseURLs(base_urls);
-
-        auto obj_metadata_ptr = object_store.findMetadataByURL(obj_locator.str());
+        auto obj_locator = obj.value()->getLocator();
+        auto obj_metadata_ptr = object_store.findMetadataByURL(obj_locator);
 
         auto it = m_objectMetadataCache.find(obj.value().get());
         if (it != m_objectMetadataCache.end() && !it->second.beenRequested) {
@@ -136,10 +133,10 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> ObjectManife
 
             if (obj_metadata_ptr) {
                 fetch_object_metadata = *obj_metadata_ptr;
-                ogs_debug("%s", std::format("Object {} at {} to be refetched at {}", fetch_object_metadata.objectId(), obj_locator.str(), obj_fetch_time).c_str());
+                ogs_debug("%s", std::format("Object {} at {} to be refetched at {}", fetch_object_metadata.objectId(), obj_locator, obj_fetch_time).c_str());
             } else {
-                fetch_object_metadata = ObjectStore::Metadata(nextObjectId(), std::string(), obj_locator.str(), obj_locator.str(), obj.value()->getLocator(), ObjectStore::Metadata::datetime_type());
-                ogs_debug("%s", std::format("Object at {} to be fetched at {}", obj_locator.str(), obj_fetch_time).c_str());
+                fetch_object_metadata = ObjectStore::Metadata(nextObjectId(), std::string(), obj_locator, obj_locator, obj_locator, ObjectStore::Metadata::datetime_type());
+                ogs_debug("%s", std::format("Object at {} to be fetched at {}", obj_locator, obj_fetch_time).c_str());
             }
 
             if (obj_fetch_time < current_time) obj_fetch_time = current_time;
@@ -278,7 +275,7 @@ double ObjectManifestHandler::getRepetitionIntervalForUrl(const std::string &url
     for (const auto &obj : m_objectManifest.getObjects()) {
         if (!obj || !obj.value()) continue;
         const auto &rep_interval = obj.value()->getRepetitionInterval();
-        auto locator = resolveLocator(obj.value()->getLocator());
+        auto locator = obj.value()->getLocator();
         if (locator == url) {
             if (rep_interval) {
                 ogs_debug("Object %s has %lfs repetition interval", url.c_str(), static_cast<double>(rep_interval.value())/1000.0);
@@ -314,7 +311,7 @@ void ObjectManifestHandler::finishRequest(const std::string &url)
     auto &object_store = m_controller->objectStore();
     for (const auto &obj : m_objectManifest.getObjects()) {
         if (!obj || !obj.value()) continue;
-        std::string obj_locator = resolveLocator(obj.value()->getLocator());
+        std::string obj_locator = obj.value()->getLocator();
         if (obj_locator == url) {
             auto obj_meta_it = m_objectMetadataCache.find(obj.value().get());
             if (obj_meta_it != m_objectMetadataCache.end()) {
@@ -350,13 +347,6 @@ void ObjectManifestHandler::finishRequest(const std::string &url)
 }
 
 /* private: */
-
-std::string ObjectManifestHandler::resolveLocator(const std::string &relative_url) const
-{
-    if (!m_manifestFile) return relative_url;
-    std::list<BaseURL> base_urls{BaseURL(m_manifestFile->second.getFetchedUrl())};
-    return URI(relative_url).resolveUsingBaseURLs(base_urls).str();
-}
 
 std::string ObjectManifestHandler::generateUUID() {
     uuid_t uuid;

--- a/src/mbstf/ObjectManifestHandler.cc
+++ b/src/mbstf/ObjectManifestHandler.cc
@@ -185,7 +185,10 @@ bool ObjectManifestHandler::update(const std::shared_ptr<ObjectStore::Object> &n
         if (new_it == new_objects.end()) {
             /* object removed from carousel */
             auto &object_store = m_controller->objectStore();
-            object_store.removeObject(object_store.findMetadataByURL(old_it->value()->getLocator())->objectId());
+            auto *metadata = object_store.findMetadataByURL(old_it->value()->getLocator());
+            if (metadata) {
+                object_store.removeObject(metadata->objectId());
+            }
             m_objectMetadataCache.erase(old_it->value().get());
             m_objectManifest.removeObjects(*old_it);
         } else {
@@ -373,7 +376,7 @@ static ObjectManifest ingest_manifest(const std::shared_ptr<ObjectStore::Object>
         new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json;version=\"Rel17\""){
          throw std::invalid_argument("Does not look like an ObjectManifest as the media type is invalid. Expected media type: application/3gpp-mbs-object-manifest+json;version=\"Rel17\"");
     }
-    
+
     try {
         auto json = CJson::parse(std::string(reinterpret_cast<const char*>(new_manifest->first.data()), new_manifest->first.size()));
         return ObjectManifest(json, true);

--- a/src/mbstf/ObjectManifestHandler.cc
+++ b/src/mbstf/ObjectManifestHandler.cc
@@ -54,14 +54,15 @@ MBSTF_NAMESPACE_START
 
 using time_type = std::chrono::system_clock::time_point;
 
-static ObjectManifest ingest_manifest(const ObjectStore::Object &new_manifest);
+static ObjectManifest ingest_manifest(const std::shared_ptr<ObjectStore::Object> &new_manifest);
 
-ObjectManifestHandler::ObjectManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution)
+ObjectManifestHandler::ObjectManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller,
+                                             bool pull_distribution)
     :ManifestHandler(controller, pull_distribution)
     ,m_objectManifestMutex(new decltype(m_objectManifestMutex)::element_type())
     ,m_objectManifest(ingest_manifest(object))
     ,m_objectMetadataCache()
-    ,m_manifestFile(&object)
+    ,m_manifestFile(object)
     ,m_refreshManifest(false)
 {
     std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
@@ -166,14 +167,54 @@ ManifestHandler::durn_type ObjectManifestHandler::getDefaultDeadline()
     return 10s; /* wait up to 10 seconds for objects in the manifest to arrive */
 }
 
-bool ObjectManifestHandler::update(const ObjectStore::Object &new_manifest)
+bool ObjectManifestHandler::update(const std::shared_ptr<ObjectStore::Object> &new_manifest_obj)
 {
     // Process the new ObjectManifest and see what has changed, throw an exception of the Object is not understood or invalid
 
     std::lock_guard<decltype(m_objectManifestMutex)::element_type> lock(*m_objectManifestMutex);
-    m_objectManifest = ingest_manifest(new_manifest);
-    m_manifestFile = &new_manifest;
+    auto new_manifest = ingest_manifest(new_manifest_obj);
+    m_manifestFile = new_manifest_obj;
+
+    m_objectManifest.setUpdateInterval(new_manifest.getUpdateInterval());
+
+    const auto &new_objects = new_manifest.getObjects();
+    const auto &old_objects = m_objectManifest.getObjects();
+    for (auto old_it = old_objects.begin(); old_it != old_objects.end(); old_it++) {
+        if (!*old_it || !old_it->value()) continue;
+        auto new_it = std::find_if(new_objects.begin(), new_objects.end(), [&old_it](const auto &new_obj) -> bool {
+                                    if (!new_obj || !new_obj.value()) return false;
+                                    return (old_it->value()->getLocator() == new_obj.value()->getLocator());
+                                });
+        if (new_it == new_objects.end()) {
+            /* object removed from carousel */
+            auto &object_store = m_controller->objectStore();
+            object_store.removeObject(object_store.findMetadataByURL(old_it->value()->getLocator())->objectId());
+            m_objectMetadataCache.erase(old_it->value().get());
+            m_objectManifest.removeObjects(*old_it);
+        } else {
+            /* object same or update */
+            (*old_it->value()) = std::move(*new_it->value());
+            new_manifest.removeObjects(*new_it);
+        }
+    }
+
+    auto now = datetime_type::clock::now();
+    for (const auto &obj : new_objects) {
+        if (!obj || !obj.value()) continue;
+        auto fetch_time = now;
+        auto &lft = obj.value()->getLatestFetchTime();
+        if (lft && fetch_time >= iso8601_utc_str_to_time_point(lft.value())) continue;
+        auto &eft = obj.value()->getEarliestFetchTime();
+        if (eft) {
+            auto eft_dt = iso8601_utc_str_to_time_point(eft.value());
+            if (fetch_time < eft_dt) fetch_time = eft_dt;
+        }
+        m_objectMetadataCache.insert(std::make_pair(obj.value().get(), ObjectMetadataCache{fetch_time, false}));
+        m_objectManifest.addObjects(obj);
+    }
+
     m_refreshManifest = false;
+
     ObjectManifestChangeEvent evt;
     sendEventSynchronous(evt);
 
@@ -333,17 +374,18 @@ static bool g_registered3 = ManifestHandlerFactory::registerManifestHandler("app
 
 /* local functions */
 
-static ObjectManifest ingest_manifest(const ObjectStore::Object &new_manifest)
+static ObjectManifest ingest_manifest(const std::shared_ptr<ObjectStore::Object> &new_manifest)
 {
-    ogs_debug("%s", std::format("ingest_manifest: mediaType() = {}", new_manifest.second.mediaType()).c_str());
-    if (new_manifest.second.mediaType() != "application/3gpp-mbs-object-manifest+json" &&
-        new_manifest.second.mediaType() != "application/3gpp-mbs-object-manifest+json;version=Rel17" &&
-        new_manifest.second.mediaType() != "application/3gpp-mbs-object-manifest+json;version=\"Rel17\""){
+    auto &new_metadata = new_manifest->second;
+    ogs_debug("%s", std::format("ingest_manifest: mediaType() = {}", new_metadata.mediaType()).c_str());
+    if (new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json" &&
+        new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json;version=Rel17" &&
+        new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json;version=\"Rel17\""){
          throw std::invalid_argument("Does not look like an ObjectManifest as the media type is invalid. Expected media type: application/3gpp-mbs-object-manifest+json;version=\"Rel17\"");
     }
     
     try {
-        auto json = CJson::parse(std::string(reinterpret_cast<const char*>(new_manifest.first.data()), new_manifest.first.size()));
+        auto json = CJson::parse(std::string(reinterpret_cast<const char*>(new_manifest->first.data()), new_manifest->first.size()));
         return ObjectManifest(json, true);
     } catch (ModelException &ex) {
         ogs_debug("%s", std::format("Does not look like an ObjectManifest: {}", ex.what()).c_str());

--- a/src/mbstf/ObjectManifestHandler.hh
+++ b/src/mbstf/ObjectManifestHandler.hh
@@ -77,7 +77,6 @@ private:
         bool beenRequested;
     };
 
-    std::string resolveLocator(const std::string &relative_url) const;
     std::string generateUUID();
 
     std::unique_ptr<std::recursive_mutex> m_objectManifestMutex;

--- a/src/mbstf/ObjectManifestHandler.hh
+++ b/src/mbstf/ObjectManifestHandler.hh
@@ -1,0 +1,94 @@
+#ifndef _MBS_TF_OBJECT_MANIFEST_HANDLER_HH_
+#define _MBS_TF_OBJECT_MANIFEST_HANDLER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Manifest Handler class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <chrono>
+#include <list>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "common.hh"
+#include "Event.hh"
+#include "ManifestHandler.hh"
+#include "ObjectStore.hh"
+#include "PullObjectIngester.hh"
+#include "SubscriptionService.hh"
+#include "openapi/model/ObjectManifest.h"
+
+MBSTF_NAMESPACE_START
+
+class ObjectManifestHandler : public ManifestHandler {
+public:
+    using datetime_type = std::chrono::system_clock::time_point;
+
+    class ObjectManifestChangeEvent : public Event {
+    public:
+        static constexpr const char *event_name = "ObjectManifestChange";
+
+        ObjectManifestChangeEvent() : Event(event_name) {};
+        ObjectManifestChangeEvent(const ObjectManifestChangeEvent &other) : Event(other) {};
+        ObjectManifestChangeEvent(ObjectManifestChangeEvent &&other) : Event(std::move(other)) {};
+
+        virtual ~ObjectManifestChangeEvent() {};
+
+        virtual Event clone() const { return ObjectManifestChangeEvent(); };
+        virtual Event *newClone() const { return new ObjectManifestChangeEvent; };
+        virtual std::string reprString() const { return "ObjectManifestChangeEvent()"; };
+    };
+
+    ObjectManifestHandler() = delete;
+    ObjectManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution);
+    ObjectManifestHandler(const ObjectManifestHandler &) = delete;
+    ObjectManifestHandler(ObjectManifestHandler &&) = delete;
+
+    virtual ~ObjectManifestHandler();
+
+    ObjectManifestHandler &operator=(const ObjectManifestHandler &) = delete;
+    ObjectManifestHandler &operator=(ObjectManifestHandler &&) = delete;
+
+    virtual std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> nextIngestItems();
+    virtual ManifestHandler::durn_type getDefaultDeadline();
+    virtual bool update(const ObjectStore::Object &new_manifest);
+    virtual void startedFetch(const PullObjectIngester::IngestItem &item);
+
+    virtual std::string nextObjectId();
+
+    static unsigned int factoryPriority() { return 100; };
+    const reftools::mbstf::ObjectManifest::ObjectsType &getObjects() const;
+    std::list<std::shared_ptr<reftools::mbstf::Object> > getActiveObjects() const;
+
+    double getRepetitionIntervalForUrl(const std::string &url) const;
+    bool isObjectURLActive(const std::string &url) const;
+    void finishRequest(const std::string &url);
+
+private:
+    struct ObjectMetadataCache {
+        datetime_type nextFetchTime;
+        bool beenRequested;
+    };
+
+    std::string resolveLocator(const std::string &relative_url) const;
+    std::string generateUUID();
+
+    std::unique_ptr<std::recursive_mutex> m_objectManifestMutex;
+    reftools::mbstf::ObjectManifest  m_objectManifest;
+    std::map<reftools::mbstf::Object*, ObjectMetadataCache> m_objectMetadataCache;
+    const ObjectStore::Object *m_manifestFile;
+    bool m_refreshManifest;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_OBJECT_MANIFEST_HANDLER_HH_ */

--- a/src/mbstf/ObjectManifestHandler.hh
+++ b/src/mbstf/ObjectManifestHandler.hh
@@ -47,7 +47,7 @@ public:
     };
 
     ObjectManifestHandler() = delete;
-    ObjectManifestHandler(const ObjectStore::Object &object, ObjectController *controller, bool pull_distribution);
+    ObjectManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller, bool pull_distribution);
     ObjectManifestHandler(const ObjectManifestHandler &) = delete;
     ObjectManifestHandler(ObjectManifestHandler &&) = delete;
 
@@ -58,7 +58,7 @@ public:
 
     virtual std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> nextIngestItems();
     virtual ManifestHandler::durn_type getDefaultDeadline();
-    virtual bool update(const ObjectStore::Object &new_manifest);
+    virtual bool update(const std::shared_ptr<ObjectStore::Object> &new_manifest);
     virtual void startedFetch(const PullObjectIngester::IngestItem &item);
 
     virtual std::string nextObjectId();
@@ -83,7 +83,7 @@ private:
     std::unique_ptr<std::recursive_mutex> m_objectManifestMutex;
     reftools::mbstf::ObjectManifest  m_objectManifest;
     std::map<reftools::mbstf::Object*, ObjectMetadataCache> m_objectMetadataCache;
-    const ObjectStore::Object *m_manifestFile;
+    std::shared_ptr<ObjectStore::Object> m_manifestFile;
     bool m_refreshManifest;
 };
 

--- a/src/mbstf/ObjectPackager.cc
+++ b/src/mbstf/ObjectPackager.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object packager base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object packager base class
  ******************************************************************************
- * Copyright: (C)2024 British Broadcasting Corporation
+ * Copyright: (C)2024-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this
@@ -11,6 +12,10 @@
  */
 // Open5GS includes
 #include "ogs-sbi.h" // include before "common.hh" to get correct logging domain
+
+// STL includes
+#include <sstream>
+#include <string>
 
 // spdlog includes
 #include "spdlog/spdlog.h"
@@ -26,8 +31,22 @@
 
 MBSTF_NAMESPACE_START
 
+std::string ObjectPackager::PackagingFailedEvent::reprString() const
+{
+    std::ostringstream oss;
+    oss << "ObjectPackager::" << event_name << "(reason=\"" << m_reason << "\", type=" << m_failureType << ")";
+    return oss.str();
+}
+
 // Prevent spdlog default logger being deleted too early on exit.
 auto spdlog_logger = spdlog::default_logger();
+
+ObjectPackager::~ObjectPackager()
+{
+    abort();
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
+    m_transmitter.reset();
+}
 
 void ObjectPackager::workerLoop(ObjectPackager *packager)
 {

--- a/src/mbstf/ObjectPackager.cc
+++ b/src/mbstf/ObjectPackager.cc
@@ -25,6 +25,8 @@
 
 // local includes
 #include "common.hh"
+#include "ObjectController.hh"
+#include "DistributionSession.hh"
 
 // this class include
 #include "ObjectPackager.hh"
@@ -57,13 +59,8 @@ void ObjectPackager::workerLoop(ObjectPackager *packager)
     packager->m_workerRunning = false;
 }
 
-ObjectPackager& ObjectPackager::setDestIpAddr(const std::optional<std::string> &dest_ip_addr) {
-    m_destIpAddr = dest_ip_addr;
-    return *this;
-}
-
-ObjectPackager& ObjectPackager::setPort(in_port_t port) {
-    m_port = port;
+ObjectPackager& ObjectPackager::setSsmPort(const SsmPort &ssm_port) {
+    m_ssmPort = ssm_port;
     return *this;
 }
 
@@ -100,6 +97,11 @@ bool ObjectPackager::deactivate()
         return true;
     }
     return false;
+}
+
+uint64_t ObjectPackager::tsi() const
+{
+    return m_controller.distributionSession().getTSI();
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectPackager.cc
+++ b/src/mbstf/ObjectPackager.cc
@@ -89,8 +89,8 @@ void ObjectPackager::activate()
 
 bool ObjectPackager::deactivate()
 {
-    std::lock_guard<std::recursive_mutex> guard(m_deactivateMutex);
     m_deactivating = true;
+    std::lock_guard<decltype(m_transmitterMutex)::element_type> lock(*m_transmitterMutex);
     ogs_debug("FLUTE Transmitter has %zu files left", m_transmitter?m_transmitter->number_of_files():0);
     if (m_transmitter && m_transmitter->number_of_files() == 0) {
         ogs_debug("Deactivating FLUTE stream, no files to purge");

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -1,10 +1,11 @@
 #ifndef _MBS_TF_OBJECT_PACKAGER_HH_
 #define _MBS_TF_OBJECT_PACKAGER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Packager base class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Packager base class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this
@@ -38,10 +39,11 @@ class Event;
 
 class ObjectPackager: public SubscriptionService {
 public:
-   class ObjectSendCompleted : public Event {
+    class ObjectSendCompleted : public Event {
     public:
+        static constexpr const char *event_name = "ObjectSendCompleted";
         ObjectSendCompleted(const std::string& object_id, bool queue_empty)
-            :Event("ObjectSendCompleted")
+            :Event(event_name)
             ,m_object_id(object_id)
             ,m_queue_empty(queue_empty)
         {};
@@ -77,7 +79,7 @@ public:
         virtual Event clone() const { return ObjectSendCompleted(*this); };
         virtual Event *newClone() const { return new ObjectSendCompleted(*this); };
         virtual std::string reprString() const {
-            return std::format("ObjectSendCompleted(\"{}\", queue_empty={})", m_object_id, m_queue_empty);
+            return std::format("{}(\"{}\", queue_empty={})", event_name, m_object_id, m_queue_empty);
         };
 
     private:
@@ -85,13 +87,48 @@ public:
         bool m_queue_empty;
     };
 
+    class PackagingFailedEvent : public Event {
+    public:
+        static constexpr const char *event_name = "ObjectPackagingFailed";
+        typedef enum {
+            BIT_RATE_OVERFLOW = 1,
+            BIT_RATE_UNDERFLOW,
+            OBJECT_TOO_BIG,
+            RESOURCE_NOT_AVAILABLE
+        } FailureType;
+
+        PackagingFailedEvent(const std::string &reason, FailureType fail_type)
+            : Event(event_name), m_reason(reason), m_failureType(fail_type) {};
+        PackagingFailedEvent(const PackagingFailedEvent &other)
+            : Event(other), m_reason(other.m_reason), m_failureType(other.m_failureType) {};
+        PackagingFailedEvent(PackagingFailedEvent &&other)
+            : Event(std::move(other)), m_reason(std::move(other.m_reason)), m_failureType(std::move(other.m_failureType)) {};
+
+        virtual ~PackagingFailedEvent() {};
+
+        PackagingFailedEvent &operator=(const PackagingFailedEvent &other) { Event::operator=(other); m_reason = other.m_reason; m_failureType = other.m_failureType; return *this; };
+        PackagingFailedEvent &operator=(PackagingFailedEvent &&other) { Event::operator=(std::move(other)); m_reason = std::move(other.m_reason); m_failureType = std::move(other.m_failureType); return *this; };
+
+        const std::string &reason() const { return m_reason; };
+        FailureType failureType() const { return m_failureType; };
+
+        virtual Event clone() const { return PackagingFailedEvent(*this); };
+        virtual Event *newClone() const { return new PackagingFailedEvent(*this); };
+
+        virtual std::string reprString() const;
+
+    private:
+        std::string m_reason;
+        FailureType m_failureType;
+    };
 
     ObjectPackager() = delete;
     ObjectPackager(ObjectPackager &&) = delete;
     ObjectPackager(const ObjectPackager &) = delete;
 
     ObjectPackager(ObjectStore &objectStore, ObjectController &controller, std::optional<std::string> destIpAddr = std::nullopt, uint32_t rateLimit = 0, unsigned short mtu = 0, in_port_t port = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
-        :m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_deactivating(false), m_queuedObjectId()
+        :m_transmitterMutex(new decltype(m_transmitterMutex)::element_type)
+        ,m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_deactivating(false), m_queuedObjectId()
         ,m_objectStore(objectStore), m_controller(controller), m_destIpAddr(destIpAddr), m_rateLimit(rateLimit), m_mtu(mtu)
         ,m_port(port), m_workerThread(), m_workerCancel(false), m_workerRunning(false)
         ,m_tunnelAddress(tunnel_address), m_tunnelPort(tunnel_port)
@@ -105,9 +142,7 @@ public:
         }
     };
 
-    virtual ~ObjectPackager() {
-        abort();
-    };
+    virtual ~ObjectPackager();
 
     ObjectPackager& setDestIpAddr(const std::optional<std::string> &destIpAddr);
     ObjectPackager& setPort(in_port_t port);
@@ -138,7 +173,8 @@ protected:
 
     virtual void doObjectPackage() = 0;
 
-    LibFlute::Transmitter *m_transmitter;
+    std::shared_ptr<std::recursive_mutex> m_transmitterMutex;
+    std::shared_ptr<LibFlute::Transmitter> m_transmitter;
     boost::asio::io_service m_io;
     uint32_t m_queuedToi;
     bool m_queued;

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -178,9 +178,7 @@ protected:
     boost::asio::io_service m_io;
     uint32_t m_queuedToi;
     bool m_queued;
-    bool m_deactivating;
-    std::recursive_mutex m_deactivateMutex;
-    std::condition_variable_any m_deactivateCond;
+    std::atomic_bool m_deactivating;
     std::string m_queuedObjectId;
 
 private:

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -25,6 +25,7 @@
 
 #include "common.hh"
 #include "Event.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
 
 namespace LibFlute{
@@ -35,7 +36,6 @@ MBSTF_NAMESPACE_START
 
 class ObjectStore;
 class ObjectController;
-class Event;
 
 class ObjectPackager: public SubscriptionService {
 public:
@@ -126,11 +126,11 @@ public:
     ObjectPackager(ObjectPackager &&) = delete;
     ObjectPackager(const ObjectPackager &) = delete;
 
-    ObjectPackager(ObjectStore &objectStore, ObjectController &controller, std::optional<std::string> destIpAddr = std::nullopt, uint32_t rateLimit = 0, unsigned short mtu = 0, in_port_t port = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
+    ObjectPackager(ObjectStore &objectStore, ObjectController &controller, const SsmPort &ssm_port = SsmPort(), uint32_t rateLimit = 0, unsigned short mtu = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
         :m_transmitterMutex(new decltype(m_transmitterMutex)::element_type)
         ,m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_deactivating(false), m_queuedObjectId()
-        ,m_objectStore(objectStore), m_controller(controller), m_destIpAddr(destIpAddr), m_rateLimit(rateLimit), m_mtu(mtu)
-        ,m_port(port), m_workerThread(), m_workerCancel(false), m_workerRunning(false)
+        ,m_objectStore(objectStore), m_controller(controller), m_ssmPort(ssm_port), m_rateLimit(rateLimit), m_mtu(mtu)
+        ,m_workerThread(), m_workerCancel(false), m_workerRunning(false)
         ,m_tunnelAddress(tunnel_address), m_tunnelPort(tunnel_port)
     {
     };
@@ -144,8 +144,7 @@ public:
 
     virtual ~ObjectPackager();
 
-    ObjectPackager& setDestIpAddr(const std::optional<std::string> &destIpAddr);
-    ObjectPackager& setPort(in_port_t port);
+    ObjectPackager& setSsmPort(const SsmPort &ssm_port);
     ObjectPackager& setMtu(unsigned short mtu);
     ObjectPackager& setRateLimit(uint32_t rateLimit);
     void startWorker() {
@@ -164,11 +163,11 @@ protected:
     ObjectStore &objectStore() { return m_objectStore; };
     const ObjectController &controller() const { return m_controller; };
     ObjectController &controller() { return m_controller; };
-    const std::optional<std::string> &destIpAddr() const { return m_destIpAddr; };
+    const SsmPort &ssmPort() const { return m_ssmPort; };
     const std::optional<std::string> &tunnelAddr() const { return m_tunnelAddress; };
     uint32_t rateLimit() const { return m_rateLimit; };
     unsigned short mtu() const { return m_mtu; };
-    in_port_t port() const { return m_port; };
+    uint64_t tsi() const;
     in_port_t tunnelPort() const { return m_tunnelPort; };
 
     virtual void doObjectPackage() = 0;
@@ -185,10 +184,9 @@ private:
     static void workerLoop(ObjectPackager*);
     ObjectStore &m_objectStore;
     ObjectController &m_controller;
-    std::optional<std::string> m_destIpAddr;
+    SsmPort m_ssmPort;
     uint32_t m_rateLimit;
     unsigned short m_mtu;
-    in_port_t m_port;
     std::thread m_workerThread;
     std::atomic_bool m_workerCancel;
     std::atomic_bool m_workerRunning;

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -219,12 +219,12 @@ void ObjectStore::updateMetadata(const std::string& object_id, Metadata &&metada
     }
 }
 
-void ObjectStore::updateError(const std::string& object_id, int response_code, bool synchronous_event)
+void ObjectStore::updateError(const std::string& object_id, int response_code, const std::string &url, bool synchronous_event)
 {
     /* TODO: Evict Object? */
 
     /* send event */
-    std::shared_ptr<Event> event(new ObjectStore::ObjectUpdateErrorEvent(object_id, response_code));
+    std::shared_ptr<Event> event(new ObjectStore::ObjectUpdateErrorEvent(object_id, response_code, url));
     if (synchronous_event) {
         sendEventSynchronous(*event);
     } else {
@@ -299,7 +299,7 @@ bool ObjectStore::removeObject(const std::string& object_id) {
     auto it = m_store.find(object_id);
     if (it != m_store.end()) {
         m_store.erase(it);
-	return true;
+        return true;
     } else {
         return false;
     }

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object store
+ * 5G-MAG Reference Tools: MBS Transport Function: Object store
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this
@@ -224,6 +225,11 @@ void ObjectStore::deleteObject(const std::string& object_id) {
     m_store.erase(object_id);
     std::shared_ptr<Event> event(new ObjectStore::ObjectDeletedEvent(object_id));
     sendEventAsynchronous(event);
+}
+
+ObjectStore::Object& ObjectStore::operator[](const std::string& object_id) {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    return m_store.at(object_id);
 }
 
 const ObjectStore::Object& ObjectStore::operator[](const std::string& object_id) const {

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -181,16 +181,50 @@ ObjectStore::~ObjectStore()
 
 void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    //std::unique_lock<std::shared_mutex> lock(m_mutex);
 
     try {
-        m_store.insert_or_assign(object_id, std::make_pair(std::move(object), std::move(metadata)));
+        std::shared_ptr<Object> obj(new std::pair(std::move(object), std::move(metadata)));
+        m_store.insert_or_assign(object_id, obj);
     } catch (const std::bad_alloc& e) {
         ogs_error("memory allocation failed: %s", e.what());
 
     }
 
+    /* send event */
     std::shared_ptr<Event> event(new ObjectStore::ObjectAddedEvent(object_id));
+    if (synchronous_event) {
+        sendEventSynchronous(*event);
+    } else {
+        sendEventAsynchronous(event);
+    }
+}
+
+void ObjectStore::updateMetadata(const std::string& object_id, Metadata &&metadata, bool synchronous_event)
+{
+    std::lock_guard<decltype(m_mutex)> lock(m_mutex);
+
+    auto it = m_store.find(object_id);
+    if (it == m_store.end()) {
+        throw std::out_of_range(std::format("Attempt to update Object {}, but it is not in the ObjectStore", object_id));
+    }
+
+    it->second->second = std::move(metadata);
+
+    /* send event */
+    std::shared_ptr<Event> event(new ObjectStore::ObjectUpdatedEvent(object_id));
+    if (synchronous_event) {
+        sendEventSynchronous(*event);
+    } else {
+        sendEventAsynchronous(event);
+    }
+}
+
+void ObjectStore::updateError(const std::string& object_id, int response_code, bool synchronous_event)
+{
+    /* TODO: Evict Object? */
+
+    /* send event */
+    std::shared_ptr<Event> event(new ObjectStore::ObjectUpdateErrorEvent(object_id, response_code));
     if (synchronous_event) {
         sendEventSynchronous(*event);
     } else {
@@ -200,53 +234,40 @@ void ObjectStore::addObject(const std::string& object_id, ObjectData &&object, M
 
 const ObjectStore::ObjectData& ObjectStore::getObjectData(const std::string& object_id) const {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    //std::shared_lock<std::shared_mutex> lock(m_mutex);
-    return  m_store.at(object_id).first;
+    return  m_store.at(object_id)->first;
 }
 
 ObjectStore::ObjectData& ObjectStore::getObjectData(const std::string& object_id) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    return m_store.at(object_id).first;
+    return m_store.at(object_id)->first;
 }
 
 const ObjectStore::Metadata& ObjectStore::getMetadata(const std::string& object_id) const {
    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-   return m_store.at(object_id).second;
+   return m_store.at(object_id)->second;
 }
 
 ObjectStore::Metadata& ObjectStore::getMetadata(const std::string& object_id) {
    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-   return m_store.at(object_id).second;
+   return m_store.at(object_id)->second;
 }
 
 void ObjectStore::deleteObject(const std::string& object_id) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    //std::unique_lock<std::shared_mutex> lock(m_mutex);
     m_store.erase(object_id);
     std::shared_ptr<Event> event(new ObjectStore::ObjectDeletedEvent(object_id));
     sendEventAsynchronous(event);
 }
 
-ObjectStore::Object& ObjectStore::operator[](const std::string& object_id) {
+const std::shared_ptr<ObjectStore::Object> &ObjectStore::operator[](const std::string& object_id) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     return m_store.at(object_id);
 }
 
-const ObjectStore::Object& ObjectStore::operator[](const std::string& object_id) const {
+std::shared_ptr<const ObjectStore::Object> ObjectStore::operator[](const std::string& object_id) const {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     return m_store.at(object_id);
 }
-
-/*
-bool ObjectStore::hasExpired(const std::string& object_id) const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    const auto& metadata = m_store.at(object_id).second;
-    if (metadata.cacheExpires().has_value()) {
-        return std::chrono::system_clock::now() > metadata.cacheExpires().value();
-    }
-    return false;
-}
-*/
 
 bool ObjectStore::isStale(const std::string& object_id) const {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
@@ -255,28 +276,27 @@ bool ObjectStore::isStale(const std::string& object_id) const {
         return false;
     }
 
-    const Metadata& metadata = it->second.second;
+    const Metadata& metadata = it->second->second;
     return metadata.cacheExpires().has_value() && metadata.cacheExpires().value() < std::chrono::system_clock::now();
 }
 
-std::map<std::string, const ObjectStore::Object&> ObjectStore::getStale() const {
+std::map<std::string, std::shared_ptr<ObjectStore::Object> > ObjectStore::getStale() const {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    std::map<std::string, const ObjectStore::Object&> staleObjects;
+    std::map<std::string, std::shared_ptr<ObjectStore::Object>> stale_objects;
 
     for (const auto& pair : m_store) {
         const std::string& object_id = pair.first;
         if (isStale(object_id)) {
-            staleObjects.emplace(object_id, pair.second);
+            stale_objects.emplace(object_id, pair.second);
         }
     }
 
-    return staleObjects;
+    return stale_objects;
 }
 
-bool ObjectStore::removeObject(const std::string& objectId) {
+bool ObjectStore::removeObject(const std::string& object_id) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    //std::unique_lock<std::shared_mutex> lock(m_mutex);
-    auto it = m_store.find(objectId);
+    auto it = m_store.find(object_id);
     if (it != m_store.end()) {
         m_store.erase(it);
 	return true;
@@ -285,17 +305,13 @@ bool ObjectStore::removeObject(const std::string& objectId) {
     }
 }
 
-bool ObjectStore::removeObjects(const std::list<std::string>& objectIds) {
+bool ObjectStore::removeObjects(const std::list<std::string>& object_ids) {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
-    //std::unique_lock<std::shared_mutex> lock(m_mutex);
-    for (const auto& objectId : objectIds) {
-        auto it = m_store.find(objectId);
+    for (const auto& object_id : object_ids) {
+        auto it = m_store.find(object_id);
         if (it != m_store.end()) {
             m_store.erase(it);
-        } /*else {
-            return false;
-            // Optionally handle the case where the objectId is not found
-        } */
+        }
     }
     return true;
 }
@@ -303,10 +319,10 @@ bool ObjectStore::removeObjects(const std::list<std::string>& objectIds) {
 const ObjectStore::Metadata *ObjectStore::findMetadataByURL(const std::string &url) const
 {
     auto it = std::find_if(m_store.begin(), m_store.end(), [&url](const decltype(m_store)::value_type &obj){
-            auto &metadata = obj.second.second;
+            auto &metadata = obj.second->second;
             return metadata.getOriginalUrl() == url || metadata.getFetchedUrl() == url;
         });
-    if (it != m_store.end()) return &it->second.second;
+    if (it != m_store.end()) return &it->second->second;
     return nullptr;
 }
 
@@ -314,8 +330,8 @@ void ObjectStore::reconfigureMetadatas(const std::optional<std::string> &ingest_
                                        const std::optional<std::string> &distribution_base_url)
 {
     for (auto &[obj_id, obj] : m_store) {
-        obj.second.objIngestBaseUrl(ingest_base_url);
-        obj.second.objDistributionBaseUrl(distribution_base_url);
+        obj->second.objIngestBaseUrl(ingest_base_url);
+        obj->second.objDistributionBaseUrl(distribution_base_url);
     }
 }
 

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -1,9 +1,9 @@
 #ifndef _MBS_TF_OBJECT_STORE_HH_
 #define _MBS_TF_OBJECT_STORE_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Store class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Store class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
  *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
@@ -249,6 +249,7 @@ public:
     bool removeObject(const std::string& objectId);
     bool removeObjects(const std::list<std::string>& objectIds);
     std::list<std::pair<const std::string*, const Object*>> getExpired();
+    Object &operator[](const std::string& object_id);
     const Object &operator[](const std::string& object_id) const;
     bool isStale(const std::string& object_id) const;
     std::map<std::string, const Object&> getStale() const;

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -125,31 +125,35 @@ public:
     class ObjectUpdateErrorEvent : public ObjectChangedEvent {
     public:
         constexpr static const char *event_name = "ObjectUpdateError";
-        ObjectUpdateErrorEvent(const std::string& object_id, int response_code) :ObjectChangedEvent(event_name, object_id), m_responseCode(response_code) {};
-        ObjectUpdateErrorEvent(const ObjectUpdateErrorEvent &other) :ObjectChangedEvent(other), m_responseCode(other.m_responseCode) {};
-        ObjectUpdateErrorEvent(ObjectUpdateErrorEvent &&other) :ObjectChangedEvent(std::move(other)), m_responseCode(other.m_responseCode) {};
+        ObjectUpdateErrorEvent(const std::string& object_id, int response_code, const std::string &url) :ObjectChangedEvent(event_name, object_id), m_responseCode(response_code), m_url(url) {};
+        ObjectUpdateErrorEvent(const ObjectUpdateErrorEvent &other) :ObjectChangedEvent(other), m_responseCode(other.m_responseCode), m_url(other.m_url) {};
+        ObjectUpdateErrorEvent(ObjectUpdateErrorEvent &&other) :ObjectChangedEvent(std::move(other)), m_responseCode(other.m_responseCode), m_url(std::move(other.m_url)) {};
 
         virtual ~ObjectUpdateErrorEvent() {};
 
         ObjectUpdateErrorEvent &operator=(const ObjectUpdateErrorEvent &other) {
             ObjectChangedEvent::operator=(other);
             m_responseCode = other.m_responseCode;
+            m_url = other.m_url;
             return *this;
         };
         ObjectUpdateErrorEvent &operator=(ObjectUpdateErrorEvent &&other) {
             ObjectChangedEvent::operator=(std::move(other));
             m_responseCode = other.m_responseCode;
+            m_url = std::move(other.m_url);
             return *this;
         };
 
         int responseCode() const { return m_responseCode; };
+        const std::string &url() const { return m_url; };
 
         virtual Event clone() const { return ObjectUpdateErrorEvent(*this); };
         virtual Event *newClone() const { return new ObjectUpdateErrorEvent(*this); };
-        virtual std::string reprString() const { return std::format("ObjectUpdateErrorEvent(\"{}\", {})", objectId(), m_responseCode); };
+        virtual std::string reprString() const { return std::format("ObjectUpdateErrorEvent(\"{}\", {}, \"{}\")", objectId(), m_responseCode, m_url); };
 
     private:
         int m_responseCode;
+        std::string m_url;
     };
 
     class Metadata {
@@ -193,8 +197,8 @@ public:
         Metadata &mediaType(const std::string &media_type) {m_mediaType = media_type; return *this;};
         Metadata &mediaType(std::string &&media_type) {m_mediaType = std::move(media_type); return *this;};
 
-	bool hasExpiryTime() const { return m_cacheExpires.has_value(); };
-	const datetime_type &ExpiryTime() const { return m_cacheExpires.value();};
+        bool hasExpiryTime() const { return m_cacheExpires.has_value(); };
+        const datetime_type &ExpiryTime() const { return m_cacheExpires.value();};
         const std::optional<datetime_type>& cacheExpires() const { return m_cacheExpires;};
         std::optional<datetime_type>& cacheExpires(const datetime_type &cacheExpires) {
             m_cacheExpires = cacheExpires;
@@ -209,7 +213,7 @@ public:
 
         Metadata &entityTag(const std::optional<std::string>& entityTag) {m_entityTag = entityTag; if (m_fileDescription && entityTag) m_fileDescription->set_etag(entityTag.value()); return *this;};
 
-	Metadata &keepAfterSend(bool keep_after_send) {m_keepAfterSend = keep_after_send; return *this;};
+        Metadata &keepAfterSend(bool keep_after_send) {m_keepAfterSend = keep_after_send; return *this;};
         bool keepAfterSend() const { return m_keepAfterSend;};
 
         const std::optional<std::string> &objIngestBaseUrl() const { return m_objIngestBaseUrl;};
@@ -234,15 +238,15 @@ public:
         };
         Metadata &objDistributionBaseUrl(std::nullopt_t) {m_objDistributionBaseUrl.reset(); return *this;};
 
-	const datetime_type &receivedTime() const { return m_receivedTime;};
+        const datetime_type &receivedTime() const { return m_receivedTime;};
         Metadata &receivedTime(const datetime_type &val) { m_receivedTime = val; return *this; };
         Metadata &receivedTime(datetime_type &&val) { m_receivedTime = std::move(val); return *this; };
 
-	const datetime_type &created() const { return m_created;};
+        const datetime_type &created() const { return m_created;};
         Metadata &created(const datetime_type &val) { m_created = val; return *this; };
         Metadata &created(datetime_type &&val) { m_created = std::move(val); return *this; };
 
-	const datetime_type &modified() const { return m_modified;};
+        const datetime_type &modified() const { return m_modified;};
         Metadata &modified(const datetime_type &val) { m_modified = val; return *this; };
         Metadata &modified(datetime_type &&val) { m_modified = std::move(val); return *this; };
 
@@ -261,12 +265,12 @@ public:
         };
 
     private:
-	std::string m_objectId;
+        std::string m_objectId;
         std::string m_mediaType;
         std::string m_originalUrl;
         std::string m_fetchedUrl;
         std::string m_acquisitionId;
-	bool m_keepAfterSend;
+        bool m_keepAfterSend;
         std::optional<std::string> m_objIngestBaseUrl;
         std::optional<std::string> m_objDistributionBaseUrl;
         std::optional<std::string> m_entityTag;
@@ -290,7 +294,7 @@ public:
 
     void addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event = false);
     void updateMetadata(const std::string& object_id, Metadata &&metadata, bool synchronous_event = false);
-    void updateError(const std::string& object_id, int response_code, bool synchronous_event = false);
+    void updateError(const std::string& object_id, int response_code, const std::string &url, bool synchronous_event = false);
     const ObjectData& getObjectData(const std::string& object_id) const;
     ObjectData& getObjectData(const std::string& object_id);
     const Metadata& getMetadata(const std::string& object_id) const;

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -46,62 +46,110 @@ class ObjectStore: public SubscriptionService {
 public:
     using datetime_type = std::chrono::system_clock::time_point;
 
-    class ObjectAddedEvent : public Event {
+    class ObjectChangedEvent : public Event {
     public:
-        ObjectAddedEvent(const std::string& object_id) :Event("ObjectAdded"), m_object_id(object_id) {};
-        ObjectAddedEvent(const ObjectAddedEvent &other) :Event(other), m_object_id(other.m_object_id) {};
-        ObjectAddedEvent(ObjectAddedEvent &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
+        ObjectChangedEvent(const char *event_name, const std::string& object_id) :Event(event_name), m_object_id(object_id) {};
+        ObjectChangedEvent(const ObjectChangedEvent &other) :Event(other), m_object_id(other.m_object_id) {};
+        ObjectChangedEvent(ObjectChangedEvent &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
 
-        virtual ~ObjectAddedEvent() {};
+        virtual ~ObjectChangedEvent() {};
 
-        ObjectAddedEvent &operator=(const ObjectAddedEvent &other) {
+        ObjectChangedEvent &operator=(const ObjectChangedEvent &other) {
             Event::operator=(other);
             m_object_id = other.m_object_id;
             return *this;
         };
-        ObjectAddedEvent &operator=(ObjectAddedEvent &&other) {
+        ObjectChangedEvent &operator=(ObjectChangedEvent &&other) {
             Event::operator=(std::move(other));
             m_object_id = std::move(other.m_object_id);
             return *this;
         };
 
-        std::string objectId() const { return m_object_id; }
-
-        virtual Event clone() const { return ObjectAddedEvent(*this); };
-        virtual Event *newClone() const { return new ObjectAddedEvent(*this); };
-        virtual std::string reprString() const { return std::format("ObjectAddedEvent(\"{}\")", m_object_id); };
+        const std::string &objectId() const { return m_object_id; }
 
     private:
         std::string m_object_id;
     };
 
-    class ObjectDeletedEvent : public Event {
+    class ObjectAddedEvent : public ObjectChangedEvent {
     public:
-        ObjectDeletedEvent(const std::string& object_id) :Event("ObjectDeleted"), m_object_id(object_id) {};
-        ObjectDeletedEvent(const ObjectDeletedEvent &other) :Event(other), m_object_id(other.m_object_id) {};
-        ObjectDeletedEvent(ObjectDeletedEvent &&other) :Event(std::move(other)), m_object_id(std::move(other.m_object_id)) {};
+        constexpr static const char *event_name = "ObjectAdded";
+        ObjectAddedEvent(const std::string& object_id) :ObjectChangedEvent(event_name, object_id) {};
+        ObjectAddedEvent(const ObjectAddedEvent &other) :ObjectChangedEvent(other) {};
+        ObjectAddedEvent(ObjectAddedEvent &&other) :ObjectChangedEvent(std::move(other)) {};
+
+        virtual ~ObjectAddedEvent() {};
+
+        ObjectAddedEvent &operator=(const ObjectAddedEvent &other) { ObjectChangedEvent::operator=(other); return *this; };
+        ObjectAddedEvent &operator=(ObjectAddedEvent &&other) { ObjectChangedEvent::operator=(std::move(other)); return *this; };
+
+        virtual Event clone() const { return ObjectAddedEvent(*this); };
+        virtual Event *newClone() const { return new ObjectAddedEvent(*this); };
+        virtual std::string reprString() const { return std::format("ObjectAddedEvent(\"{}\")", objectId()); };
+    };
+
+    class ObjectUpdatedEvent : public ObjectChangedEvent {
+    public:
+        constexpr static const char *event_name = "ObjectUpdated";
+        ObjectUpdatedEvent(const std::string& object_id) :ObjectChangedEvent(event_name, object_id) {};
+        ObjectUpdatedEvent(const ObjectUpdatedEvent &other) :ObjectChangedEvent(other) {};
+        ObjectUpdatedEvent(ObjectUpdatedEvent &&other) :ObjectChangedEvent(std::move(other)) {};
+
+        virtual ~ObjectUpdatedEvent() {};
+
+        ObjectUpdatedEvent &operator=(const ObjectUpdatedEvent &other) { ObjectChangedEvent::operator=(other); return *this; };
+        ObjectUpdatedEvent &operator=(ObjectUpdatedEvent &&other) { ObjectChangedEvent::operator=(std::move(other)); return *this; };
+
+        virtual Event clone() const { return ObjectUpdatedEvent(*this); };
+        virtual Event *newClone() const { return new ObjectUpdatedEvent(*this); };
+        virtual std::string reprString() const { return std::format("ObjectUpdatedEvent(\"{}\")", objectId()); };
+    };
+
+    class ObjectDeletedEvent : public ObjectChangedEvent {
+    public:
+        constexpr static const char *event_name = "ObjectDeleted";
+        ObjectDeletedEvent(const std::string& object_id) :ObjectChangedEvent(event_name, object_id) {};
+        ObjectDeletedEvent(const ObjectDeletedEvent &other) :ObjectChangedEvent(other) {};
+        ObjectDeletedEvent(ObjectDeletedEvent &&other) :ObjectChangedEvent(std::move(other)) {};
 
         virtual ~ObjectDeletedEvent() {};
 
-        ObjectDeletedEvent &operator=(const ObjectDeletedEvent &other) {
-            Event::operator=(other);
-            m_object_id = other.m_object_id;
-            return *this;
-        };
-        ObjectDeletedEvent &operator=(ObjectDeletedEvent &&other) {
-            Event::operator=(std::move(other));
-            m_object_id = std::move(other.m_object_id);
-            return *this;
-        };
-
-        std::string objectId() const { return m_object_id; }
+        ObjectDeletedEvent &operator=(const ObjectDeletedEvent &other) { ObjectChangedEvent::operator=(other); return *this; };
+        ObjectDeletedEvent &operator=(ObjectDeletedEvent &&other) { ObjectChangedEvent::operator=(std::move(other)); return *this; };
 
         virtual Event clone() const { return ObjectDeletedEvent(*this); };
         virtual Event *newClone() const { return new ObjectDeletedEvent(*this); };
-        virtual std::string reprString() const { return std::format("ObjectDeletedEvent(\"{}\")", m_object_id); };
+        virtual std::string reprString() const { return std::format("ObjectDeletedEvent(\"{}\")", objectId()); };
+    };
+
+    class ObjectUpdateErrorEvent : public ObjectChangedEvent {
+    public:
+        constexpr static const char *event_name = "ObjectUpdateError";
+        ObjectUpdateErrorEvent(const std::string& object_id, int response_code) :ObjectChangedEvent(event_name, object_id), m_responseCode(response_code) {};
+        ObjectUpdateErrorEvent(const ObjectUpdateErrorEvent &other) :ObjectChangedEvent(other), m_responseCode(other.m_responseCode) {};
+        ObjectUpdateErrorEvent(ObjectUpdateErrorEvent &&other) :ObjectChangedEvent(std::move(other)), m_responseCode(other.m_responseCode) {};
+
+        virtual ~ObjectUpdateErrorEvent() {};
+
+        ObjectUpdateErrorEvent &operator=(const ObjectUpdateErrorEvent &other) {
+            ObjectChangedEvent::operator=(other);
+            m_responseCode = other.m_responseCode;
+            return *this;
+        };
+        ObjectUpdateErrorEvent &operator=(ObjectUpdateErrorEvent &&other) {
+            ObjectChangedEvent::operator=(std::move(other));
+            m_responseCode = other.m_responseCode;
+            return *this;
+        };
+
+        int responseCode() const { return m_responseCode; };
+
+        virtual Event clone() const { return ObjectUpdateErrorEvent(*this); };
+        virtual Event *newClone() const { return new ObjectUpdateErrorEvent(*this); };
+        virtual std::string reprString() const { return std::format("ObjectUpdateErrorEvent(\"{}\", {})", objectId(), m_responseCode); };
 
     private:
-        std::string m_object_id;
+        int m_responseCode;
     };
 
     class Metadata {
@@ -241,6 +289,8 @@ public:
     ObjectStore &operator=(ObjectStore&&) = delete;
 
     void addObject(const std::string& object_id, ObjectData &&object, Metadata &&metadata, bool synchronous_event = false);
+    void updateMetadata(const std::string& object_id, Metadata &&metadata, bool synchronous_event = false);
+    void updateError(const std::string& object_id, int response_code, bool synchronous_event = false);
     const ObjectData& getObjectData(const std::string& object_id) const;
     ObjectData& getObjectData(const std::string& object_id);
     const Metadata& getMetadata(const std::string& object_id) const;
@@ -248,12 +298,12 @@ public:
     void deleteObject(const std::string& object_id);
     bool removeObject(const std::string& objectId);
     bool removeObjects(const std::list<std::string>& objectIds);
-    std::list<std::pair<const std::string*, const Object*>> getExpired();
-    Object &operator[](const std::string& object_id);
-    const Object &operator[](const std::string& object_id) const;
+    std::list<std::pair<const std::string*, std::shared_ptr<Object> > > getExpired();
+    const std::shared_ptr<Object> &operator[](const std::string& object_id);
+    std::shared_ptr<const Object> operator[](const std::string& object_id) const;
     bool isStale(const std::string& object_id) const;
-    std::map<std::string, const Object&> getStale() const;
-    const std::map<std::string, Object> &getObjects() const { return m_store; };
+    std::map<std::string, std::shared_ptr<Object>> getStale() const;
+    const std::map<std::string, std::shared_ptr<Object> > &getObjects() const { return m_store; };
 
     const Metadata *findMetadataByURL(const std::string &url) const;
 
@@ -265,7 +315,7 @@ private:
     void checkExpiredObjects();
     mutable std::recursive_mutex m_mutex;
     ObjectController &m_controller;
-    std::map<std::string, Object> m_store;
+    std::map<std::string, std::shared_ptr<Object> > m_store;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -45,7 +45,8 @@ using reftools::mbstf::DistSessionState;
 MBSTF_NAMESPACE_START
 
 static void validate_distribution_session(DistributionSession &distributionSession);
-static bool check_if_object_added_is_manifest(std::string &objectId, ObjectStore &objectStore, std::string &manifest_url);
+static bool check_if_object_added_is_manifest(const std::string &object_id, ObjectStore &object_store,
+                                              const std::string &manifest_url);
 
 ObjectStreamingController::ObjectStreamingController(DistributionSession &distributionSession)
     :ObjectManifestController(distributionSession)
@@ -102,12 +103,13 @@ std::shared_ptr<ObjectListPackager> ObjectStreamingController::getObjectListPack
 
 void ObjectStreamingController::processEvent(Event &event, SubscriptionService &event_service)
 {
-    if (event.eventName() == "ObjectAdded") {
-        ObjectStore::ObjectAddedEvent &objAddedEvent = dynamic_cast<ObjectStore::ObjectAddedEvent&>(event);
-        std::string objectId = objAddedEvent.objectId();
-        ogs_info("Object added with ID: %s", objectId.c_str());
-	if(check_if_object_added_is_manifest(objectId, objectStore(), getManifestUrl())) {
-	    const ObjectStore::Object &object = objectStore()[objectId];
+    if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
+        event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
+        ObjectStore::ObjectChangedEvent &obj_changed_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
+        const std::string &object_id = obj_changed_event.objectId();
+        ogs_info("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
+	if(check_if_object_added_is_manifest(object_id, objectStore(), getManifestUrl())) {
+	    const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
 	    if(manifestHandler()) {
 	        try {
 	            if(!manifestHandler()->update(object)) {
@@ -117,7 +119,7 @@ void ObjectStreamingController::processEvent(Event &event, SubscriptionService &
 			return;
 		    }
 		    startWorker();
-                    sendToPackager(objectId);
+                    sendToPackager(object_id);
 	        } catch (std::exception &ex) {
                     ogs_error("Invalid Manifest update: %s", ex.what());
 		    unsetObjectListPackager();
@@ -128,20 +130,20 @@ void ObjectStreamingController::processEvent(Event &event, SubscriptionService &
 	    } else {
 		std::unique_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
                 manifestHandler(std::move(manifest_handler));
-                sendToPackager(objectId);
+                sendToPackager(object_id);
             }
 	} else {
-            sendToPackager(objectId);
+            sendToPackager(object_id);
         }
     }
     ObjectManifestController::processEvent(event, event_service);
 }
 
-void ObjectStreamingController::sendToPackager(const std::string &objectId)
+void ObjectStreamingController::sendToPackager(const std::string &object_id)
 {
     auto packager = getObjectListPackager();
     if (packager) {
-        ObjectListPackager::PackageItem item(objectId);
+        ObjectListPackager::PackageItem item(object_id);
         packager->add(item);
     }
 }
@@ -157,12 +159,12 @@ void ObjectStreamingController::reconfigureObjectPackager()
         if (packager) {
             const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
             const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
-            uint32_t mbr = distributionSession().getRateLimit();
+            uint32_t rate_limit = distributionSession().getRateLimit();
             in_port_t port = distributionSession().getPortNumber();
             in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
 
             if (dest_ip_addr) {
-                packager->updateFluteInfo(dest_ip_addr.value(), port, mbr, tunnel_addr, tunnel_port);
+                packager->updateFluteInfo(dest_ip_addr.value(), port, rate_limit, tunnel_addr, tunnel_port);
             }
         }
     }
@@ -183,8 +185,9 @@ static void validate_distribution_session(DistributionSession &distributionSessi
     }
 }
 
-static bool check_if_object_added_is_manifest(std::string &objectId, ObjectStore &objectStore, std::string &manifest_url) {
-    ObjectStore::Metadata &metadata = objectStore.getMetadata(objectId);
+static bool check_if_object_added_is_manifest(const std::string &object_id, ObjectStore &object_store,
+                                              const std::string &manifest_url) {
+    ObjectStore::Metadata &metadata = object_store.getMetadata(object_id);
     if(metadata.getOriginalUrl() == manifest_url || metadata.getFetchedUrl() == manifest_url) {
         metadata.keepAfterSend(true);
         return true;

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -37,10 +37,13 @@
 #include "ObjectListPackager.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
+#include "openapi/model/ProblemCause.hh"
 
 #include "ObjectStreamingController.hh"
 
 using reftools::mbstf::DistSessionState;
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
 
 MBSTF_NAMESPACE_START
 
@@ -76,7 +79,7 @@ void ObjectStreamingController::setObjectPackager()
     startWorker();
     const auto &obj_list = objectStore().getObjects();
     for (const auto &[obj_id, object] : obj_list) {
-        sendToPackager(obj_id);
+        sendToPackager(object);
     }
 }
 
@@ -108,42 +111,42 @@ void ObjectStreamingController::processEvent(Event &event, SubscriptionService &
         ObjectStore::ObjectChangedEvent &obj_changed_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
         const std::string &object_id = obj_changed_event.objectId();
         ogs_info("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
-	if(check_if_object_added_is_manifest(object_id, objectStore(), getManifestUrl())) {
-	    const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
-	    if(manifestHandler()) {
-	        try {
-	            if(!manifestHandler()->update(object)) {
-		        ogs_error("Failed to update Manifest");
-			unsetObjectListPackager();
-			event.stopProcessing();
-			return;
-		    }
-		    startWorker();
-                    sendToPackager(object_id);
-	        } catch (std::exception &ex) {
+        const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
+        if(check_if_object_added_is_manifest(object_id, objectStore(), getManifestUrl())) {
+            if(manifestHandler()) {
+                try {
+                    if(!manifestHandler()->update(object)) {
+                        ogs_error("Failed to update Manifest");
+                        unsetObjectListPackager();
+                        event.stopProcessing();
+                        return;
+                    }
+                    startWorker();
+                    sendToPackager(object);
+                } catch (std::exception &ex) {
                     ogs_error("Invalid Manifest update: %s", ex.what());
-		    unsetObjectListPackager();
-		    event.stopProcessing();
-		    return;
+                    unsetObjectListPackager();
+                    event.stopProcessing();
+                    return;
                 }
 
-	    } else {
-		std::unique_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
+            } else {
+                std::unique_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
                 manifestHandler(std::move(manifest_handler));
-                sendToPackager(object_id);
+                sendToPackager(object);
             }
-	} else {
-            sendToPackager(object_id);
+        } else {
+            sendToPackager(object);
         }
     }
     ObjectManifestController::processEvent(event, event_service);
 }
 
-void ObjectStreamingController::sendToPackager(const std::string &object_id)
+void ObjectStreamingController::sendToPackager(const std::shared_ptr<ObjectStore::Object> &object)
 {
     auto packager = getObjectListPackager();
     if (packager) {
-        ObjectListPackager::PackageItem item(object_id);
+        ObjectListPackager::PackageItem item(object);
         packager->add(item);
     }
 }
@@ -178,11 +181,12 @@ static const struct init {
 } g_init;
 }
 
-static void validate_distribution_session(DistributionSession &distributionSession)
+static void validate_distribution_session(DistributionSession &distribution_session)
 {
-    if (distributionSession.getObjectDistributionOperatingMode() != "STREAMING") {
+    if (distribution_session.getObjectDistributionOperatingMode() != "STREAMING") {
         throw std::logic_error("Expected objDistributionOperatingMode to be set to STREAMING.");
     }
+    ObjectController::validateDistributionSession(distribution_session);
 }
 
 static bool check_if_object_added_is_manifest(const std::string &object_id, ObjectStore &object_store,

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: ObjectStreamingController class
+ * 5G-MAG Reference Tools: MBS Transport Function: ObjectStreamingController class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -30,11 +30,12 @@
 #include "Event.hh"
 #include "ManifestHandlerFactory.hh"
 #include "ObjectController.hh"
+#include "ObjectListPackager.hh"
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
 #include "PushObjectIngester.hh"
+#include "SsmPort.hh"
 #include "SubscriptionService.hh"
-#include "ObjectListPackager.hh"
 #include "utilities.hh"
 #include "openapi/model/DistSessionState.h"
 #include "openapi/model/ProblemCause.hh"
@@ -67,13 +68,12 @@ ObjectStreamingController::~ObjectStreamingController()
 
 void ObjectStreamingController::setObjectPackager()
 {
-    const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+    auto ssm_port = distributionSession().getSsmPort();
     const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t port = distributionSession().getPortNumber();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(dest_ip_addr, port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
-    packager(new ObjectListPackager(objectStore(), *this, dest_ip_addr, rate_limit, mtu, port, tunnel_addr, tunnel_port));
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);
     startWorker();
@@ -160,14 +160,13 @@ void ObjectStreamingController::reconfigureObjectPackager()
     if (distributionSession().getState() == DistSessionState::VAL_ACTIVE) {
         auto packager = getObjectListPackager();
         if (packager) {
-            const std::optional<std::string> &dest_ip_addr = distributionSession().getDestIpAddr();
+            auto ssm_port = distributionSession().getSsmPort();
             const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
             uint32_t rate_limit = distributionSession().getRateLimit();
-            in_port_t port = distributionSession().getPortNumber();
             in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
 
-            if (dest_ip_addr) {
-                packager->updateFluteInfo(dest_ip_addr.value(), port, rate_limit, tunnel_addr, tunnel_port);
+            if (ssm_port) {
+                packager->updateFluteInfo(ssm_port, rate_limit, tunnel_addr, tunnel_port);
             }
         }
     }

--- a/src/mbstf/ObjectStreamingController.hh
+++ b/src/mbstf/ObjectStreamingController.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OBJECT_STREAMING_CONTROLLER_HH_
 #define _MBS_TF_OBJECT_STREAMING_CONTROLLER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Object Streaming Controller class
+ * 5G-MAG Reference Tools: MBS Transport Function: Object Streaming Controller class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/ObjectStreamingController.hh
+++ b/src/mbstf/ObjectStreamingController.hh
@@ -19,6 +19,7 @@
 #include "common.hh"
 #include "openapi/model/ObjDistributionData.h"
 #include "ObjectManifestController.hh"
+#include "ObjectStore.hh"
 
 MBSTF_NAMESPACE_START
 
@@ -71,7 +72,7 @@ protected:
     virtual void deactivateObjectPackager();
 
 private:
-    void sendToPackager(const std::string &object_id);
+    void sendToPackager(const std::shared_ptr<ObjectStore::Object> &object);
     //std::string generateUUID();
     //std::shared_ptr<ObjectListPackager> m_objectListPackager;
 //    std::thread m_ingestSchedulingThread;

--- a/src/mbstf/Open5GSEvent.hh
+++ b/src/mbstf/Open5GSEvent.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_EVENT_HH_
 #define _MBS_TF_OPEN5GS_EVENT_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS Event interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS Event interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSFSM.hh
+++ b/src/mbstf/Open5GSFSM.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_FSM_HH_
 #define _MBS_TF_OPEN5GS_FSM_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS FSM interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS FSM interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSNetworkFunction.cc
+++ b/src/mbstf/Open5GSNetworkFunction.cc
@@ -236,7 +236,7 @@ int Open5GSNetworkFunction::setServerName(void) {
         if (!advertise)
             advertise = server->node.addr;
         ogs_assert(advertise);
-	res = getnameinfo((struct sockaddr *) &advertise->sa,
+        res = getnameinfo((struct sockaddr *) &advertise->sa,
                       ogs_sockaddr_len(advertise),
                       server_name, NI_MAXHOST,
                       NULL, 0, NI_NAMEREQD);
@@ -247,7 +247,7 @@ int Open5GSNetworkFunction::setServerName(void) {
         } else {
             ogs_debug("node=%s", server_name);
             ogs_info("SERVER NAME NODE=%s", server_name);
-	    m_serverName = server_name;
+            m_serverName = server_name;
             return 1;
         }
     }
@@ -335,8 +335,8 @@ void Open5GSNetworkFunction::addAddressesToNFService(ogs_sbi_nf_service_t *nf_se
     for (const auto &addrs: addresses) {
 
         for (ogs_copyaddrinfo(&addr, addrs->ogsSockAddr()); addr && nf_service->num_of_addr < OGS_SBI_MAX_NUM_OF_IP_ADDRESS;
-			addr = addr->next)
-	{
+                        addr = addr->next)
+        {
             bool is_port = true;
             int port = 0;
 

--- a/src/mbstf/Open5GSNetworkFunction.cc
+++ b/src/mbstf/Open5GSNetworkFunction.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS Application interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS Application interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSNetworkFunction.hh
+++ b/src/mbstf/Open5GSNetworkFunction.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_NETWORK_FUNCTION_HH_
 #define _MBS_TF_OPEN5GS_NETWORK_FUNCTION_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS Application interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS Application interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIClient.cc
+++ b/src/mbstf/Open5GSSBIClient.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Client class
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Client class
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIClient.cc
+++ b/src/mbstf/Open5GSSBIClient.cc
@@ -70,12 +70,12 @@ Open5GSSBIClient::Open5GSSBIClient(const char *hostname, int port)
     rv = ogs_getaddrinfo(&addr, AF_UNSPEC, hostname, port, 0);
     if (rv != OGS_OK) {
         ogs_error("getaddrinfo failed");
-	throw std::runtime_error("getaddrinfo failed!");
+        throw std::runtime_error("getaddrinfo failed!");
     }
 
     if (addr == nullptr) {
         ogs_error("Could not get the address of the Application Server");
-	throw std::runtime_error("Unable to get client address!");
+        throw std::runtime_error("Unable to get client address!");
     }
 
     m_ogsClient = ogs_sbi_client_add(scheme, addr);

--- a/src/mbstf/Open5GSSBIClient.hh
+++ b/src/mbstf/Open5GSSBIClient.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_CLIENT_HH_
 #define _MBS_TF_OPEN5GS_SBI_CLIENT_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Client interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Client interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIMessage.cc
+++ b/src/mbstf/Open5GSSBIMessage.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Message interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Message interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIMessage.hh
+++ b/src/mbstf/Open5GSSBIMessage.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_MESSAGE_HH_
 #define _MBS_TF_OPEN5GS_SBI_MESSAGE_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Message interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Message interface
  ******************************************************************************
  * Copyright: (C)2024-2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIRequest.cc
+++ b/src/mbstf/Open5GSSBIRequest.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Request interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Request interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author: David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIRequest.hh
+++ b/src/mbstf/Open5GSSBIRequest.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_REQUEST_HH_
 #define _MBS_TF_OPEN5GS_SBI_REQUEST_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Request interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Request interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIResponse.cc
+++ b/src/mbstf/Open5GSSBIResponse.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Response interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Response interface
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author: David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIResponse.hh
+++ b/src/mbstf/Open5GSSBIResponse.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_RESPONSE_HH_
 #define _MBS_TF_OPEN5GS_SBI_RESPONSE_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Response interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Response interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIServer.cc
+++ b/src/mbstf/Open5GSSBIServer.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Server interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Server interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIServer.hh
+++ b/src/mbstf/Open5GSSBIServer.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_SERVER_HH_
 #define _MBS_TF_OPEN5GS_SBI_SERVER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Server interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Server interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSBIStream.hh
+++ b/src/mbstf/Open5GSSBIStream.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_STREAM_HH_
 #define _MBS_TF_OPEN5GS_SBI_STREAM_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI Stream interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI Stream interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSSockAddr.hh
+++ b/src/mbstf/Open5GSSockAddr.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_SBI_SOCKADDR_HH_
 #define _MBS_TF_OPEN5GS_SBI_SOCKADDR_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS SBI SockAddr interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS SBI SockAddr interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSTimer.hh
+++ b/src/mbstf/Open5GSTimer.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_TIMER_HH_
 #define _MBS_TF_OPEN5GS_TIMER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS ogs_timer_t wrapper
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS ogs_timer_t wrapper
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSYamlDocument.hh
+++ b/src/mbstf/Open5GSYamlDocument.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_YAML_DOCUMENT_HH_
 #define _MBS_TF_OPEN5GS_YAML_DOCUMENT_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS YAML document interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS YAML document interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSYamlIter.cc
+++ b/src/mbstf/Open5GSYamlIter.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS YAML iterator
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS YAML iterator
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Open5GSYamlIter.hh
+++ b/src/mbstf/Open5GSYamlIter.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_OPEN5GS_YAML_ITER_HH_
 #define _MBS_TF_OPEN5GS_YAML_ITER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Open5GS YAML Iterator class
+ * 5G-MAG Reference Tools: MBS Transport Function: Open5GS YAML Iterator class
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -236,6 +236,7 @@ void PullObjectIngester::doObjectIngest() {
                     this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
                 } else if (response_code == 304) {
                     /* Not Modified - just update metadata */
+                    if (old_meta) metadata.mediaType(old_meta->mediaType()); // 304 may not have Content-Type due to no content
                     this->objectStore().updateMetadata(item.objectId(), std::move(metadata), true);
                 } else {
                     /* error response - do we throw the object away? */

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -219,18 +219,28 @@ void PullObjectIngester::doObjectIngest() {
             // Check the result
             if (bytesReceived >= 0) {
                 ogs_debug("Received %ld bytes of data", bytesReceived);
-	        auto lastModified = std::chrono::system_clock::now();
                 std::string fetched_url = URI(m_curl->getPermanentRedirectUrl()).resolveUsingBaseURLs(std::list<BaseURL>{BaseURL(item.url())}).str();
                 if (fetched_url.empty()) fetched_url = item.url();
-	        ObjectStore::Metadata metadata(item.objectId(), m_curl->getContentType(), item.url(), fetched_url, item.acquisitionId(), lastModified, item.objIngestBaseUrl(), item.objDistributionBaseUrl());
+	        ObjectStore::Metadata metadata(item.objectId(), m_curl->getContentType(), item.url(), fetched_url, item.acquisitionId(), m_curl->getLastModified(), item.objIngestBaseUrl(), item.objDistributionBaseUrl());
                 if (old_meta) metadata.fluteFileDescription(old_meta->fluteFileDescription());
                 unsigned long max_age = m_curl->getCacheControlMaxAge();
-	        metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
+                unsigned long current_age = m_curl->getAge();
+	        metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age - current_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
                 const std::string& etag = m_curl->getEtag();
 	        if (!etag.empty()) {
                     metadata.entityTag(etag);
 	        }
-	        this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
+                auto response_code = m_curl->getResponseCode();
+                if (response_code >= 200 && response_code <= 299) {
+                    /* received object - store it */
+                    this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
+                } else if (response_code == 304) {
+                    /* Not Modified - just update metadata */
+                    this->objectStore().updateMetadata(item.objectId(), std::move(metadata), true);
+                } else {
+                    /* error response - do we throw the object away? */
+                    this->objectStore().updateError(item.objectId(), response_code, true);
+                }
             } else if (bytesReceived == -1) {
                 ogs_error("Request timed out.");
                 emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::TIMED_OUT);

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Pull Object Ingester
+ * 5G-MAG Reference Tools: MBS Transport Function: Pull Object Ingester
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this
@@ -18,6 +19,9 @@
 #include <iostream>
 #include <string>
 
+#include <libmpd++/BaseURL.hh>
+#include <libmpd++/URI.hh>
+
 #include "common.hh"
 #include "App.hh"
 #include "PullObjectIngester.hh"
@@ -25,6 +29,8 @@
 #include "Curl.hh"
 #include "ObjectStore.hh"
 
+LIBMPDPP_NAMESPACE_USING(BaseURL);
+LIBMPDPP_NAMESPACE_USING(URI);
 using namespace std::literals::chrono_literals;
 
 MBSTF_NAMESPACE_START
@@ -214,7 +220,7 @@ void PullObjectIngester::doObjectIngest() {
             if (bytesReceived >= 0) {
                 ogs_debug("Received %ld bytes of data", bytesReceived);
 	        auto lastModified = std::chrono::system_clock::now();
-                std::string fetched_url = m_curl->getPermanentRedirectUrl();
+                std::string fetched_url = URI(m_curl->getPermanentRedirectUrl()).resolveUsingBaseURLs(std::list<BaseURL>{BaseURL(item.url())}).str();
                 if (fetched_url.empty()) fetched_url = item.url();
 	        ObjectStore::Metadata metadata(item.objectId(), m_curl->getContentType(), item.url(), fetched_url, item.acquisitionId(), lastModified, item.objIngestBaseUrl(), item.objDistributionBaseUrl());
                 if (old_meta) metadata.fluteFileDescription(old_meta->fluteFileDescription());

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -35,6 +35,8 @@ using namespace std::literals::chrono_literals;
 
 MBSTF_NAMESPACE_START
 
+/***** PullObjectIngester::IngestItem methods *****/
+
 PullObjectIngester::IngestItem::IngestItem(const ObjectStore::Metadata &object_meta,
                                            const std::optional<time_type> &download_deadline)
     :m_objectId(object_meta.objectId())
@@ -75,6 +77,14 @@ PullObjectIngester::IngestItem::IngestItem(IngestItem &&other)
     ,m_deadline(std::move(other.m_deadline))
 {
 }
+
+/***** PullObjectIngester::PullIngestFailedEvent methods *****/
+
+std::string PullObjectIngester::PullIngestFailedEvent::reprString() const {
+    return std::format("PullIngestFailedEvent(<item>, \"{}\", {})", url(), static_cast<int>(failureType()));
+}
+
+/***** PullObjectIngester methods *****/
 
 PullObjectIngester::~PullObjectIngester() {abort();}
 
@@ -182,8 +192,8 @@ void PullObjectIngester::doObjectIngest() {
         if (!m_fetchList.empty()) {
             // Make the GET request and get the number of bytes received
             auto item = m_fetchList.front();
-	    m_fetchList.pop_front();
-	    m_ingestItemsMutex->unlock(); // temp unlock while we fetch
+            m_fetchList.pop_front();
+            m_ingestItemsMutex->unlock(); // temp unlock while we fetch
             ObjectStore::Metadata *old_meta = nullptr;
             try {
                 auto &meta = objectStore().getMetadata(item.objectId());
@@ -197,7 +207,7 @@ void PullObjectIngester::doObjectIngest() {
             } catch (const std::out_of_range &ex) {
                 ogs_debug("Fetching %s...", item.url().c_str());
             }
-           
+
             const auto &deadline = item.deadline();
             std::chrono::milliseconds timeout(10000);
             if (deadline) {
@@ -221,38 +231,55 @@ void PullObjectIngester::doObjectIngest() {
                 ogs_debug("Received %ld bytes of data", bytesReceived);
                 std::string fetched_url = URI(m_curl->getPermanentRedirectUrl()).resolveUsingBaseURLs(std::list<BaseURL>{BaseURL(item.url())}).str();
                 if (fetched_url.empty()) fetched_url = item.url();
-	        ObjectStore::Metadata metadata(item.objectId(), m_curl->getContentType(), item.url(), fetched_url, item.acquisitionId(), m_curl->getLastModified(), item.objIngestBaseUrl(), item.objDistributionBaseUrl());
+                ObjectStore::Metadata metadata(item.objectId(), m_curl->getContentType(), item.url(), fetched_url, item.acquisitionId(), m_curl->getLastModified(), item.objIngestBaseUrl(), item.objDistributionBaseUrl());
+                /* re-get metadata from ObjectStore as it may have changed */
+                try {
+                    auto &meta = objectStore().getMetadata(item.objectId());
+                    old_meta = &meta;
+                } catch (const std::out_of_range &ex) {
+                    old_meta = nullptr;
+                }
                 if (old_meta) metadata.fluteFileDescription(old_meta->fluteFileDescription());
                 unsigned long max_age = m_curl->getCacheControlMaxAge();
                 unsigned long current_age = m_curl->getAge();
-	        metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age) - std::chrono::seconds(current_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
+                metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age) - std::chrono::seconds(current_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
                 const std::string& etag = m_curl->getEtag();
-	        if (!etag.empty()) {
+                if (!etag.empty()) {
                     metadata.entityTag(etag);
-	        }
+                }
                 auto response_code = m_curl->getResponseCode();
                 if (response_code >= 200 && response_code <= 299) {
                     /* received object - store it */
                     this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
                 } else if (response_code == 304) {
                     /* Not Modified - just update metadata */
-                    if (old_meta) metadata.mediaType(old_meta->mediaType()); // 304 may not have Content-Type due to no content
-                    this->objectStore().updateMetadata(item.objectId(), std::move(metadata), true);
+                    if (old_meta) {
+                        metadata.mediaType(old_meta->mediaType()); // 304 may not have Content-Type due to no content
+                        this->objectStore().updateMetadata(item.objectId(), std::move(metadata), true);
+                    }
                 } else {
                     /* error response - do we throw the object away? */
-                    this->objectStore().updateError(item.objectId(), response_code, true);
+                    ogs_debug("Fetch error %i", response_code);
+                    emitObjectPullIngestFailedEvent(item, fetched_url, (response_code >= 400 && response_code <= 499)?ObjectIngester::IngestFailedEvent::CLIENT_ERROR:ObjectIngester::IngestFailedEvent::SERVER_ERROR);
+                    this->objectStore().updateError(item.objectId(), response_code, item.url(), false);
                 }
             } else if (bytesReceived == -1) {
                 ogs_error("Request timed out.");
-                emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::TIMED_OUT);
+                emitObjectPullIngestFailedEvent(item, item.url(), ObjectIngester::IngestFailedEvent::TIMED_OUT);
             } else {
                 ogs_error("An error occurred while fetching the data.");
-                emitObjectIngestFailedEvent(item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
+                emitObjectPullIngestFailedEvent(item, item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
             }
             m_ingestItemsMutex->lock();
             if (m_fetchList.empty()) sendEventAsynchronous(new ObjectPullQueueExhaustedEvent);
-	}
+        }
     }
+}
+
+void PullObjectIngester::emitObjectPullIngestFailedEvent(const PullObjectIngester::IngestItem &item, const std::string &fetch_url,
+                                                         IngestFailedEvent::FailureType fail_type)
+{
+    sendEventAsynchronous(PullIngestFailedEvent(item, fetch_url, fail_type));
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -225,7 +225,7 @@ void PullObjectIngester::doObjectIngest() {
                 if (old_meta) metadata.fluteFileDescription(old_meta->fluteFileDescription());
                 unsigned long max_age = m_curl->getCacheControlMaxAge();
                 unsigned long current_age = m_curl->getAge();
-	        metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age - current_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
+	        metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age) - std::chrono::seconds(current_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
                 const std::string& etag = m_curl->getEtag();
 	        if (!etag.empty()) {
                     metadata.entityTag(etag);

--- a/src/mbstf/PullObjectIngester.hh
+++ b/src/mbstf/PullObjectIngester.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_PULL_OBJECT_INGESTER_HH_
 #define _MBS_TF_PULL_OBJECT_INGESTER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Pull Object Ingester class
+ * 5G-MAG Reference Tools: MBS Transport Function: Pull Object Ingester class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/PullObjectIngester.hh
+++ b/src/mbstf/PullObjectIngester.hh
@@ -112,6 +112,7 @@ public:
 
 protected:
     virtual void doObjectIngest();
+    virtual void cancelWorker() { m_ingestItemsCondVar.notify_all(); };
 
 private:
     void sortListByPolicy();

--- a/src/mbstf/PullObjectIngester.hh
+++ b/src/mbstf/PullObjectIngester.hh
@@ -45,7 +45,7 @@ public:
 
         IngestItem() = delete;
         IngestItem(const ObjectStore::Metadata &object_meta, const std::optional<time_type> &download_deadline = std::nullopt);
-	IngestItem(const std::string &object_id, const std::string &url, const std::string &acquisition_id,
+        IngestItem(const std::string &object_id, const std::string &url, const std::string &acquisition_id,
                    const std::optional<std::string> &obj_ingest_base_url = std::nullopt,
                    const std::optional<std::string> &obj_distribution_base_url = std::nullopt,
                    const std::optional<time_type> &download_deadline = std::nullopt);
@@ -70,7 +70,7 @@ public:
 
         bool hasDeadline() const { return m_deadline.has_value(); };
         const std::optional<time_type> &deadline() const { return m_deadline; };
-	const time_type &getDeadline() const { return m_deadline.value(); };
+        const time_type &getDeadline() const { return m_deadline.value(); };
 
         time_type deadline(const time_type &default_deadline) const { return m_deadline.value_or(default_deadline); };
         IngestItem &deadline(std::nullopt_t) { m_deadline.reset(); return *this; };
@@ -80,10 +80,31 @@ public:
     private:
         std::string m_objectId;
         std::string m_url;
-	std::string m_acquisitionId;
+        std::string m_acquisitionId;
         std::optional<std::string> m_objIngestBaseUrl;
         std::optional<std::string> m_objDistributionBaseUrl;
         std::optional<time_type> m_deadline;
+    };
+
+    class PullIngestFailedEvent : public ObjectIngester::IngestFailedEvent {
+    public:
+        PullIngestFailedEvent(const PullObjectIngester::IngestItem &item, const std::string &url, ObjectIngester::IngestFailedEvent::FailureType fail_type) : ObjectIngester::IngestFailedEvent(url, fail_type), m_item(item) {};
+        PullIngestFailedEvent(const PullIngestFailedEvent &other) : ObjectIngester::IngestFailedEvent(other), m_item(other.m_item) {};
+        PullIngestFailedEvent(PullIngestFailedEvent &&other) : ObjectIngester::IngestFailedEvent(std::move(other)), m_item(std::move(other.m_item)) {};
+
+        virtual ~PullIngestFailedEvent() {};
+
+        PullIngestFailedEvent &operator=(const PullIngestFailedEvent &other) = delete;
+        PullIngestFailedEvent &operator=(PullIngestFailedEvent &&other) = delete;
+
+        const PullObjectIngester::IngestItem &item() const { return m_item; };
+
+        virtual Event clone() const { return PullIngestFailedEvent(*this); };
+        virtual Event *newClone() const { return new PullIngestFailedEvent(*this); };
+        virtual std::string reprString() const;
+
+    private:
+        PullObjectIngester::IngestItem m_item;
     };
 
     PullObjectIngester() = delete;
@@ -113,6 +134,7 @@ public:
 protected:
     virtual void doObjectIngest();
     virtual void cancelWorker() { m_ingestItemsCondVar.notify_all(); };
+    void emitObjectPullIngestFailedEvent(const IngestItem &item, const std::string &fetch_url, IngestFailedEvent::FailureType fail_type);
 
 private:
     void sortListByPolicy();

--- a/src/mbstf/PushObjectIngester.cc
+++ b/src/mbstf/PushObjectIngester.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Push Object Ingester
+ * 5G-MAG Reference Tools: MBS Transport Function: Push Object Ingester
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/PushObjectIngester.hh
+++ b/src/mbstf/PushObjectIngester.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_PUSH_OBJECT_INGESTER_HH_
 #define _MBS_TF_PUSH_OBJECT_INGESTER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Push Object Ingester class
+ * 5G-MAG Reference Tools: MBS Transport Function: Push Object Ingester class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/PushObjectIngester.hh
+++ b/src/mbstf/PushObjectIngester.hh
@@ -40,16 +40,16 @@ public:
         Request() = delete;
         Request(const Request&) = delete;
         Request(Request&&) = delete;
-	Request(struct MHD_Connection *mhd_connection, PushObjectIngester &poi);
+        Request(struct MHD_Connection *mhd_connection, PushObjectIngester &poi);
 
-	virtual ~Request() {};
+        virtual ~Request() {};
 
         Request &operator=(const Request&) = delete;
         Request &operator=(Request&&) = delete;
 
-	const std::string &method() const { return m_method; };
+        const std::string &method() const { return m_method; };
 
-	Request &method(const std::string &method) { m_method = method; return *this; };
+        Request &method(const std::string &method) { m_method = method; return *this; };
         Request &method(std::string &&method) { m_method = std::move(method); return *this; };
 
         const std::string &urlPath() const { return m_urlPath; };
@@ -59,7 +59,7 @@ public:
         const std::string &protocolVersion() const { return m_protocolVersion; };
         Request &protocolVersion(const std::string &proto_ver) { m_protocolVersion = proto_ver; return *this; };
 
-	Request &protocolVersion(std::string &&proto_ver) { m_protocolVersion = std::move(proto_ver); return *this;};
+        Request &protocolVersion(std::string &&proto_ver) { m_protocolVersion = std::move(proto_ver); return *this;};
 
         const std::optional<std::string> &etag() const { return m_etag; };
         Request &etag(std::nullopt_t) { m_etag.reset(); return *this; };
@@ -81,24 +81,24 @@ public:
         Request &lastModified(const time_type &last_modified) { m_lastModified = last_modified; return *this; };
         Request &lastModified(const std::optional<time_type> &last_modified) { m_lastModified = last_modified; return *this; };
 
-	std::optional<std::string> getHeader(const std::string &field) const;
+        std::optional<std::string> getHeader(const std::string &field) const;
         data_size_type bodySize() const { return m_totalBodySize; };
 
-	bool addBodyBlock(const data_type &body_block);
-	bool setError(unsigned int status_code = 0, const std::string &reason = std::string());
+        bool addBodyBlock(const data_type &body_block);
+        bool setError(unsigned int status_code = 0, const std::string &reason = std::string());
         void completed(struct MHD_Connection *connection, enum MHD_RequestTerminationCode term_code);
-	virtual void waitClose() {};
-	void requestHandler(struct MHD_Connection *connection);
-	typedef bool (*HeaderProcessingCallback)(const std::string &key, const std::string &value, void *data);
-	void processRequestHeader(HeaderProcessingCallback callback, void *data) const;
+        virtual void waitClose() {};
+        void requestHandler(struct MHD_Connection *connection);
+        typedef bool (*HeaderProcessingCallback)(const std::string &key, const std::string &value, void *data);
+        void processRequestHeader(HeaderProcessingCallback callback, void *data) const;
 
         virtual std::string reprString() const;
 
     protected:
-	//Request(const std::string &url, const std::string &method, const std::string &version);
-	virtual void processRequest();
+        //Request(const std::string &url, const std::string &method, const std::string &version);
+        virtual void processRequest();
 
-	struct MHD_Connection *m_mhdConnection;
+        struct MHD_Connection *m_mhdConnection;
         struct MHD_Response *m_mhdResponse;
 
     private:
@@ -120,7 +120,7 @@ public:
         std::string m_errorReason;
         bool m_noMoreBodyData;
 
-	std::unique_ptr<std::recursive_mutex> m_mutex;
+        std::unique_ptr<std::recursive_mutex> m_mutex;
         std::condition_variable_any m_condVar; /**< CondVar for new response content/eof */
     };
 

--- a/src/mbstf/SsmPort.cc
+++ b/src/mbstf/SsmPort.cc
@@ -1,0 +1,118 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: SSM with Port class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <stdint.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "common.hh"
+#include "openapi/model/IpAddr.h"
+#include "openapi/model/UpTrafficFlowInfo.h"
+
+#include "SsmPort.hh"
+
+using reftools::mbstf::IpAddr;
+using reftools::mbstf::UpTrafficFlowInfo;
+
+MBSTF_NAMESPACE_START
+
+static std::string _conv_IpAddr_to_string(const std::shared_ptr<IpAddr> &ip_addr);
+
+/*** SsmPort class ***/
+
+SsmPort::SsmPort()
+    :m_sourceAddr()
+    ,m_destAddr()
+    ,m_port(0)
+{
+}
+
+SsmPort::SsmPort(const std::shared_ptr<UpTrafficFlowInfo> &up_traffic_flow_info)
+    :m_sourceAddr()
+    ,m_destAddr()
+    ,m_port(0)
+{
+    if (up_traffic_flow_info) {
+        m_port = static_cast<in_port_t>(up_traffic_flow_info->getPortNumber());
+        auto &src_addr = up_traffic_flow_info->getSrcIpAddr();
+        if (src_addr) {
+            m_sourceAddr = _conv_IpAddr_to_string(src_addr.value());
+        }
+        m_destAddr = _conv_IpAddr_to_string(up_traffic_flow_info->getDestIpAddr());
+    }
+}
+
+SsmPort::SsmPort(in_port_t port, const std::string &multicast_destination, const std::optional<std::string> &unicast_source)
+    :m_sourceAddr(unicast_source)
+    ,m_destAddr(multicast_destination)
+    ,m_port(port)
+{
+}
+
+SsmPort::SsmPort(const SsmPort &other)
+    :m_sourceAddr(other.m_sourceAddr)
+    ,m_destAddr(other.m_destAddr)
+    ,m_port(other.m_port)
+{
+}
+
+SsmPort::SsmPort(SsmPort &&other)
+    :m_sourceAddr(std::move(other.m_sourceAddr))
+    ,m_destAddr(std::move(other.m_destAddr))
+    ,m_port(other.m_port)
+{
+}
+
+SsmPort &SsmPort::operator=(const SsmPort &other)
+{
+    m_sourceAddr = other.m_sourceAddr;
+    m_destAddr = other.m_destAddr;
+    m_port = other.m_port;
+    return *this;
+}
+
+SsmPort &SsmPort::operator=(SsmPort &&other)
+{
+    m_sourceAddr = std::move(other.m_sourceAddr);
+    m_destAddr = std::move(other.m_destAddr);
+    m_port = other.m_port;
+    return *this;
+}
+
+bool SsmPort::operator==(const SsmPort &other) const
+{
+    return m_port == other.m_port && m_destAddr == other.m_destAddr && m_sourceAddr == other.m_sourceAddr;
+}
+
+/*** Local functions ***/
+
+static std::string _conv_IpAddr_to_string(const std::shared_ptr<IpAddr> &ip_addr)
+{
+    if (!ip_addr) return std::string();
+    const auto &ipv4_addr = ip_addr->getIpv4Addr();
+    if (ipv4_addr) return ipv4_addr.value();
+    const auto &ipv6_addr = ip_addr->getIpv6Addr();
+    if (ipv6_addr && ipv6_addr.value()) {
+        return *ipv6_addr.value();
+    }
+    const auto &ipv6_prefix = ip_addr->getIpv6Prefix();
+    if (ipv6_prefix && ipv6_prefix.value()) {
+        return *ipv6_prefix.value();
+    }
+    return std::string();
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/SsmPort.hh
+++ b/src/mbstf/SsmPort.hh
@@ -1,0 +1,73 @@
+#ifndef _MBS_TF_SSM_PORT_HH_
+#define _MBS_TF_SSM_PORT_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: SSM with Port class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <stdint.h>
+#include <netinet/in.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "common.hh"
+
+namespace reftools::mbstf {
+    class UpTrafficFlowInfo;
+}
+
+MBSTF_NAMESPACE_START
+
+class SsmPort {
+public:
+    SsmPort();
+    SsmPort(const std::shared_ptr<reftools::mbstf::UpTrafficFlowInfo> &up_traffic_flow_info);
+    SsmPort(in_port_t port, const std::string &multicast_destination, const std::optional<std::string> &unicast_source);
+    SsmPort(const SsmPort &other);
+    SsmPort(SsmPort &&other);
+
+    virtual ~SsmPort() {};
+
+    SsmPort &operator=(const SsmPort &other);
+    SsmPort &operator=(SsmPort &&other);
+
+    bool operator==(const SsmPort &other) const;
+    bool operator!=(const SsmPort &other) const { return !(*this == other); };
+
+    operator bool() const { return m_port != 0 && !m_destAddr.empty(); };
+
+    const std::optional<std::string> &sourceAddress() const { return m_sourceAddr; };
+    bool hasSourceAddress() const { return m_sourceAddr.has_value(); };
+    SsmPort &sourceAddress(const std::nullopt_t &val) { m_sourceAddr.reset(); return *this; };
+    SsmPort &sourceAddress(const std::optional<std::string> &val) { m_sourceAddr = val; return *this; };
+    SsmPort &sourceAddress(std::optional<std::string> &&val) { m_sourceAddr = std::move(val); return *this; };
+    SsmPort &sourceAddress(const std::string &val) { m_sourceAddr = val; return *this; };
+    SsmPort &sourceAddress(std::string &&val) { m_sourceAddr = std::move(val); return *this; };
+
+    const std::string &destinationAddress() const { return m_destAddr; };
+    SsmPort &destinationAddress(const std::string &val) { m_destAddr = val; return *this; };
+    SsmPort &destinationAddress(std::string &&val) { m_destAddr = std::move(val); return *this; };
+
+    in_port_t port() const { return m_port; };
+    SsmPort &port(in_port_t val) { m_port = val; return *this; };
+
+private:
+    std::optional<std::string> m_sourceAddr;
+    std::string m_destAddr;
+    in_port_t m_port;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* _MBS_TF_SSM_PORT_HH_ */

--- a/src/mbstf/Subscriber.cc
+++ b/src/mbstf/Subscriber.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Subscriber class
+ * 5G-MAG Reference Tools: MBS Transport Function: Subscriber class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/Subscriber.hh
+++ b/src/mbstf/Subscriber.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_SUBSCRIBER_HH_
 #define _MBS_TF_SUBSCRIBER_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Subscriber class
+ * 5G-MAG Reference Tools: MBS Transport Function: Subscriber class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/SubscriptionService.cc
+++ b/src/mbstf/SubscriptionService.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Subscription Service class
+ * 5G-MAG Reference Tools: MBS Transport Function: Subscription Service class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/SubscriptionService.cc
+++ b/src/mbstf/SubscriptionService.cc
@@ -329,10 +329,10 @@ void SubscriptionService::asyncEventsLoop()
     auto self = shared_from_this(); /* make sure we don't get deleted while sending events, but exit if we are the last holder */
     while (!m_asyncCancel && self.use_count() > 1) {
         std::lock_guard guard(*m_asyncMutex);
-        while (!m_asyncCancel && m_asyncEventQueue.empty()) {
+        while (!m_asyncCancel && m_asyncEventQueue.empty() && self.use_count() > 1) {
             m_asyncCondVar.wait_for(*m_asyncMutex, 500ms);
         }
-        while (!m_asyncCancel && !m_asyncEventQueue.empty()) {
+        while (!m_asyncCancel && !m_asyncEventQueue.empty() && self.use_count() > 1) {
             auto event = m_asyncEventQueue.front();
             m_asyncEventQueue.pop_front();
             m_asyncMutex->unlock();
@@ -348,7 +348,11 @@ void SubscriptionService::asyncEventsLoop()
         std::shared_ptr<Open5GSEvent> evt(new Open5GSEvent(new ogs_event_t));
         evt->ogsEvent()->id = LocalEvents::RELEASE_SUBSCRIPTION_SVC;
         evt->setSbiData(new std::shared_ptr<SubscriptionService>(self));
-        App::self().queuePush(evt);
+        try {
+            App::self().queuePush(evt);
+        } catch (std::runtime_error &ex) {
+            /* App not running (happens in unit tests), so just ignore */
+        }
     }
 }
 

--- a/src/mbstf/SubscriptionService.cc
+++ b/src/mbstf/SubscriptionService.cc
@@ -257,7 +257,9 @@ std::string SubscriptionService::reprString() const
 bool SubscriptionService::sendEventSynchronous(Event &event)
 {
     std::lock_guard guard(*m_asyncMutex);
-    auto self = shared_from_this(); /* make sure we don't get deleted while sending events */
+    // make sure we don't get deleted while sending events
+    auto self = weak_from_this().lock();
+    if (!self) return false; // If this object has been deleted, abort event
     auto it = m_namedEventSubscriptions.find(event.eventName());
     if (it != m_namedEventSubscriptions.end()) {
         for (auto &subsc : it->second) {
@@ -326,7 +328,9 @@ void SubscriptionService::asyncEventsLoopRunner(SubscriptionService *svc)
 void SubscriptionService::asyncEventsLoop()
 {
     using namespace std::literals;
-    auto self = shared_from_this(); /* make sure we don't get deleted while sending events, but exit if we are the last holder */
+    /* make sure we don't get deleted while sending events, but exit if we are the last holder */
+    auto self = weak_from_this().lock();
+    if (!self) return; // object has already been deleted
     while (!m_asyncCancel && self.use_count() > 1) {
         std::lock_guard guard(*m_asyncMutex);
         while (!m_asyncCancel && m_asyncEventQueue.empty() && self.use_count() > 1) {

--- a/src/mbstf/SubscriptionService.cc
+++ b/src/mbstf/SubscriptionService.cc
@@ -270,9 +270,9 @@ bool SubscriptionService::sendEventSynchronous(Event &event)
     if (event.stopProcessingFlag()) return false;
     for (auto &subsc : m_allEventSubscriptions) {
         m_asyncMutex->unlock();
-	subsc->processEvent(event, *this);
+        subsc->processEvent(event, *this);
         m_asyncMutex->lock();
-	if (event.stopProcessingFlag()) break;
+        if (event.stopProcessingFlag()) break;
     }
     return !event.preventDefaultFlag();
 }

--- a/src/mbstf/SubscriptionService.hh
+++ b/src/mbstf/SubscriptionService.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_SUBSCRIPTION_SERVICE_HH_
 #define _MBS_TF_SUBSCRIPTION_SERVICE_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Subscription Service class
+ * 5G-MAG Reference Tools: MBS Transport Function: Subscription Service class
  ******************************************************************************
  * Copyright: (C)2025 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/TimerFunc.hh
+++ b/src/mbstf/TimerFunc.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_TIMER_FUNC_HH_
 #define _MBS_TF_TIMER_FUNC_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Timer function interface
+ * 5G-MAG Reference Tools: MBS Transport Function: Timer function interface
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/common.cc
+++ b/src/mbstf/common.cc
@@ -1,5 +1,5 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Common values and macros
+ * 5G-MAG Reference Tools: MBS Transport Function: Common values and macros
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/common.hh
+++ b/src/mbstf/common.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_COMMON_HH_
 #define _MBS_TF_COMMON_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Common values and macros
+ * 5G-MAG Reference Tools: MBS Transport Function: Common values and macros
  ******************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/generator-mbstf
+++ b/src/mbstf/generator-mbstf
@@ -5,7 +5,7 @@
 #
 # Author(s): David Waring <david.warin2@bbc.co.uk>
 #            Dev Audsin <dev.audsin@bbc.co.uk>
-# Copyright: ©2022-2025 British Broadcasting Corporation
+# Copyright: ©2022-2026 British Broadcasting Corporation
 #   License: 5G-MAG Public License v1.0
 #
 # Prerequisites:
@@ -37,7 +37,7 @@ scriptdir=`cd "$scriptdir"; pwd`
 
 # Command line option defaults
 default_branch='REL-18'
-default_apis="TS29581_Nmbstf_DistSession"
+default_apis="TS29581_Nmbstf_DistSession TS26517_MBSObjectManifest"
 default_cache_dir="${MESON_BUILD_ROOT:+$MESON_BUILD_ROOT/$MESON_SUBDIR/openapi-generator-cache}"
 
 # Parse command line arguments

--- a/src/mbstf/hash.hh
+++ b/src/mbstf/hash.hh
@@ -1,7 +1,7 @@
 #ifndef _MBS_TF_HASH_HH_
 #define _MBS_TF_HASH_HH_
 /*****************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: SHA256 hashing function
+ * 5G-MAG Reference Tools: MBS Transport Function: SHA256 hashing function
  *****************************************************************************
  * Copyright: (C)2024 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -161,6 +161,8 @@ libmbstf_dist_sources = files('''
     PullObjectIngester.hh
     PushObjectIngester.cc
     PushObjectIngester.hh
+    SsmPort.cc
+    SsmPort.hh
     SubscriptionService.cc
     SubscriptionService.hh
     Subscriber.cc

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -1,7 +1,7 @@
 # License: 5G-MAG Public License (v1.0)
 # Author(s): David Waring <david.waring2@bbc.co.uk>
 #            Dev Audsin <dev.audsin@bbc.co.uk>
-# Copyright: (C) 2024-2025 British Broadcasting Corporation
+# Copyright: (C) 2024-2026 British Broadcasting Corporation
 #
 # Licensed under the License terms and conditions for use, reproduction, and
 # distribution of 5G-MAG software (the “License”).  You may not use this file
@@ -73,6 +73,10 @@ test_source_dash_manifest_handler = test_source_object_store + test_source_pull_
   DASHManifestHandler.hh
   '''.split())
 
+test_source_object_manifest_handler = test_source_object_store + test_source_pull_object_ingester + files('''
+  ObjectManifestHandler.cc
+  ObjectManifestHandler.hh
+  '''.split())
 
 libmbstf_dist_sources = files('''
     BitRate.cc
@@ -111,12 +115,18 @@ libmbstf_dist_sources = files('''
     MBSTFNetworkFunction.hh
     NfServer.cc
     NfServer.hh
+    ObjectCarouselController.cc
+    ObjectCarouselController.hh
+    ObjectCarouselPackager.cc
+    ObjectCarouselPackager.hh
     ObjectController.cc
     ObjectController.cc
     ObjectListController.cc
     ObjectListController.hh
     ObjectManifestController.cc
     ObjectManifestController.hh
+    ObjectManifestHandler.cc
+    ObjectManifestHandler.hh
     ObjectStore.cc
     ObjectStore.hh
     ObjectStreamingController.cc

--- a/src/mbstf/post-process.sh
+++ b/src/mbstf/post-process.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 ##############################################################################
-# 5G-MAG Reference Tools: MBS Traffic Function: OpenAPI-Generator post process
+# 5G-MAG Reference Tools: MBS Transport Function: OpenAPI-Generator post process
 ##############################################################################
 # Copyright: (C)2024 British Broadcasting Corporation
 # Author(s): David Waring <david.waring2@bbc.co.uk>

--- a/src/mbstf/post-process.sh
+++ b/src/mbstf/post-process.sh
@@ -26,6 +26,6 @@ file="$1"
 
 case "$file" in
 *.cc|*.cpp)
-	sed -i '/StringValidator[^(]*("[^"]*", nullptr, "[^\/]/ {h;s/.*StringValidator[^(]*("[^"]*", nullptr, "//;s/\([^\\]\)".*/\1/;s/\\/\\\\/;s/^/\//;s/$/\//;H;x;s/\(StringValidator[^(]*("[^"]*", nullptr, "\)[^\n]*\("[^\n]*\)\n\(.*\)/\1\3\2/}' "$file"
-	;;
+        sed -i '/StringValidator[^(]*("[^"]*", nullptr, "[^\/]/ {h;s/.*StringValidator[^(]*("[^"]*", nullptr, "//;s/\([^\\]\)".*/\1/;s/\\/\\\\/;s/^/\//;s/$/\//;H;x;s/\(StringValidator[^(]*("[^"]*", nullptr, "\)[^\n]*\("[^\n]*\)\n\(.*\)/\1\3\2/}' "$file"
+        ;;
 esac

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -30,6 +30,7 @@
 #include <sstream>
 
 #include "common.hh"
+#include "SsmPort.hh"
 
 #include "utilities.hh"
 
@@ -103,8 +104,7 @@ int get_path_mtu(const ogs_sockaddr_t &sock_addr)
     return mtu;
 }
 
-int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
-                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
+int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
 {
     int mtu = 1500; // default to 1500 if no MTU can be found.
 
@@ -115,9 +115,9 @@ int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t 
             ogs_freeaddrinfo(sa);
         } // else error already reported
     } else { // No tunnel provided so try MTU of direct destination
-        if (dest_ip) {
+        if (ssm_port) {
             ogs_sockaddr_t *sa = nullptr;
-            if (ogs_addaddrinfo(&sa, AF_UNSPEC, dest_ip.value().c_str(), dest_port, AI_NUMERICSERV) == OGS_OK) {
+            if (ogs_addaddrinfo(&sa, AF_UNSPEC, ssm_port.destinationAddress().c_str(), ssm_port.port(), AI_NUMERICSERV) == OGS_OK) {
                 mtu = get_path_mtu(*sa);
                 ogs_freeaddrinfo(sa);
             }

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -45,7 +45,7 @@ std::string trim_slashes(const std::string &path)
 
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime)
 {
-    return std::format("%b, %d %b %Y %T GMT", datetime);
+    return std::format("{0:%b}, {0:%d} {0:%b} {0:%Y} {0:%T} GMT", datetime);
 }
 
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime)

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -1,7 +1,7 @@
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Common utility functions
+ * 5G-MAG Reference Tools: MBS Transport Function: Common utility functions
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
@@ -52,6 +52,16 @@ std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_
     oss.imbue(std::locale("C"));
     oss << std::format("{0:%F}T{0:%T}Z", datetime_us);
     return oss.str();
+}
+
+std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::string &iso8601_str)
+{
+    std::chrono::system_clock::time_point retval;
+    std::istringstream iss{iso8601_str};
+    iss.imbue(std::locale("C"));
+    iss >> std::chrono::parse("%FT%TZ", retval);
+    if (iss.fail()) throw std::out_of_range(std::format("Bad ISO8601 UTC time: {}", iso8601_str));
+    return retval;
 }
 
 int get_path_mtu(const ogs_sockaddr_t &sock_addr)

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -45,7 +45,7 @@ std::string trim_slashes(const std::string &path)
 
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime)
 {
-    return std::format("{0:%b}, {0:%d} {0:%b} {0:%Y} {0:%T} GMT", datetime);
+    return std::format("{0:%a}, {0:%d} {0:%b} {0:%Y} {0:%T} GMT", datetime);
 }
 
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime)

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -23,8 +23,11 @@
 #include "ogs-core.h"
 
 #include <chrono>
+#include <exception>
 #include <format>
+#include <locale>
 #include <string>
+#include <sstream>
 
 #include "common.hh"
 
@@ -61,6 +64,27 @@ std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::s
     iss.imbue(std::locale("C"));
     iss >> std::chrono::parse("%FT%TZ", retval);
     if (iss.fail()) throw std::out_of_range(std::format("Bad ISO8601 UTC time: {}", iso8601_str));
+    return retval;
+}
+
+std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std::string &rfc9110_str)
+{
+    std::chrono::system_clock::time_point retval;
+    std::istringstream iss{rfc9110_str};
+    iss.imbue(std::locale("C"));
+    iss >> std::chrono::parse("%a, %d %b %Y %T", retval);
+    if (iss.fail()) throw std::out_of_range(std::format("Bad RFC9110 HTTP-date: {}", rfc9110_str));
+    if (iss.peek() == '.') {
+        /* extra fractions of a second */
+        double frac;
+        iss >> frac;
+        retval += std::chrono::microseconds(static_cast<int>(frac*1000000.0));
+    }
+    char tz[5];
+    iss.get(tz, sizeof(tz));
+    if (std::string(tz) != " GMT") {
+        throw std::out_of_range(std::format("Bad RFC9110 HTTP-date: {}", rfc9110_str));
+    }
     return retval;
 }
 

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -30,6 +30,7 @@ std::string trim_slashes(const std::string &path);
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
 std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::string &iso8601_str);
+std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std::string &rfc9110_str);
 
 int get_path_mtu(const ogs_sockaddr_t &sock_addr);
 int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -19,11 +19,14 @@
  * under the License.
  */
 #include <chrono>
+#include <optional>
 #include <string>
 
 #include "common.hh"
 
 MBSTF_NAMESPACE_START
+
+class SsmPort;
 
 std::string trim_slashes(const std::string &path);
 
@@ -33,8 +36,7 @@ std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::s
 std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std::string &rfc9110_str);
 
 int get_path_mtu(const ogs_sockaddr_t &sock_addr);
-int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,
-                            const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
+int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
 
 MBSTF_NAMESPACE_STOP
 

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -1,9 +1,9 @@
 #ifndef _MBS_TF_UTILITIES_HH_
 #define _MBS_TF_UTILITIES_HH_
 /******************************************************************************
- * 5G-MAG Reference Tools: MBS Traffic Function: Common utility functions
+ * 5G-MAG Reference Tools: MBS Transport Function: Common utility functions
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
@@ -29,6 +29,7 @@ std::string trim_slashes(const std::string &path);
 
 std::string time_point_to_http_datetime_str(const std::chrono::system_clock::time_point &datetime);
 std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_point &datetime);
+std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::string &iso8601_str);
 
 int get_path_mtu(const ogs_sockaddr_t &sock_addr);
 int get_tunnelled_path_mtu(const std::optional<std::string> &dest_ip, in_port_t dest_port,

--- a/subprojects/rt-libflute.wrap
+++ b/subprojects/rt-libflute.wrap
@@ -1,7 +1,6 @@
 [wrap-git]
 url = https://github.com/5G-MAG/rt-libflute.git
-#revision = rt-libflute-0.12.3
-revision = development
+revision = rt-libflute-0.12.3
 method = cmake
 
 #diff_files = rt-libflute/IpSec-xfrm_algo.patch

--- a/subprojects/rt-libflute.wrap
+++ b/subprojects/rt-libflute.wrap
@@ -1,6 +1,7 @@
 [wrap-git]
 url = https://github.com/5G-MAG/rt-libflute.git
-revision = rt-libflute-0.12.2
+#revision = rt-libflute-0.12.3
+revision = development
 method = cmake
 
 #diff_files = rt-libflute/IpSec-xfrm_algo.patch

--- a/tests/test_ObjectStore.cc
+++ b/tests/test_ObjectStore.cc
@@ -163,6 +163,7 @@ int main() {
     testGetStaleObjects(*store);
     std::cout<<"Test: ObjectStore "<<"Pass: "<<pass<<" Fail: "<<fail<<std::endl;
     std::cout<<"### ObjectStore: Test finish #### "<<std::endl;
+    store.reset();
     return 0;
 }
 

--- a/tests/test_ObjectStore.cc
+++ b/tests/test_ObjectStore.cc
@@ -148,19 +148,19 @@ MBSTF_NAMESPACE_USING;
 int main() {
     
     ObjectController objectController;
-    ObjectStore store(objectController);
+    std::shared_ptr<ObjectStore> store(new ObjectStore(objectController));
 
     std::cout<<"### ObjectStore: Test start #### "<<std::endl;
     
-    testAddObject(store);
-    testGetMetadata(store);
-    testDeleteFirstObject(store);
-    testDeleteSecondObject(store);
-    testAddObject(store);
-    testRemoveObjects(store);
-    testAddObject(store);
+    testAddObject(*store);
+    testGetMetadata(*store);
+    testDeleteFirstObject(*store);
+    testDeleteSecondObject(*store);
+    testAddObject(*store);
+    testRemoveObjects(*store);
+    testAddObject(*store);
     std::this_thread::sleep_for(10s);
-    testGetStaleObjects(store);
+    testGetStaleObjects(*store);
     std::cout<<"Test: ObjectStore "<<"Pass: "<<pass<<" Fail: "<<fail<<std::endl;
     std::cout<<"### ObjectStore: Test finish #### "<<std::endl;
     return 0;

--- a/tests/test_SubscriberSubscription.cc
+++ b/tests/test_SubscriberSubscription.cc
@@ -199,15 +199,15 @@ enum Result {
 };
 
 struct TestContext {
-    TestSubscriptionService *services[3];
+    std::shared_ptr<TestSubscriptionService> services[3];
     TestSubscriber *subscribers[3];
     TestAsyncSubscriber *async_subscribers[1];
 };
 
 void test_setup(TestContext &context)
 {
-    context.services[0] = new TestSubscriptionService;
-    context.services[1] = new TestSubscriptionService;
+    context.services[0].reset(new TestSubscriptionService);
+    context.services[1].reset(new TestSubscriptionService);
 }
 
 Result test_synchronous_filtered(TestContext &ctx)
@@ -300,9 +300,8 @@ Result test_synchronous_filtered(TestContext &ctx)
         ctx.subscribers[1]->resetResult();
     }
 
-    auto tmp_svc = ctx.services[0];
-    delete ctx.services[0];
-    ctx.services[0] = nullptr;
+    auto tmp_svc = ctx.services[0].get();
+    ctx.services[0].reset();
 
     if (ctx.subscribers[0]->subscribedTo(*tmp_svc) || ctx.subscribers[1]->subscribedTo(*tmp_svc)) {
         std::cerr << "Unsubscribe upon service deletion failed to propagate" << std::endl;
@@ -342,7 +341,7 @@ Result test_synchronous_filtered(TestContext &ctx)
 
     // Restore subscribers and services
 
-    ctx.services[0] = new TestSubscriptionService;
+    ctx.services[0].reset(new TestSubscriptionService);
     ctx.subscribers[0] = new TestSubscriber;
 
     ctx.subscribers[0]->addSubscribeToT1(*ctx.services[0]);
@@ -471,7 +470,7 @@ Result test_asynchronous_filtered(TestContext &ctx)
     // async test
 
     ctx.async_subscribers[0] = new TestAsyncSubscriber();
-    ctx.services[2] = new TestSubscriptionService;
+    ctx.services[2].reset(new TestSubscriptionService);
     std::shared_ptr<Event> t5(new EventType1(1));
     
     ctx.async_subscribers[0]->addSubscribeToT1(*ctx.services[2]);
@@ -505,10 +504,10 @@ Result test_asynchronous_unfiltered(TestContext &ctx)
 
 void test_cleanup(TestContext &ctx)
 {
-    for (auto *svc : ctx.services) {
+    for (auto &svc : ctx.services) {
         if (svc) {
             //std::cout << "delete TestSubscriptionService " << svc << std::endl;
-            delete svc;
+            svc.reset();
         }
     }
     for (auto *sub : ctx.subscribers) {


### PR DESCRIPTION
Release of v1.3.0 of the MBS Transport Function.

This release includes the following changes:
- Added CAROUSEL object operating mode.
- Uplift to TS 29.581 v18.6.0:
   - Adds SSM source address and FLUTE Transport Session Identifier (TSI) to the *Nmbstf* configuration API at reference point Nmb2.
- Various bug fixes and code tidying

The release candidate for this release is tagged as `rt-mbs-transport-function-1.3.0-rc1`.