### PR TITLE
Feature: Add packet distribution mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 install
 .*.swp
 *.bak
+subprojects/.wraplock
+subprojects/wrapdb.json

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -47,6 +47,7 @@ Context::Context()
     ,cacheControl({60, 60})
     ,totalMaxBitRateSoftLimit(100)
     ,consecutiveIngestFailuresBeforeDeactivate(5)
+    ,packetModeSchedulingQueueSize(128*1024) // 128KB queue for rate smoothing
 {
 }
 
@@ -124,6 +125,17 @@ bool Context::parseConfig()
                         }
                     } else {
                         throw std::out_of_range("Bad configuration node at mbstf.consecutiveIngestFailuresBeforeDeactivate");
+                    }
+                } else if (mbstf_key == "packetModeSchedulingQueueSize") {
+                    if (mbstf_iter.type() == YAML_MAPPING_NODE) {
+                        std::string num_val(mbstf_iter.value());
+                        size_t idx = 0;
+                        packetModeSchedulingQueueSize = std::stoi(num_val, &idx);
+                        if (idx != num_val.size()) {
+                            throw std::out_of_range("Bad configuration value at mbstf.packetModeSchedulingQueueSize");
+                        }
+                    } else {
+                        throw std::out_of_range("Bad configuration node at mbstf.packetModeSchedulingQueueSize");
                     }
                 } else {
                     ogs_warn("Unknown key `mbstf.%s` in configuration", mbstf_key.c_str());

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -1,7 +1,7 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: App context class
  ******************************************************************************
- * Copyright: (C)2024 British Broadcasting Corporation
+ * Copyright: (C)2024-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -3,7 +3,7 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: MBSTF Context
  ******************************************************************************
- * Copyright: (C)2024 British Broadcasting Corporation
+ * Copyright: (C)2024-2026 British Broadcasting Corporation
  * Author(s): David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -72,6 +72,7 @@ public:
     } cacheControl;
     int totalMaxBitRateSoftLimit; // total maximum bit rate this MBSTF ought to asked to handle
     int consecutiveIngestFailuresBeforeDeactivate; // The number of consecutive ingest failures allowed before the session aborts
+    size_t packetModeSchedulingQueueSize; // The maximum queue size for packet mode scheduling per DistSession
 
 private:
     void parseCacheControl(Open5GSYamlIter &iter);

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -1060,10 +1060,10 @@ void DistributionSession::_apiSessionCreate(Open5GSSBIStream &stream, Open5GSSBI
         return;
     } catch (std::exception &err) {
         ogs_error("Error while populating MBSTF Distribution Session: %s", err.what());
-        char *error = ogs_msprintf("Invalid ObjDistributionData parameters [%s]", err.what());
+        char *error = ogs_msprintf("Invalid ObjDistributionData or PktDistributionData parameters [%s]", err.what());
         ogs_error("%s", error);
         ogs_assert(true == NfServer::sendError(stream, ProblemCause::INVALID_MSG_FORMAT, 1, message, app_meta, api,
-                                                "Invalid ObjDistributionData parameters", error));
+                                                "Invalid ObjDistributionData  or PktDistributionData parameters", error));
         ogs_free(error);
         return;
     }

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -498,6 +498,13 @@ uint64_t DistributionSession::getTSI() const
     return static_cast<uint32_t>(tsi.value());
 }
 
+const std::optional<std::shared_ptr<TunnelAddress>> &DistributionSession::getTunnel() const
+{
+    std::shared_ptr<CreateReqData> create_req_data = distributionSessionReqData();
+    std::shared_ptr<DistSession> dist_session = create_req_data->getDistSession();
+    return dist_session->getMbUpfTunAddr();
+}
+
 const std::optional<std::string> &DistributionSession::getTunnelAddr() const
 {
     std::shared_ptr<CreateReqData> create_req_data = distributionSessionReqData();

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -42,6 +42,7 @@ namespace reftools::mbstf {
     class CreateReqData;
     class DistSessionSubscription;
     class ObjDistributionData;
+    class TunnelAddress;
 }
 
 MBSTF_NAMESPACE_START
@@ -86,6 +87,7 @@ public:
     const std::string &getObjectDistributionOperatingMode() const;
     const SsmPort getSsmPort() const;
     uint64_t getTSI() const;
+    const std::optional<std::shared_ptr<reftools::mbstf::TunnelAddress>> &getTunnel() const;
     const std::optional<std::string> &getTunnelAddr() const;
     in_port_t getTunnelPortNumber() const;
     uint32_t getRateLimit() const;

--- a/src/mbstf/DistributionSession.hh
+++ b/src/mbstf/DistributionSession.hh
@@ -3,8 +3,9 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: Distribution Session class
  ******************************************************************************
- * Copyright: (C)2024-2025 British Broadcasting Corporation
+ * Copyright: (C)2024-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * Licensed under the License terms and conditions for use, reproduction, and

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -77,7 +77,7 @@ void ObjectCarouselController::setObjectPackager()
     const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port, GET_MTU_ETHERNET_PAYLOAD) - GTP_HEADER_SIZE;
     packager(new ObjectCarouselPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     auto pkgr = getObjectCarouselPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -74,7 +74,7 @@ void ObjectListController::setObjectPackager() {
     std::optional<std::string> tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port, GET_MTU_ETHERNET_PAYLOAD) - GTP_HEADER_SIZE;
     const auto &obj_list = objectStore().getObjects();
     packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     // Send all objects that are in the ObjectStore

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: ObjectListController class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this

--- a/src/mbstf/ObjectListController.hh
+++ b/src/mbstf/ObjectListController.hh
@@ -3,8 +3,9 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: Object List Controller class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -72,7 +72,7 @@ void ObjectStreamingController::setObjectPackager()
     const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
     uint32_t rate_limit = distributionSession().getRateLimit();
     in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port) - GTP_HEADER_SIZE;
+    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port, GET_MTU_ETHERNET_PAYLOAD) - GTP_HEADER_SIZE;
     packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -1,8 +1,9 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: ObjectStreamingController class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this

--- a/src/mbstf/ObjectStreamingController.hh
+++ b/src/mbstf/ObjectStreamingController.hh
@@ -3,8 +3,9 @@
 /******************************************************************************
  * 5G-MAG Reference Tools: MBS Transport Function: Object Streaming Controller class
  ******************************************************************************
- * Copyright: (C)2025 British Broadcasting Corporation
+ * Copyright: (C)2025-2026 British Broadcasting Corporation
  * Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+ *            David Waring <david.waring2@bbc.co.uk>
  * License: 5G-MAG Public License v1
  *
  * For full license terms please see the LICENSE file distributed with this

--- a/src/mbstf/Packet.cc
+++ b/src/mbstf/Packet.cc
@@ -1,0 +1,721 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/ip_icmp.h>
+#include <netinet/icmp6.h>
+#include <netinet/udp.h>
+#include <sys/socket.h>
+#include <linux/if_packet.h>
+#include <net/ethernet.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+
+#include "Packet.hh"
+
+MBSTF_NAMESPACE_START
+
+static int g_rawIcmpv4Socket = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
+static int g_rawIcmpv6Socket = socket(AF_INET6, SOCK_RAW, IPPROTO_RAW);
+
+Packet::Packet()
+    :m_packet(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))
+    ,m_originalPayloadOffset(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))
+    ,m_payloadOffset(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))
+    ,m_payloadEndOffset(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))
+    ,m_encapsulatedIpOffset(0)
+    ,m_encapsulatedUdpOffset(0)
+    ,m_encapsulatedPayloadOffset(0)
+    ,m_fragmentOffset(0)
+    ,m_moreFragments(false)
+    ,m_haveEncapsulation(false)
+    ,m_originalIfc(-1)
+    ,m_originalSourceAddress()
+    ,m_originalSourceAddressLen(0)
+    ,m_originalDestinationAddress()
+    ,m_originalDestinationAddressLen(0)
+{
+}
+
+Packet::Packet(const uint8_t *buffer, size_t buffer_size, bool encapsulated_hdrs)
+    :m_packet()
+    ,m_originalPayloadOffset(encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr)))
+    ,m_payloadOffset(encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr)))
+    ,m_payloadEndOffset((encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))) + buffer_size)
+    ,m_encapsulatedIpOffset(0)
+    ,m_encapsulatedUdpOffset(0)
+    ,m_encapsulatedPayloadOffset(0)
+    ,m_fragmentOffset(0)
+    ,m_moreFragments(false)
+    ,m_haveEncapsulation(encapsulated_hdrs)
+    ,m_originalIfc(-1)
+    ,m_originalSourceAddress()
+    ,m_originalSourceAddressLen(0)
+    ,m_originalDestinationAddress()
+    ,m_originalDestinationAddressLen(0)
+{
+    m_packet.reserve((encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))) + buffer_size);
+    if (m_payloadOffset) m_packet.insert(m_packet.begin(), m_payloadOffset, 0);
+    m_packet.insert(m_packet.end(), buffer, buffer + buffer_size);
+    if (m_haveEncapsulation) {
+        m_encapsulatedIpOffset = m_payloadOffset;
+        const struct iphdr *ip = reinterpret_cast<const struct iphdr*>(buffer);
+        if (ip->version == 4) {
+            m_encapsulatedUdpOffset = m_encapsulatedIpOffset + ip->ihl * 4;
+        } else if (ip->version == 6) {
+            m_encapsulatedUdpOffset = m_encapsulatedIpOffset + sizeof(ip6_hdr);
+            for (const struct ip6_ext *ip6e = reinterpret_cast<const struct ip6_ext*>(buffer + sizeof(ip6_hdr));
+                 ip6e->ip6e_nxt != IPPROTO_UDP;
+                 ip6e = reinterpret_cast<const struct ip6_ext*>(reinterpret_cast<const uint8_t*>(ip6e) + ip6e->ip6e_len)) {
+                m_encapsulatedUdpOffset += ip6e->ip6e_len;
+            }
+        }
+        if (m_encapsulatedUdpOffset) m_encapsulatedPayloadOffset = m_encapsulatedUdpOffset + sizeof(udphdr);
+    }
+}
+
+Packet::Packet(struct msghdr *msg, const std::shared_ptr<struct sockaddr> &listen_address, bool encapsulated_hdrs)
+    :m_packet()
+    ,m_originalPayloadOffset(encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr)))
+    ,m_payloadOffset(encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr)))
+    ,m_payloadEndOffset((encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))) + msg->msg_iov->iov_len)
+    ,m_encapsulatedIpOffset(0)
+    ,m_encapsulatedUdpOffset(0)
+    ,m_encapsulatedPayloadOffset(0)
+    ,m_fragmentOffset(0)
+    ,m_moreFragments(false)
+    ,m_haveEncapsulation(encapsulated_hdrs)
+    ,m_originalIfc(-1)
+    ,m_originalSourceAddress()
+    ,m_originalSourceAddressLen(0)
+    ,m_originalDestinationAddress()
+    ,m_originalDestinationAddressLen(0)
+{
+    auto *buffer = reinterpret_cast<const uint8_t*>(msg->msg_iov->iov_base);
+    auto buffer_len = msg->msg_iov->iov_len;
+    m_packet.reserve((encapsulated_hdrs?0:(std::max(sizeof(iphdr), sizeof(ip6_hdr)) + sizeof(udphdr))) + buffer_len);
+    if (m_payloadOffset) m_packet.insert(m_packet.begin(), m_payloadOffset, 0);
+    m_packet.insert(m_packet.end(), buffer, buffer + buffer_len);
+    if (m_haveEncapsulation) {
+        m_encapsulatedIpOffset = m_payloadOffset;
+        const struct iphdr *ip = reinterpret_cast<const struct iphdr*>(buffer);
+        if (ip->version == 4) {
+            m_encapsulatedUdpOffset = m_encapsulatedIpOffset + ip->ihl * 4;
+        } else if (ip->version == 6) {
+            m_encapsulatedUdpOffset = m_encapsulatedIpOffset + sizeof(ip6_hdr);
+            for (const struct ip6_ext *ip6e = reinterpret_cast<const struct ip6_ext*>(buffer + sizeof(ip6_hdr));
+                 ip6e->ip6e_nxt != IPPROTO_UDP;
+                 ip6e = reinterpret_cast<const struct ip6_ext*>(reinterpret_cast<const uint8_t*>(ip6e) + ip6e->ip6e_len)) {
+                m_encapsulatedUdpOffset += ip6e->ip6e_len;
+            }
+        }
+        if (m_encapsulatedUdpOffset) m_encapsulatedPayloadOffset = m_encapsulatedUdpOffset + sizeof(udphdr);
+    }
+    if (msg->msg_namelen > 0) {
+        m_originalSourceAddress = std::reinterpret_pointer_cast<struct sockaddr>(std::make_shared<uint8_t[]>(msg->msg_namelen));
+        m_originalSourceAddressLen = msg->msg_namelen;
+        memcpy(m_originalSourceAddress.get(), msg->msg_name, msg->msg_namelen);
+    }
+    for (auto cmsg = CMSG_FIRSTHDR(msg); cmsg; cmsg = CMSG_NXTHDR(msg, cmsg)) {
+        if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_PKTINFO) {
+            struct in_pktinfo pkt_info;
+            memcpy(&pkt_info, CMSG_DATA(cmsg), sizeof(pkt_info));
+            auto ipv4_addr = std::make_shared<struct sockaddr_in>();
+            ipv4_addr->sin_family = AF_INET;
+            ipv4_addr->sin_addr = pkt_info.ipi_addr;
+            ipv4_addr->sin_port = listen_address?std::reinterpret_pointer_cast<struct sockaddr_in>(listen_address)->sin_port:0;
+            m_originalIfc = pkt_info.ipi_ifindex;
+            m_originalDestinationAddress = std::reinterpret_pointer_cast<struct sockaddr>(ipv4_addr);
+            m_originalDestinationAddressLen = sizeof(struct sockaddr_in);
+        } else if (cmsg->cmsg_level == IPPROTO_IPV6 && cmsg->cmsg_type == IPV6_PKTINFO) {
+            struct in6_pktinfo pkt_info;
+            memcpy(&pkt_info, CMSG_DATA(cmsg), sizeof(pkt_info));
+            auto ipv6_addr = std::make_shared<struct sockaddr_in6>();
+            ipv6_addr->sin6_family = AF_INET6;
+            ipv6_addr->sin6_addr = pkt_info.ipi6_addr;
+            ipv6_addr->sin6_port = listen_address?std::reinterpret_pointer_cast<struct sockaddr_in6>(listen_address)->sin6_port:0;
+            m_originalIfc = pkt_info.ipi6_ifindex;
+            m_originalDestinationAddress = std::reinterpret_pointer_cast<struct sockaddr>(ipv6_addr);
+            m_originalDestinationAddressLen = sizeof(struct sockaddr_in6);
+        }
+    }
+}
+
+Packet::Packet(const Packet &other)
+    :m_packet(other.m_packet)
+    ,m_originalPayloadOffset(other.m_originalPayloadOffset)
+    ,m_payloadOffset(other.m_payloadOffset)
+    ,m_payloadEndOffset(other.m_payloadEndOffset)
+    ,m_encapsulatedIpOffset(other.m_encapsulatedIpOffset)
+    ,m_encapsulatedUdpOffset(other.m_encapsulatedUdpOffset)
+    ,m_encapsulatedPayloadOffset(other.m_encapsulatedPayloadOffset)
+    ,m_fragmentOffset(other.m_fragmentOffset)
+    ,m_moreFragments(other.m_moreFragments)
+    ,m_haveEncapsulation(other.m_haveEncapsulation)
+    ,m_originalIfc(other.m_originalIfc)
+    ,m_originalSourceAddress(other.m_originalSourceAddress)
+    ,m_originalSourceAddressLen(other.m_originalSourceAddressLen)
+    ,m_originalDestinationAddress(other.m_originalDestinationAddress)
+    ,m_originalDestinationAddressLen(other.m_originalDestinationAddressLen)
+{
+}
+
+Packet::Packet(Packet &&other)
+    :m_packet(std::move(other.m_packet))
+    ,m_originalPayloadOffset(other.m_originalPayloadOffset)
+    ,m_payloadOffset(other.m_payloadOffset)
+    ,m_payloadEndOffset(other.m_payloadEndOffset)
+    ,m_encapsulatedIpOffset(other.m_encapsulatedIpOffset)
+    ,m_encapsulatedUdpOffset(other.m_encapsulatedUdpOffset)
+    ,m_encapsulatedPayloadOffset(other.m_encapsulatedPayloadOffset)
+    ,m_fragmentOffset(other.m_fragmentOffset)
+    ,m_moreFragments(other.m_moreFragments)
+    ,m_haveEncapsulation(other.m_haveEncapsulation)
+    ,m_originalIfc(other.m_originalIfc)
+    ,m_originalSourceAddress(std::move(other.m_originalSourceAddress))
+    ,m_originalSourceAddressLen(other.m_originalSourceAddressLen)
+    ,m_originalDestinationAddress(std::move(other.m_originalDestinationAddress))
+    ,m_originalDestinationAddressLen(other.m_originalDestinationAddressLen)
+{
+}
+
+Packet &Packet::operator=(const Packet &other)
+{
+    m_packet = other.m_packet;
+    m_payloadOffset = other.m_payloadOffset;
+    m_payloadEndOffset = other.m_payloadEndOffset;
+    m_encapsulatedIpOffset = other.m_encapsulatedIpOffset;
+    m_encapsulatedUdpOffset = other.m_encapsulatedUdpOffset;
+    m_encapsulatedPayloadOffset = other.m_encapsulatedPayloadOffset;
+    m_fragmentOffset = other.m_fragmentOffset;
+    m_moreFragments = other.m_moreFragments;
+    m_haveEncapsulation = other.m_haveEncapsulation;
+    m_originalIfc = other.m_originalIfc;
+    m_originalSourceAddress = other.m_originalSourceAddress;
+    m_originalSourceAddressLen = other.m_originalSourceAddressLen;
+    m_originalDestinationAddress = other.m_originalDestinationAddress;
+    m_originalDestinationAddressLen = other.m_originalDestinationAddressLen;
+    return *this;
+}
+
+Packet &Packet::operator=(Packet &&other)
+{
+    m_packet = std::move(other.m_packet);
+    m_payloadOffset = other.m_payloadOffset;
+    m_payloadEndOffset = other.m_payloadEndOffset;
+    m_encapsulatedIpOffset = other.m_encapsulatedIpOffset;
+    m_encapsulatedUdpOffset = other.m_encapsulatedUdpOffset;
+    m_encapsulatedPayloadOffset = other.m_encapsulatedPayloadOffset;
+    m_fragmentOffset = other.m_fragmentOffset;
+    m_moreFragments = other.m_moreFragments;
+    m_haveEncapsulation = other.m_haveEncapsulation;
+    m_originalIfc = other.m_originalIfc;
+    m_originalSourceAddress = std::move(other.m_originalSourceAddress);
+    m_originalSourceAddressLen = other.m_originalSourceAddressLen;
+    m_originalDestinationAddress = std::move(other.m_originalDestinationAddress);
+    m_originalDestinationAddressLen = other.m_originalDestinationAddressLen;
+    return *this;
+}
+
+bool Packet::operator==(const Packet &other) const
+{
+    return m_fragmentOffset == other.m_fragmentOffset && m_packet == other.m_packet;
+}
+
+bool Packet::setEncapsulatedUdpHeader(struct in_addr *source_address, in_port_t source_port,
+                                      struct in_addr *dest_address, in_port_t dest_port,
+                                      uint8_t ttl, bool do_not_fragment)
+{
+    size_t payload_start = m_payloadOffset;
+    if (m_haveEncapsulation) {
+        payload_start = m_encapsulatedPayloadOffset;
+    }
+
+    m_encapsulatedPayloadOffset = payload_start;
+    m_encapsulatedUdpOffset = m_encapsulatedPayloadOffset - sizeof(udphdr);
+    m_encapsulatedIpOffset = m_encapsulatedUdpOffset - sizeof(iphdr);
+    m_payloadOffset = m_encapsulatedIpOffset;
+    m_haveEncapsulation = true;
+
+    struct iphdr *ip = reinterpret_cast<struct iphdr*>(m_packet.data() + m_encapsulatedIpOffset);
+    ip->version = 4;
+    ip->ihl = static_cast<uint8_t>(sizeof(iphdr)/4);
+    ip->tos = 0;
+    ip->id = 0;
+    ip->frag_off = htons(do_not_fragment?0x4000:0);
+    ip->ttl = ttl;
+    ip->protocol = static_cast<uint8_t>(IPPROTO_UDP);
+    ip->saddr = source_address->s_addr;
+    ip->daddr = dest_address->s_addr;
+
+    struct udphdr *udp = reinterpret_cast<struct udphdr*>(m_packet.data() + m_encapsulatedUdpOffset);
+    udp->uh_sport = htons(source_port);
+    udp->uh_dport = htons(dest_port);
+    udp->uh_sum = 0;
+    udp->uh_ulen = htons(static_cast<uint16_t>(m_payloadEndOffset - m_encapsulatedUdpOffset));
+    struct {
+        struct in_addr saddr;
+        struct in_addr daddr;
+        uint8_t zero;
+        uint8_t protocol;
+        uint16_t udp_len;
+    } pseudo_ip = {
+        ip->saddr,
+        ip->daddr,
+        0,
+        IPPROTO_UDP,
+        udp->uh_ulen
+    };
+    udp->uh_sum = addChecksum(checksum(&pseudo_ip, sizeof(pseudo_ip)), udp, m_payloadEndOffset - m_encapsulatedUdpOffset);
+    
+    recalculateEncapsulatedSizesAndChecksums();
+
+    return true;
+}
+
+bool Packet::setEncapsulatedUdpHeader(struct in6_addr *source_address, in_port_t source_port,
+                                      struct in6_addr *dest_address, in_port_t dest_port,
+                                      uint8_t ttl)
+{
+    size_t payload_start = m_payloadOffset;
+    if (m_haveEncapsulation) {
+        payload_start = m_encapsulatedPayloadOffset;
+    }
+
+    m_encapsulatedPayloadOffset = payload_start;
+    m_encapsulatedUdpOffset = m_encapsulatedPayloadOffset - sizeof(udphdr);
+    m_encapsulatedIpOffset = m_encapsulatedUdpOffset - sizeof(ip6_hdr);
+    m_payloadOffset = m_encapsulatedIpOffset;
+    m_haveEncapsulation = true;
+
+    struct ip6_hdr *ip = reinterpret_cast<struct ip6_hdr*>(m_packet.data() + m_encapsulatedIpOffset);
+    ip->ip6_vfc = 6;
+    ip->ip6_nxt = IPPROTO_UDP;
+    ip->ip6_hlim = ttl;
+    ip->ip6_src = *source_address;
+    ip->ip6_dst = *dest_address;
+
+    struct udphdr *udp = reinterpret_cast<struct udphdr*>(m_packet.data() + m_encapsulatedUdpOffset);
+    udp->uh_sport = htons(source_port);
+    udp->uh_dport = htons(dest_port);
+    udp->uh_sum = 0;
+    udp->uh_ulen = htons(static_cast<uint16_t>(m_payloadEndOffset - m_encapsulatedUdpOffset));
+    struct {
+        struct in6_addr saddr;
+        struct in6_addr daddr;
+        uint32_t udp_len;
+        uint16_t zero1;
+        uint8_t zero2;
+        uint8_t protocol;
+    } pseudo_ip = {
+        ip->ip6_src,
+        ip->ip6_dst,
+        htonl(static_cast<uint32_t>(m_payloadEndOffset - m_encapsulatedUdpOffset)),
+        0, 0,
+        IPPROTO_UDP
+    };
+    udp->uh_sum = addChecksum(checksum(&pseudo_ip, sizeof(pseudo_ip)), udp, m_payloadEndOffset - m_encapsulatedUdpOffset);
+
+    recalculateEncapsulatedSizesAndChecksums();
+    
+    return true;
+}
+
+int Packet::originalFamily() const
+{
+    if (!m_originalSourceAddress) return AF_UNSPEC;
+    return m_originalSourceAddress->sa_family;
+}
+
+int Packet::family() const
+{
+    if (m_haveEncapsulation) {
+        const struct iphdr *ip = reinterpret_cast<const struct iphdr*>(m_packet.data() + m_encapsulatedIpOffset);
+        if (ip->version == 4) return AF_INET;
+        if (ip->version == 6) return AF_INET6;
+    }
+    return AF_UNSPEC;
+}
+
+bool Packet::doNotFragment() const
+{
+    if (!m_haveEncapsulation) return false;
+    const struct iphdr *ip = reinterpret_cast<const struct iphdr*>(m_packet.data() + m_encapsulatedIpOffset);
+    if (ip->version == 6) return true;
+    if (ip->version == 4) return (ntohs(ip->frag_off) & 0x4000) != 0;
+    return false;
+}
+
+uint16_t Packet::addChecksum(uint16_t current_checksum, const void *buffer, size_t buffer_len)
+{
+    uint64_t next_checksum = checksum(buffer, buffer_len);
+    uint64_t result = (~current_checksum & 0xffff) + (~next_checksum & 0xffff);
+
+    while (result > 0xFFFF) {
+        result = (result & 0xFFFF) + (result >> 16);
+    }
+
+    return ~static_cast<uint16_t>(result);
+}
+
+uint16_t Packet::checksum(const void *buffer, size_t buffer_len)
+{
+    uint64_t result = 0;
+    const uint32_t *buf32 = reinterpret_cast<const uint32_t*>(buffer);
+
+    size_t i = buffer_len;
+    while (i >= sizeof(uint32_t)) {
+        result += *buf32++;
+        i -= sizeof(uint32_t);
+    }
+
+    if (i > 0) {
+        const uint8_t *buf8 = reinterpret_cast<const uint8_t*>(buf32);
+        std::array<uint8_t, sizeof(uint32_t)> partial_word;
+        size_t j = 0;
+        while (i > 0) {
+            partial_word[j++] = *buf8++;
+            i--;
+        }
+        result += *reinterpret_cast<const uint32_t*>(partial_word.data());
+    }
+
+    while (result > 0xFFFF) {
+        result = (result & 0xFFFF) + (result >> 16);
+    }
+
+    return ~static_cast<uint16_t>(result);
+}
+
+Packet Packet::fragmentData(size_t maximum_size)
+{
+    auto pl = payload();
+    ogs_debug("Create fragment of size %zu from payload %sof size %zu", maximum_size, m_haveEncapsulation?"including encap ":"", pl.size());
+    size_t new_payload_size;
+    if (m_haveEncapsulation) {
+        if (pl.size() > maximum_size) {
+            auto hdrs_size = m_encapsulatedUdpOffset - m_encapsulatedIpOffset;
+            // fragment payload size must be multiple of 8 unless it's the last packet
+            new_payload_size = ((maximum_size - hdrs_size)&~static_cast<size_t>(7)) + hdrs_size;
+        } else {
+            new_payload_size = pl.size();
+        }
+    } else {
+        if (pl.size() > (maximum_size - sizeof(udphdr) - sizeof(ip6_hdr))) {
+            new_payload_size = (maximum_size - sizeof(udphdr) - sizeof(ip6_hdr))&~static_cast<size_t>(7);
+        } else {
+            new_payload_size = pl.size();
+        }
+    }
+
+    Packet result{pl.data(), new_payload_size, m_haveEncapsulation};
+    result.m_fragmentOffset = m_fragmentOffset;
+    result.m_moreFragments = (pl.size() > new_payload_size);
+
+    if (m_haveEncapsulation) {
+        // recalculate checksums in headers of new packet
+        result.recalculateEncapsulatedSizesAndChecksums();
+        
+        // reduce this encapsulated payload by size in new packet
+        auto pl_remove_start = m_packet.begin() + m_encapsulatedUdpOffset;
+        auto pl_remove_end = m_packet.begin() + m_encapsulatedIpOffset + new_payload_size;
+        size_t enc_payload_bytes = pl_remove_end - pl_remove_start;
+        m_packet.erase(pl_remove_start, pl_remove_end);
+        m_payloadEndOffset -= enc_payload_bytes;
+        m_fragmentOffset += enc_payload_bytes;
+        m_encapsulatedPayloadOffset = m_encapsulatedUdpOffset;
+        if (m_payloadEndOffset == m_encapsulatedUdpOffset) {
+            // no data left, empty the packet
+            m_packet.clear();
+            m_encapsulatedIpOffset = m_encapsulatedUdpOffset = m_encapsulatedPayloadOffset = m_payloadEndOffset = m_payloadOffset = 0;
+            m_haveEncapsulation = false;
+        }
+    } else {
+        // reduce this payload by size of new packet
+        m_packet.erase(m_packet.begin() + m_payloadOffset, m_packet.begin() + m_payloadOffset + new_payload_size);
+        m_payloadEndOffset -= new_payload_size;
+        m_fragmentOffset += new_payload_size + sizeof(udphdr);
+    }
+
+    return result;
+}
+
+int Packet::sendICMPNeedSmallerMTU(uint16_t mtu) const
+{
+    if (m_originalIfc < 0 || !m_originalSourceAddress || !m_originalDestinationAddress) {
+        return 0; // return empty when we don't have original packet details
+    }
+
+    std::vector<uint8_t> buffer;
+
+    if (m_originalSourceAddress->sa_family == AF_INET) {
+        if (g_rawIcmpv4Socket < 0) return 0;
+        uint16_t icmpdata[2] = {0, htons(mtu)};
+        return sendICMP(3, 4, *reinterpret_cast<uint32_t*>(icmpdata), sizeof(iphdr) + 8);
+    } else if (m_originalSourceAddress->sa_family == AF_INET6) {
+        if (g_rawIcmpv6Socket < 0) return 0;
+        uint32_t icmpdata = htonl(mtu);
+        return sendICMP6(2, 0, icmpdata, -1);
+    } else {
+        ogs_warn("Unknown protocol, cannot send ICMP/ICMP6 packet too big message");
+    }
+
+    return 0;
+}
+
+// private:
+
+Packet &Packet::recalculateEncapsulatedSizesAndChecksums()
+{
+    struct iphdr *ip4 = reinterpret_cast<struct iphdr*>(m_packet.data() + m_encapsulatedIpOffset);
+    if (ip4->version == 4) {
+        ip4->tot_len = htons(static_cast<uint16_t>(m_payloadEndOffset - m_encapsulatedIpOffset));
+        ip4->frag_off = htons((ntohs(ip4->frag_off)&0xc000) | (m_moreFragments?0x2000:0) | ((m_fragmentOffset/8)&0x1fff));
+        ip4->check = 0;
+        ip4->check = checksum(ip4, sizeof(iphdr));
+    } else if (ip4->version == 6) {
+        struct ip6_hdr *ip6 = reinterpret_cast<struct ip6_hdr*>(ip4);
+        ip6->ip6_plen = htons(m_payloadEndOffset - m_encapsulatedIpOffset);
+    }
+    return *this;
+}
+
+int Packet::sendICMP(uint8_t typ, uint8_t code, uint32_t icmpdata, ssize_t original_ip_packet_bytes) const
+{
+    ogs_debug("ICMP: type=%u, code=%u, data=0x%x", typ, code, icmpdata);
+
+    //  0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    // +-------+-------+---------------+-------------------------------+
+    // |Version| IHL(5)|      TOS      |         Total Length          | IPv4 Header
+    // +-------+-------+---------------+-----+-------------------------+
+    // |        Identification         |Flags|  Fragment Offset (0)    |
+    // +---------------+---------------+-----+-------------------------+
+    // |  Time to Live | Protocol (1)  |        Header checksum        |
+    // +---------------+---------------+-------------------------------+
+    // |                       Source Address                          |
+    // +---------------------------------------------------------------+
+    // |                     Destination Address                       |
+    // +---------------+---------------+-------------------------------+
+    // |      Type     |      Code     |           Checksum            | ICMP Header
+    // +---------------+---------------+-------------------------------+
+    // |  ICMP message specific data                                   |
+    // +---------------------------------------------------------------+
+    // |  First N bytes of the original message including IP and UDP   :
+    // :  headers                                                      :
+
+    if (original_ip_packet_bytes < 0) {
+        // use all available space - base size on original packet size
+        original_ip_packet_bytes = m_payloadEndOffset - m_originalPayloadOffset - sizeof(iphdr) - sizeof(icmphdr);
+    }
+
+    std::vector<uint8_t> packet;
+    packet.reserve(sizeof(iphdr) + sizeof(icmphdr) + original_ip_packet_bytes);
+
+    struct iphdr ip;
+    ip.version = 4;
+    ip.ihl = 5;
+    ip.tos = 0;
+    ip.id = 0;
+    ip.frag_off = 0;
+    ip.ttl = 64;
+    ip.protocol = IPPROTO_ICMP;
+    ip.check = 0;
+    auto sin_orig_dst = std::reinterpret_pointer_cast<struct sockaddr_in>(m_originalDestinationAddress);
+    ip.saddr = sin_orig_dst->sin_addr.s_addr; // going back from our address
+    auto sin_orig_src = std::reinterpret_pointer_cast<struct sockaddr_in>(m_originalSourceAddress);
+    ip.daddr = sin_orig_src->sin_addr.s_addr; // going to the original packet source
+    //ip.check = checksum(&ip, sizeof(ip));
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&ip), reinterpret_cast<uint8_t*>(&ip + 1));
+
+    struct icmphdr icmp;
+    icmp.type = typ;
+    icmp.code = code;
+    icmp.checksum = 0;
+    icmp.un.gateway = icmpdata; // gateway used to access full 32 bits, icmpdata not necessarily a gateway address
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&icmp), reinterpret_cast<uint8_t*>(&icmp + 1));
+    auto icmp_cksum_it = packet.end() - 6;
+
+    // Recreate original IP hdr
+    ip.version = 4;
+    ip.ihl = 5; // only IP header in this recreation, no extensions. Cannot recreate without access to raw packets
+    ip.tos = 0; // may need to get this in a cmsg from recvmsg()
+    ip.tot_len = htons(static_cast<uint16_t>(sizeof(iphdr) + sizeof(udphdr) + m_payloadEndOffset - m_originalPayloadOffset));
+    ip.id = 0;  // not sure we can access this without reading raw packets
+    ip.frag_off = 0; // no access to this without raw packets
+    ip.ttl = 64; // may need to get this in a cmsg from recvmsg()
+    ip.protocol = IPPROTO_UDP;
+    ip.check = 0;
+    ip.saddr = sin_orig_src->sin_addr.s_addr; // original source
+    ip.daddr = sin_orig_dst->sin_addr.s_addr; // original destination
+    ip.check = checksum(&ip, sizeof(ip));
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&ip), reinterpret_cast<uint8_t*>(&ip + 1));
+
+    original_ip_packet_bytes -= sizeof(iphdr);
+
+    // Recreate original UDP header
+    struct udphdr udp;
+    udp.uh_sport = sin_orig_src->sin_port;
+    udp.uh_dport = sin_orig_dst->sin_port;
+    udp.uh_ulen = htons(static_cast<uint16_t>(sizeof(udphdr) + m_payloadEndOffset - m_originalPayloadOffset));
+    udp.uh_sum = 0;
+
+    struct {
+        struct in_addr saddr;
+        struct in_addr daddr;
+        uint8_t zero;
+        uint8_t protocol;
+        uint16_t udp_len;
+    } pseudo_ip = {
+        ip.saddr,
+        ip.daddr,
+        0,
+        IPPROTO_UDP,
+        udp.uh_ulen
+    };
+
+    // fake original checksum for full UDP packet
+    udp.uh_sum = addChecksum(addChecksum(checksum(&pseudo_ip, sizeof(pseudo_ip)), &udp, sizeof(udp)), m_packet.data() + m_originalPayloadOffset, m_payloadEndOffset - m_originalPayloadOffset);
+
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&udp), reinterpret_cast<uint8_t*>(&udp + 1));
+
+    original_ip_packet_bytes -= sizeof(udphdr);
+
+    // Add as much packet data as allowed
+    if (original_ip_packet_bytes > 0) {
+        packet.insert(packet.end(), m_packet.data() + m_originalPayloadOffset, m_packet.data() + std::min(m_originalPayloadOffset + original_ip_packet_bytes, m_payloadEndOffset));
+    }
+
+    // Fill in ICMP checksum
+    *reinterpret_cast<uint16_t*>(&(*icmp_cksum_it)) = checksum(packet.data() + sizeof(iphdr), packet.size() - sizeof(iphdr));
+
+    return sendto(g_rawIcmpv4Socket, packet.data(), packet.size(), 0, m_originalSourceAddress.get(), m_originalSourceAddressLen);
+}
+
+int Packet::sendICMP6(uint8_t typ, uint8_t code, uint32_t icmpdata, ssize_t original_ip_packet_bytes) const
+{
+    ogs_debug("ICMP6: type=%u, code=%u, data=0x%x", typ, code, icmpdata);
+
+    //  0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    // +-------+---------------+---------------------------------------+
+    // |Version| Traffic class |              Flow label               | IPv6 Header
+    // +-------+---------------+-------+---------------+---------------+
+    // |        Payload length         | Next Hdr (58) |   Hop limit   |
+    // +-------------------------------+---------------+---------------+
+    // |                                                               |
+    // |                        Source Address                         |
+    // |                                                               |
+    // |                                                               |
+    // +---------------------------------------------------------------+
+    // |                                                               |
+    // |                     Destination Address                       |
+    // |                                                               |
+    // |                                                               |
+    // +---------------+---------------+-------------------------------+
+    // |      Type     |      Code     |         Checksum              | ICMPv6 Header
+    // +---------------+---------------+-------------------------------+
+    // |  ICMP message specific data                                   |
+    // +---------------------------------------------------------------+
+    // |  First N bytes of the original message including IPv6 and UDP :
+    // :  headers                                                      :
+
+    if (original_ip_packet_bytes < 0) {
+        // use all available space - base size on original packet size
+        original_ip_packet_bytes = m_payloadEndOffset - m_originalPayloadOffset - sizeof(ip6_hdr) - sizeof(icmp6_hdr);
+    }
+
+    std::vector<uint8_t> packet;
+    packet.reserve(sizeof(ip6_hdr) + sizeof(icmp6_hdr) + original_ip_packet_bytes);
+
+    auto sin6_orig_src = std::reinterpret_pointer_cast<struct sockaddr_in6>(m_originalSourceAddress);
+    auto sin6_orig_dst = std::reinterpret_pointer_cast<struct sockaddr_in6>(m_originalDestinationAddress);
+
+    struct ip6_hdr ip;
+    ip.ip6_vfc = 6;
+    ip.ip6_nxt = IPPROTO_ICMPV6;
+    ip.ip6_hlim = 64;
+    ip.ip6_src = sin6_orig_dst->sin6_addr; // going back from our address
+    ip.ip6_dst = sin6_orig_src->sin6_addr; // going to the original source
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&ip), reinterpret_cast<uint8_t*>(&ip + 1));
+
+    struct icmp6_hdr icmp;
+    icmp.icmp6_type = typ;
+    icmp.icmp6_code = code;
+    icmp.icmp6_cksum = 0;
+    icmp.icmp6_data32[0] = icmpdata;
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&icmp), reinterpret_cast<uint8_t*>(&icmp + 1));
+    auto icmp_cksum_it = packet.end() - 6;
+
+    // Recreate original IPv6 hdr
+    ip.ip6_vfc = 6;
+    ip.ip6_nxt = IPPROTO_UDP;
+    ip.ip6_hlim = 64;
+    ip.ip6_src = sin6_orig_src->sin6_addr;
+    ip.ip6_dst = sin6_orig_dst->sin6_addr;
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&ip), reinterpret_cast<uint8_t*>(&ip + 1));
+
+    original_ip_packet_bytes -= sizeof(ip6_hdr);
+
+    // Recreate original UDP header
+    struct udphdr udp;
+    udp.uh_sport = sin6_orig_src->sin6_port;
+    udp.uh_dport = sin6_orig_dst->sin6_port;
+    udp.uh_ulen = htons(static_cast<uint16_t>(sizeof(udphdr) + m_payloadEndOffset - m_originalPayloadOffset));
+    udp.uh_sum = 0;
+
+    struct {
+        struct in6_addr saddr;
+        struct in6_addr daddr;
+        uint32_t udp_len;
+        uint16_t zero1;
+        uint8_t zero2;
+        uint8_t protocol;
+    } pseudo_ip = {
+        ip.ip6_src,
+        ip.ip6_dst,
+        htonl(static_cast<uint32_t>(sizeof(udphdr) + m_payloadEndOffset - m_originalPayloadOffset)),
+        0, 0,
+        IPPROTO_UDP
+    };
+
+    // fake original checksum for full UDP packet
+    udp.uh_sum = addChecksum(addChecksum(checksum(&pseudo_ip, sizeof(pseudo_ip)), &udp, sizeof(udp)), m_packet.data() + m_originalPayloadOffset, m_payloadEndOffset - m_originalPayloadOffset);
+
+    packet.insert(packet.end(), reinterpret_cast<uint8_t*>(&udp), reinterpret_cast<uint8_t*>(&udp + 1));
+
+    original_ip_packet_bytes -= sizeof(udphdr);
+
+    // Add as much packet data as allowed
+    if (original_ip_packet_bytes > 0) {
+        packet.insert(packet.end(), m_packet.data() + m_originalPayloadOffset, m_packet.data() + std::min(m_originalPayloadOffset + original_ip_packet_bytes, m_payloadEndOffset));
+    }
+
+    // Fill in ICMP checksum
+    *reinterpret_cast<uint16_t*>(&(*icmp_cksum_it)) = checksum(packet.data() + sizeof(ip6_hdr), packet.size() - sizeof(ip6_hdr));
+
+    return sendto(g_rawIcmpv6Socket, packet.data(), packet.size(), 0, m_originalSourceAddress.get(), m_originalSourceAddressLen);
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/Packet.cc
+++ b/src/mbstf/Packet.cc
@@ -84,8 +84,9 @@ Packet::Packet(const uint8_t *buffer, size_t buffer_size, bool encapsulated_hdrs
             m_encapsulatedUdpOffset = m_encapsulatedIpOffset + sizeof(ip6_hdr);
             for (const struct ip6_ext *ip6e = reinterpret_cast<const struct ip6_ext*>(buffer + sizeof(ip6_hdr));
                  ip6e->ip6e_nxt != IPPROTO_UDP;
-                 ip6e = reinterpret_cast<const struct ip6_ext*>(reinterpret_cast<const uint8_t*>(ip6e) + ip6e->ip6e_len)) {
-                m_encapsulatedUdpOffset += ip6e->ip6e_len;
+                 ip6e = reinterpret_cast<const struct ip6_ext*>(reinterpret_cast<const uint8_t*>(ip6e) + (ip6e->ip6e_len + 1) * 8))
+            {
+                m_encapsulatedUdpOffset += (ip6e->ip6e_len + 1) * 8;
             }
         }
         if (m_encapsulatedUdpOffset) m_encapsulatedPayloadOffset = m_encapsulatedUdpOffset + sizeof(udphdr);
@@ -307,7 +308,7 @@ bool Packet::setEncapsulatedUdpHeader(struct in6_addr *source_address, in_port_t
     m_haveEncapsulation = true;
 
     struct ip6_hdr *ip = reinterpret_cast<struct ip6_hdr*>(m_packet.data() + m_encapsulatedIpOffset);
-    ip->ip6_vfc = 6;
+    ip->ip6_vfc = 0x60; // version = 6, tc top bits = 0
     ip->ip6_nxt = IPPROTO_UDP;
     ip->ip6_hlim = ttl;
     ip->ip6_src = *source_address;
@@ -650,7 +651,7 @@ int Packet::sendICMP6(uint8_t typ, uint8_t code, uint32_t icmpdata, ssize_t orig
     auto sin6_orig_dst = std::reinterpret_pointer_cast<struct sockaddr_in6>(m_originalDestinationAddress);
 
     struct ip6_hdr ip;
-    ip.ip6_vfc = 6;
+    ip.ip6_vfc = 0x60; // version = 6, top tc bits = 0
     ip.ip6_nxt = IPPROTO_ICMPV6;
     ip.ip6_hlim = 64;
     ip.ip6_src = sin6_orig_dst->sin6_addr; // going back from our address
@@ -666,7 +667,7 @@ int Packet::sendICMP6(uint8_t typ, uint8_t code, uint32_t icmpdata, ssize_t orig
     auto icmp_cksum_it = packet.end() - 6;
 
     // Recreate original IPv6 hdr
-    ip.ip6_vfc = 6;
+    ip.ip6_vfc = 0x60; // version = 6, top tc bits = 0
     ip.ip6_nxt = IPPROTO_UDP;
     ip.ip6_hlim = 64;
     ip.ip6_src = sin6_orig_src->sin6_addr;

--- a/src/mbstf/Packet.hh
+++ b/src/mbstf/Packet.hh
@@ -1,0 +1,144 @@
+#ifndef _MBS_TF_PACKET_HH_
+#define _MBS_TF_PACKET_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <netinet/in.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common.hh"
+
+MBSTF_NAMESPACE_START
+
+class Packet {
+public:
+    class DataView {
+    public:
+        DataView() :m_ptr(nullptr), m_len(0) {};
+        DataView(const uint8_t *data, size_t len) :m_ptr(data), m_len(len) {};
+        template<class T>
+        DataView(const std::vector<T> &vec, size_t offset, size_t len)
+            :m_ptr(reinterpret_cast<const uint8_t*>(vec.data()+std::min(vec.size(),offset)))
+            ,m_len(sizeof(T) * std::min(vec.size()-std::min(vec.size(),offset),len))
+        {};
+        template<class T>
+        DataView(const std::vector<T> &vec, size_t offset = 0)
+            :m_ptr(reinterpret_cast<const uint8_t*>(vec.data()+std::min(vec.size(),offset)))
+            ,m_len(sizeof(T) * (vec.size()-std::min(vec.size(),offset)))
+        {};
+        template<class CharT>
+        DataView(const std::basic_string<CharT> &str) :m_ptr(reinterpret_cast<const uint8_t*>(str.data())), m_len(sizeof(CharT) * str.size()) {};
+        template<class CharT>
+        DataView(const std::basic_string_view<CharT> &str) :m_ptr(reinterpret_cast<const uint8_t*>(str.data())), m_len(sizeof(CharT) * str.size()) {};
+        template<class T, size_t N>
+        DataView(const std::array<T,N> &arr) :m_ptr(reinterpret_cast<const uint8_t*>(arr.data())), m_len(sizeof(T)*N) {};
+
+        const uint8_t *begin() const { return m_ptr; };
+        const uint8_t *end() const { return m_ptr + m_len; };
+        const uint8_t *cbegin() const { return m_ptr; };
+        const uint8_t *cend() const { return m_ptr + m_len; };
+
+        size_t size() const { return m_len; };
+        const uint8_t *data() const { return m_ptr; };
+
+    private:
+        const uint8_t *m_ptr;
+        size_t m_len;
+    };
+
+    Packet();
+    Packet(const uint8_t *buffer, size_t buffer_size, bool encapsulated_hdrs = false);
+    Packet(struct msghdr *msg_hdr, const std::shared_ptr<struct sockaddr> &listen_address, bool encapsulated_hdrs = false);
+    Packet(const Packet &other);
+    Packet(Packet &&other);
+
+    virtual ~Packet() {};
+
+    Packet &operator=(const Packet &other);
+    Packet &operator=(Packet &&other);
+
+    bool operator==(const Packet &other) const;
+
+    bool setEncapsulatedUdpHeader(struct in6_addr *source_address, in_port_t source_port, struct in6_addr *dest_address, in_port_t dest_port, uint8_t ttl = 64);
+    bool setEncapsulatedUdpHeader(struct in_addr *source_address, in_port_t source_port, struct in_addr *dest_address, in_port_t dest_port, uint8_t ttl = 64, bool do_not_fragment = false);
+
+    size_t size() const { return m_payloadEndOffset - m_payloadOffset; };
+    DataView payload() const { return DataView(m_packet, m_payloadOffset, m_payloadEndOffset - m_payloadOffset); };
+
+    int family() const;         // family of the encapsulated packet or AF_UNSPEC if no encapsulation
+    int originalFamily() const; // family of original packet, not the encapsulated packet, if known otherwise AF_UNSPEC
+    bool doNotFragment() const; // encapsulated doNotFragment flag if IPv4 or true if encapsulated packet is IPv6
+    std::shared_ptr<struct sockaddr> originalSourceAddress() const;
+    std::shared_ptr<struct sockaddr> originalDestinationAddress() const;
+    std::shared_ptr<struct sockaddr> encapsulatedSourceAddress() const;
+    std::shared_ptr<struct sockaddr> encapsulatedDestinationAddress() const;
+
+    Packet fragmentData(size_t max_payload_size);
+
+    static uint16_t addChecksum(uint16_t current_checksum, const void *buffer, size_t buffer_len);
+
+    static uint16_t checksum(const void *buffer, size_t buffer_len);
+
+    template<class T>
+    static uint16_t checksum(const std::vector<T> &buffer) {
+        return checksum(reinterpret_cast<const void*>(buffer.data()), buffer.size() * sizeof(T));
+    };
+
+    template<class CharT>
+    static uint16_t checksum(const std::basic_string<CharT> &buffer) {
+        return checksum(reinterpret_cast<const void*>(buffer.data()), buffer.size() * sizeof(CharT));
+    };
+
+    template<class CharT>
+    static uint16_t checksum(const std::basic_string_view<CharT> &buffer) {
+        return checksum(reinterpret_cast<const void*>(buffer.data()), buffer.size() * sizeof(CharT));
+    };
+
+    template<class T, size_t N>
+    static uint16_t checksum(const std::array<T,N> &buffer) {
+        return checksum(reinterpret_cast<const void*>(buffer.data()), sizeof(T) * N);
+    };
+
+    int sendICMPNeedSmallerMTU(uint16_t mtu) const;
+
+private:
+    Packet &recalculateEncapsulatedSizesAndChecksums();
+    int sendICMP(uint8_t typ, uint8_t code, uint32_t icmpdata, ssize_t original_ip_packet_bytes) const;
+    int sendICMP6(uint8_t typ, uint8_t code, uint32_t icmpdata, ssize_t original_ip_packet_bytes) const;
+
+    std::vector<uint8_t> m_packet;
+    size_t m_originalPayloadOffset;
+    size_t m_payloadOffset;
+    size_t m_payloadEndOffset;
+    size_t m_encapsulatedIpOffset; // equals m_payloadOffset or 0 if encapsulation not present
+    size_t m_encapsulatedUdpOffset; // equals m_encapsulatedIpOffset + sizeof(iphdr) or 0 if encapsulated UDP not present
+    size_t m_encapsulatedPayloadOffset; // equals m_encapsulatedUdpOffset + sizeof(udphdr) or 0 if encapsulation not present
+    size_t m_fragmentOffset;
+    bool m_moreFragments;
+    bool m_haveEncapsulation;
+    int m_originalIfc;
+    std::shared_ptr<struct sockaddr> m_originalSourceAddress;
+    socklen_t m_originalSourceAddressLen;
+    std::shared_ptr<struct sockaddr> m_originalDestinationAddress;
+    socklen_t m_originalDestinationAddressLen;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_HH_ */

--- a/src/mbstf/PacketController.cc
+++ b/src/mbstf/PacketController.cc
@@ -1,0 +1,328 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Controller base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+#include "common.hh"
+#include "App.hh"
+#include "Controller.hh"
+#include "DistributionSession.hh"
+#include "PacketFEC.hh"
+#include "PacketIngester.hh"
+#include "PacketPacketisation.hh"
+#include "PacketScheduler.hh"
+#include "SsmPort.hh"
+#include "utilities.hh"
+#include "openapi/model/CreateReqData.h"
+#include "openapi/model/DistSession.h"
+#include "openapi/model/PktDistributionData.h"
+#include "openapi/model/ModelException.hh"
+#include "openapi/model/ProblemCause.hh"
+#include "openapi/model/MbStfIngestAddr.h"
+#include "openapi/model/TunnelAddress.h"
+
+#include "PacketController.hh"
+
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
+using reftools::mbstf::MbStfIngestAddr;
+using reftools::mbstf::PktIngestMethod;
+using reftools::mbstf::TunnelAddress;
+
+MBSTF_NAMESPACE_START
+
+template<class TunAddr>
+static std::shared_ptr<struct sockaddr> make_shared_sockaddr(const std::shared_ptr<TunAddr> &tunnel_addr);
+static SsmPort make_ssm(const MbStfIngestAddr::AfSsmType::value_type &af_ssm);
+
+PacketController::PacketController(DistributionSession &distributionSession)
+    :Controller(distributionSession)
+    ,m_ingester()
+    ,m_fec()
+    ,m_packetiser()
+    ,m_scheduler()
+{
+    validateDistributionSession(distributionSession);
+}
+
+PacketController::~PacketController()
+{
+}
+
+    // Controller virtual functions
+void PacketController::establishInactiveInputs()
+{
+    /* Inactive state for DistSession */
+
+    // stop ingester if it already exists, or create otherwise
+    if (m_ingester) {
+        m_ingester.stop();
+    } else {
+        auto &create_req_data = distributionSession().distributionSessionReqData();
+        auto &dist_sess = create_req_data->getDistSession();
+        auto &pkt_distr_data = dist_sess->getPktDistributionData().value();
+        const auto &pkt_ingest_mode = pkt_distr_data->getPktIngestMethod();
+
+        if (!pkt_ingest_mode || pkt_ingest_mode.value()->getValue() == PktIngestMethod::VAL_UNICAST) {
+            bool is_encap = expectEncapsulatedPackets();
+            std::shared_ptr<struct sockaddr> listen; // leave listening address as any (nullptr)
+            const auto &af_egress_tun_addr = pkt_distr_data->getMbStfIngestAddr()->getAfEgressTunAddr();
+            if (!af_egress_tun_addr) {
+                throw ModelException("Missing AF Egress Tunnel Address for UNICAST ingest mode", "PacketController", "distSession.pktDistributionData.mbStfIngestAddr.afEgressTunAddr", ProblemCause::MANDATORY_IE_MISSING);
+            }
+            auto remote = make_shared_sockaddr(af_egress_tun_addr.value());
+            try {
+                m_ingester = PacketIngester(listen, remote, is_encap);
+            } catch (const std::error_condition &ex) {
+                ogs_error("Unable to create PacketIngester: %s", ex.message().c_str());
+                return;
+            }
+            TunnelAddress local_listening_addr;
+            const auto &local_addr = m_ingester.localSockAddr();
+            if (local_addr.sa_family == AF_INET) {
+                char buf[INET_ADDRSTRLEN];
+                const auto *sin = reinterpret_cast<const struct sockaddr_in*>(&local_addr);
+                if (inet_ntop(AF_INET, &sin->sin_addr, buf, sizeof(buf))) {
+                    local_listening_addr.setIpv4Addr(std::string(buf));
+                }
+                local_listening_addr.setPortNumber(ntohs(sin->sin_port));
+            } else if (local_addr.sa_family == AF_INET6) {
+                char buf[INET6_ADDRSTRLEN];
+                const auto *sin6 = reinterpret_cast<const struct sockaddr_in6*>(&local_addr);
+                if (inet_ntop(AF_INET6, &sin6->sin6_addr, buf, sizeof(buf))) {
+                    local_listening_addr.setIpv6Addr(std::string(buf));
+                }
+                local_listening_addr.setPortNumber(ntohs(sin6->sin6_port));
+            }
+            if (is_encap) {
+                auto listen_addr = std::make_shared<MbStfIngestAddr::MbStfIngressTunAddrType::value_type::element_type>();
+                listen_addr->setIpv4Addr(local_listening_addr.getIpv4Addr());
+                listen_addr->setIpv6Addr(local_listening_addr.getIpv6Addr());
+                listen_addr->setPortNumber(local_listening_addr.getPortNumber());
+                pkt_distr_data->getMbStfIngestAddr()->setMbStfIngressTunAddr(listen_addr);
+            } else {
+                auto listen_addr = std::make_shared<MbStfIngestAddr::MbStfListenAddrType::value_type::element_type>();
+                listen_addr->setIpv4Addr(local_listening_addr.getIpv4Addr());
+                listen_addr->setIpv6Addr(local_listening_addr.getIpv6Addr());
+                listen_addr->setPortNumber(local_listening_addr.getPortNumber());
+                pkt_distr_data->getMbStfIngestAddr()->setMbStfListenAddr(listen_addr);
+            }
+        } else if (pkt_ingest_mode && pkt_ingest_mode.value()->getValue() == PktIngestMethod::VAL_MULTICAST) {
+            const auto &af_ssm = pkt_distr_data->getMbStfIngestAddr()->getAfSsm();
+            if (!af_ssm) {
+                throw ModelException("Missing AF SSM Address for MULTICAST ingest mode", "PacketController", "distSession.pktDistributionData.mbStfIngestAddr.afSsm", ProblemCause::MANDATORY_IE_MISSING);
+            }
+            m_ingester = PacketIngester(make_ssm(af_ssm.value()));
+        }
+    }
+    if (m_fec) m_fec->stop();
+    if (m_packetiser) m_packetiser->stop();
+    m_scheduler.stop();
+}
+
+void PacketController::establishActiveInputs()
+{
+    /* Established state for DistSession */
+    m_ingester.start();
+}
+
+void PacketController::activateOutput()
+{
+    /* Active state for DistSession */
+    if (!m_fec) setPacketFEC();
+    if (m_fec) m_fec->start();
+
+    if (!m_packetiser) setPacketPacketisation();
+    if (m_packetiser) {
+        m_packetiser->start();
+        if (!m_scheduler) {
+            const auto &distribution_session = distributionSession();
+            uint64_t abr = static_cast<uint64_t>(distribution_session.getMbr().value_or(BitRate("10Kbps")).bitRate());
+            uint64_t burst_bits = m_packetiser->mtu() * 2 * 8; // default to burst of 2 max packet sizes
+            size_t max_buffer = App::self().context()->packetModeSchedulingQueueSize;
+            std::shared_ptr<TunnelAddress> no_tunnel;
+            std::shared_ptr<struct sockaddr> tunnel_endpoint = make_shared_sockaddr(distribution_session.getTunnel().value_or(no_tunnel));
+            m_scheduler = PacketScheduler(burst_bits, abr, max_buffer, tunnel_endpoint.get(), m_packetiser.get());
+        }
+        m_scheduler.start();
+    } else {
+        ogs_warn("Attempt to go ACTIVE for PacketController without a packetisation");
+        // distSession()->setState(inactive_state); <= ???
+    }
+}
+
+void PacketController::deactivateOutput()
+{
+    /* Deactivating state for DistSession */
+    if (m_fec) m_fec->stop();
+    if (m_packetiser) m_packetiser->stop();
+    m_scheduler.stop();
+}
+
+void PacketController::flushPackagerQueue()
+{
+    /* Empty packaging queue */
+    if (m_fec) m_fec->flush();
+    if (m_packetiser) m_packetiser->flush();
+    m_scheduler.flush();
+}
+
+void PacketController::validateDistributionSession(DistributionSession &distribution_session)
+{
+    const auto &create_req_data = distribution_session.distributionSessionReqData();
+    if (!create_req_data) {
+        throw ModelException("CreateReqData missing", "PacketController", std::string(), ProblemCause::MANDATORY_IE_MISSING);
+    }
+    const auto &dist_session = create_req_data->getDistSession();
+    if (!dist_session) {
+        throw ModelException("distSession missing", "PacketController", "distSession", ProblemCause::MANDATORY_IE_MISSING);
+    }
+    const auto &pkt_distr_data = dist_session->getPktDistributionData();
+    if (!pkt_distr_data || !pkt_distr_data.value()) {
+        throw ModelException("Packet distribution operating mode requires pktDistributionData", "PacketController", "distSession.pktDistributionData", ProblemCause::MANDATORY_IE_MISSING);
+    }
+}
+
+// protected:
+
+const std::shared_ptr<PacketFEC> &PacketController::packetFEC(PacketFEC *fec)
+{
+    std::shared_ptr<PacketFEC> new_fec{fec};
+    return packetFEC(std::move(new_fec));
+}
+
+const std::shared_ptr<PacketFEC> &PacketController::packetFEC(const std::shared_ptr<PacketFEC> &fec)
+{
+    std::shared_ptr<PacketFEC> new_fec{fec};
+    return packetFEC(std::move(new_fec));
+}
+
+const std::shared_ptr<PacketFEC> &PacketController::packetFEC(std::shared_ptr<PacketFEC> &&fec)
+{
+    bool started = (m_fec && m_fec->isStarted());
+    m_fec = std::move(fec);
+    if (m_fec) {
+        m_fec->attachSource(&m_ingester);
+        if (m_packetiser) {
+            m_fec->attachSink(m_packetiser.get());
+        } else {
+            m_fec->attachSink(&m_scheduler);
+        }
+        if (started) {
+            m_fec->start();
+        } else {
+            m_fec->stop();
+        }
+    }
+    return m_fec;
+}
+
+const std::shared_ptr<PacketPacketisation> &PacketController::packetPacketiser(PacketPacketisation *packetisation)
+{
+    std::shared_ptr<PacketPacketisation> new_packetisation{packetisation};
+    return packetPacketiser(std::move(new_packetisation));
+}
+
+const std::shared_ptr<PacketPacketisation> &PacketController::packetPacketiser(const std::shared_ptr<PacketPacketisation> &packetisation)
+{
+    std::shared_ptr<PacketPacketisation> new_packetisation{packetisation};
+    return packetPacketiser(std::move(new_packetisation));
+}
+
+const std::shared_ptr<PacketPacketisation> &PacketController::packetPacketiser(std::shared_ptr<PacketPacketisation> &&packetisation)
+{
+    bool started = (m_packetiser && m_packetiser->isStarted());
+    m_packetiser = std::move(packetisation);
+    if (m_packetiser) {
+        m_packetiser->attachSink(&m_scheduler);
+        if (m_fec) {
+            m_packetiser->attachSource(m_fec.get());
+        } else {
+            m_packetiser->attachSource(&m_ingester);
+        }
+        if (started) {
+            m_packetiser->start();
+        } else {
+            m_packetiser->stop();
+        }
+    }
+    return m_packetiser;
+}
+
+// private:
+
+void PacketController::reconfigurePacketIngester()
+{
+    m_ingester.reconfigure();
+}
+
+void PacketController::reconfigurePacketScheduler()
+{
+    m_scheduler.reconfigure();
+}
+
+// Local functions
+
+template<class TunAddr>
+static std::shared_ptr<struct sockaddr> make_shared_sockaddr(const std::shared_ptr<TunAddr> &tunnel_addr)
+{
+    std::shared_ptr<struct sockaddr> ret;
+
+    if (tunnel_addr) {
+        std::string hostname;
+        int family = AF_UNSPEC;
+        in_port_t port = static_cast<in_port_t>(tunnel_addr->getPortNumber());
+        const auto &ipv6_addr = tunnel_addr->getIpv6Addr();
+        if (ipv6_addr) {
+            hostname = ipv6_addr.value();
+            family = AF_INET6;
+        } else {
+            const auto &ipv4_addr = tunnel_addr->getIpv4Addr();
+            if (ipv4_addr) {
+                hostname = ipv4_addr.value();
+                family = AF_INET;
+            }
+        }
+
+        ret = make_shared_sockaddr(family, hostname, port);
+    }
+
+    return ret;
+}
+
+static SsmPort make_ssm(const MbStfIngestAddr::AfSsmType::value_type &af_ssm)
+{
+    if (!af_ssm) return SsmPort();
+    const auto &af_ssm_addr = af_ssm->getSsm();
+    in_port_t af_ssm_port = static_cast<in_port_t>(af_ssm->getPortNumber());
+    std::string dest;
+    const auto &dest_ip_addr = *af_ssm_addr->getDestIpAddr();
+    if (dest_ip_addr.getIpv6Addr()) dest = dest_ip_addr.getIpv6Addr().value();
+    else if (dest_ip_addr.getIpv4Addr()) dest = dest_ip_addr.getIpv4Addr().value();
+    std::string src;
+    const auto &src_ip_addr = *af_ssm_addr->getSourceIpAddr();
+    if (src_ip_addr.getIpv6Addr()) src = src_ip_addr.getIpv6Addr().value();
+    else if (src_ip_addr.getIpv4Addr()) src = src_ip_addr.getIpv4Addr().value();
+    return SsmPort(af_ssm_port, dest, src);
+}
+
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketController.cc
+++ b/src/mbstf/PacketController.cc
@@ -194,7 +194,8 @@ void PacketController::validateDistributionSession(DistributionSession &distribu
     }
     const auto &pkt_distr_data = dist_session->getPktDistributionData();
     if (!pkt_distr_data || !pkt_distr_data.value()) {
-        throw ModelException("Packet distribution operating mode requires pktDistributionData", "PacketController", "distSession.pktDistributionData", ProblemCause::MANDATORY_IE_MISSING);
+        // throw logic error to indicate that this Controller is not right for the given distribution session, but another may be
+        throw std::logic_error("Packet distribution operating mode requires pktDistributionData");
     }
 }
 

--- a/src/mbstf/PacketController.hh
+++ b/src/mbstf/PacketController.hh
@@ -1,0 +1,101 @@
+#ifndef _MBS_TF_PACKET_CONTROLLER_HH_
+#define _MBS_TF_PACKET_CONTROLLER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Controller base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+#include "common.hh"
+#include "Controller.hh"
+#include "PacketIngester.hh"
+#include "PacketScheduler.hh"
+
+MBSTF_NAMESPACE_START
+
+class DistributionSession;
+class PacketPacketisation;
+class PacketFEC;
+
+class PacketController : public Controller {
+public:
+    PacketController() = delete;
+    PacketController(DistributionSession &distributionSession);
+    PacketController(const PacketController &) = delete;
+    PacketController(PacketController &&) = delete;
+
+    virtual ~PacketController();
+
+    PacketController &operator=(const PacketController &) = delete;
+    PacketController &operator=(PacketController &&) = delete;
+
+    // Controller virtual functions
+    virtual void reconfigure() {
+        reconfigurePacketIngester();
+        this->reconfigurePacketFEC();
+        this->reconfigurePacketPacketisation();
+        reconfigurePacketScheduler();
+    };
+
+    virtual void establishInactiveInputs(); /* Inactive state for DistSession */
+    virtual void establishActiveInputs();   /* Established state for DistSession */
+    virtual void activateOutput();          /* Active state for DistSession */
+    virtual void deactivateOutput();        /* Deactivating state for DistSession */
+    virtual void flushPackagerQueue();      /* Empty packaging queue */
+
+    static void validateDistributionSession(DistributionSession &distribution_session);
+
+protected:
+    PacketIngester &packetIngester() { return m_ingester; };
+    const PacketIngester &packetIngester() const { return m_ingester; };
+
+    std::shared_ptr<PacketFEC> &packetFEC() { return m_fec; };
+    const std::shared_ptr<PacketFEC> &packetFEC() const { return m_fec; };
+    const std::shared_ptr<PacketFEC> &packetFEC(PacketFEC *fec);
+    const std::shared_ptr<PacketFEC> &packetFEC(const std::shared_ptr<PacketFEC> &fec);
+    const std::shared_ptr<PacketFEC> &packetFEC(std::shared_ptr<PacketFEC> &&fec);
+
+    std::shared_ptr<PacketPacketisation> &packetPacketiser() { return m_packetiser; };
+    const std::shared_ptr<PacketPacketisation> &packetPacketiser() const { return m_packetiser; };
+    const std::shared_ptr<PacketPacketisation> &packetPacketiser(PacketPacketisation *packetiser);
+    const std::shared_ptr<PacketPacketisation> &packetPacketiser(const std::shared_ptr<PacketPacketisation> &packetiser);
+    const std::shared_ptr<PacketPacketisation> &packetPacketiser(std::shared_ptr<PacketPacketisation> &&packetiser);
+
+    PacketScheduler &packetScheduler() { return m_scheduler; };
+    const PacketScheduler &packetScheduler() const { return m_scheduler; };
+
+    virtual void setPacketFEC() = 0;
+    virtual void unsetPacketFEC() = 0;
+    virtual void reconfigurePacketFEC() = 0;
+
+    virtual void setPacketPacketisation() = 0;
+    virtual void unsetPacketPacketisation() = 0;
+    virtual void reconfigurePacketPacketisation() = 0;
+
+    virtual bool expectEncapsulatedPackets() const { return false; };
+
+private:
+    void reconfigurePacketIngester();
+    void reconfigurePacketScheduler();
+
+    PacketIngester m_ingester;
+    std::shared_ptr<PacketFEC> m_fec;
+    std::shared_ptr<PacketPacketisation> m_packetiser;
+    PacketScheduler m_scheduler;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_CONTROLLER_HH_ */

--- a/src/mbstf/PacketFEC.cc
+++ b/src/mbstf/PacketFEC.cc
@@ -1,0 +1,22 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet FEC base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include "common.hh"
+
+#include "PacketFEC.hh"
+
+MBSTF_NAMESPACE_START
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketFEC.hh
+++ b/src/mbstf/PacketFEC.hh
@@ -1,0 +1,44 @@
+#ifndef _MBS_TF_PACKET_FEC_HH_
+#define _MBS_TF_PACKET_FEC_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet FEC base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <memory>
+
+#include "common.hh"
+#include "PacketProcessing.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketFEC : public PacketProcessing {
+public:
+    PacketFEC() :PacketProcessing() {};
+    PacketFEC(const PacketFEC &other) = delete;
+    PacketFEC(PacketFEC &&other) :PacketProcessing(std::move(other)) {};
+
+    virtual ~PacketFEC() {};
+
+    PacketFEC &operator=(const PacketFEC &) = delete;
+    PacketFEC &operator=(PacketFEC &&other) { PacketProcessing::operator=(std::move(other)); return *this; };
+
+    virtual bool start() = 0;
+    virtual bool isStarted() = 0;
+    virtual bool stop() = 0;
+    virtual bool flush() = 0;
+    virtual bool reconfigure() = 0;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_FEC_HH_ */

--- a/src/mbstf/PacketForwardOnlyController.cc
+++ b/src/mbstf/PacketForwardOnlyController.cc
@@ -1,0 +1,134 @@
+/**************************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Forward-Only Packet Controller class
+ **************************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <netinet/udp.h>
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+#include "ControllerFactory.hh"
+#include "DistributionSession.hh"
+#include "PacketController.hh"
+#include "PacketForwardPacketisation.hh"
+#include "PacketIngester.hh"
+#include "PacketScheduler.hh"
+#include "utilities.hh"
+#include "openapi/model/CreateReqData.h"
+#include "openapi/model/PktDistributionOperatingMode.h"
+
+#include "PacketForwardOnlyController.hh"
+
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
+using reftools::mbstf::PktDistributionOperatingMode;
+
+MBSTF_NAMESPACE_START
+
+// public:
+
+PacketForwardOnlyController::PacketForwardOnlyController(DistributionSession &distributionSession)
+    :PacketController(distributionSession)
+{
+    validateForwardOnlyDistributionSession(distributionSession);
+}
+
+PacketForwardOnlyController::~PacketForwardOnlyController()
+{
+}
+
+// protected:
+void PacketForwardOnlyController::setPacketFEC()
+{
+    // no FEC implemented yet
+}
+
+void PacketForwardOnlyController::unsetPacketFEC()
+{
+    // no FEC implemented yet
+}
+
+void PacketForwardOnlyController::reconfigurePacketFEC()
+{
+    // no FEC implemented yet
+}
+
+// Overhead beyond IP level is GTP header size + UDP header size
+#define OVERHEAD (2 + sizeof(udphdr))
+
+void PacketForwardOnlyController::setPacketPacketisation()
+{
+    SsmPort ssm;
+    const auto &dist_session = distributionSession();
+    const auto &tun_endpoint = dist_session.getTunnelAddr();
+    in_port_t tun_port = dist_session.getTunnelPortNumber();
+    uint16_t mtu = static_cast<uint16_t>(get_tunnelled_path_mtu(ssm, tun_endpoint, tun_port, GET_MTU_IP_PAYLOAD)) - OVERHEAD;
+    ogs_debug("Creating packetiser with MTU = %u", mtu);
+    packetPacketiser(new PacketForwardPacketisation(mtu));
+}
+
+void PacketForwardOnlyController::unsetPacketPacketisation()
+{
+    packetPacketiser(nullptr);
+}
+
+void PacketForwardOnlyController::reconfigurePacketPacketisation()
+{
+    auto packetiser = std::dynamic_pointer_cast<PacketForwardPacketisation>(packetPacketiser());
+    if (packetiser) {
+        SsmPort ssm;
+        const auto &dist_session = distributionSession();
+        const auto &tun_endpoint = dist_session.getTunnelAddr();
+        in_port_t tun_port = dist_session.getTunnelPortNumber();
+        uint16_t mtu = static_cast<uint16_t>(get_tunnelled_path_mtu(ssm, tun_endpoint, tun_port, GET_MTU_IP_PAYLOAD)) - OVERHEAD;
+        packetiser->mtu(mtu);
+        packetiser->reconfigure();
+    }
+}
+
+// private:
+
+void PacketForwardOnlyController::validateForwardOnlyDistributionSession(const DistributionSession &dist_session)
+{
+    const auto &create_req_data = dist_session.distributionSessionReqData();
+    const auto &dist_sess = create_req_data->getDistSession();
+    const auto &pkt_distr_data = dist_sess->getPktDistributionData();
+
+    const auto &pkt_dist_oper_mode = pkt_distr_data.value()->getPktDistributionOperatingMode();
+    if (pkt_dist_oper_mode->getValue() != PktDistributionOperatingMode::VAL_PACKET_FORWARD_ONLY) {
+        throw std::logic_error("Expected pktDistributionOperatingMode to be PACKET_FORWARD_ONLY");
+    }
+
+    // Controller match found, now check the DistSession for Forward-Only irregularities
+
+    const auto &up_traffic_flow_info = dist_sess->getUpTrafficFlowInfo();
+    if (up_traffic_flow_info) {
+        throw ModelException("upTrafficFlowInfo present in ForwardOnly mode", "PacketForwardOnlyController", "distSession.upTrafficFlowInfo", ProblemCause::OPTIONAL_IE_INCORRECT);
+    }
+}
+
+namespace {
+static const struct init {
+    init() {
+        ControllerFactory::registerController(new ControllerConstructor<PacketForwardOnlyController>);
+    };
+} g_init;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketForwardOnlyController.hh
+++ b/src/mbstf/PacketForwardOnlyController.hh
@@ -1,0 +1,69 @@
+#ifndef _MBS_TF_PACKET_FORWARD_ONLY_CONTROLLER_HH_
+#define _MBS_TF_PACKET_FORWARD_ONLY_CONTROLLER_HH_
+/**************************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Forward-Only Packet Controller class
+ **************************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+#include "common.hh"
+#include "PacketController.hh"
+#include "PacketIngester.hh"
+#include "PacketScheduler.hh"
+
+MBSTF_NAMESPACE_START
+
+class DistributionSession;
+
+class PacketForwardOnlyController : public PacketController {
+public:
+    PacketForwardOnlyController() = delete;
+    PacketForwardOnlyController(DistributionSession &distributionSession);
+    PacketForwardOnlyController(const PacketForwardOnlyController &) = delete;
+    PacketForwardOnlyController(PacketForwardOnlyController &&) = delete;
+
+    virtual ~PacketForwardOnlyController();
+
+    PacketForwardOnlyController &operator=(const PacketForwardOnlyController &) = delete;
+    PacketForwardOnlyController &operator=(PacketForwardOnlyController &&) = delete;
+
+    // Controller virtual functions
+    //virtual void reconfigure() //implemented in PacketController
+    //virtual void establishInactiveInputs(); //implemented in PacketController
+    //virtual void establishActiveInputs(); //implemented in PacketController
+    //virtual void activateOutput(); //implemented in PacketController
+    //virtual void deactivateOutput(); //implemented in PacketController
+    //virtual void flushPacketisationQueue(); //implemented in PacketController
+
+    static unsigned int factoryPriority() { return 100; };
+
+protected:
+    virtual void setPacketFEC();
+    virtual void unsetPacketFEC();
+    virtual void reconfigurePacketFEC();
+
+    virtual void setPacketPacketisation();
+    virtual void unsetPacketPacketisation();
+    virtual void reconfigurePacketPacketisation();
+
+    virtual bool expectEncapsulatedPackets() const { return true; };
+
+private:
+    static void validateForwardOnlyDistributionSession(const DistributionSession &dist_session);
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_FORWARD_ONLY_CONTROLLER_HH_ */

--- a/src/mbstf/PacketForwardPacketisation.cc
+++ b/src/mbstf/PacketForwardPacketisation.cc
@@ -1,0 +1,63 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet ForwardPacketisation base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+#include "PacketPacketisation.hh"
+
+#include "PacketForwardPacketisation.hh"
+
+MBSTF_NAMESPACE_START
+
+// public:
+
+bool PacketForwardPacketisation::start()
+{
+    // Always started
+    return true;
+}
+
+bool PacketForwardPacketisation::isStarted()
+{
+    // Always started
+    return true;
+}
+
+bool PacketForwardPacketisation::stop()
+{
+    // We don't stop the packetisation as it's a throughput
+    return true;
+}
+
+bool PacketForwardPacketisation::flush()
+{
+    // No queue, packetisation is always flushed
+    return true;
+}
+
+bool PacketForwardPacketisation::reconfigure()
+{
+    // No resources to change
+    return true;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketForwardPacketisation.hh
+++ b/src/mbstf/PacketForwardPacketisation.hh
@@ -1,0 +1,55 @@
+#ifndef _MBS_TF_PACKET_FORWARD_PACKETISATION_HH_
+#define _MBS_TF_PACKET_FORWARD_PACKETISATION_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet ForwardPacketisation base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "common.hh"
+#include "PacketPacketisation.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketForwardPacketisation : public PacketPacketisation {
+public:
+    PacketForwardPacketisation() = delete;
+    PacketForwardPacketisation(uint16_t mtu) :PacketPacketisation(mtu) {};
+    PacketForwardPacketisation(const PacketForwardPacketisation &other) = delete;
+    PacketForwardPacketisation(PacketForwardPacketisation &&other)
+        :PacketPacketisation(std::move(other))
+    {};
+
+    virtual ~PacketForwardPacketisation() {};
+
+    PacketForwardPacketisation &operator=(const PacketForwardPacketisation &other) = delete;
+    PacketForwardPacketisation &operator=(PacketForwardPacketisation &&other) {
+        PacketPacketisation::operator=(std::move(other));
+        return *this;
+    };
+
+    virtual bool start();
+    virtual bool isStarted();
+    virtual bool stop();
+    virtual bool flush();
+    virtual bool reconfigure();
+
+private:
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_FORWARD_PACKETISATION_HH_ */

--- a/src/mbstf/PacketIngester.cc
+++ b/src/mbstf/PacketIngester.cc
@@ -1,0 +1,443 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Ingest base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <netdb.h>
+#include <netinet/icmp6.h>
+#include <netinet/in.h>
+#include <netinet/ip_icmp.h>
+#include <net/ethernet.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <system_error>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+#include "Packet.hh"
+#include "PacketProcessing.hh"
+#include "ThreadedWorker.hh"
+
+#include "PacketIngester.hh"
+
+using namespace std::literals::chrono_literals;
+
+MBSTF_NAMESPACE_START
+
+static bool fill_sockaddr_by_hostname(void /*struct sockaddr*/ *addr, const std::string &hostname, int family);
+static bool match_sockaddrs(const struct sockaddr *a, const struct sockaddr *b);
+static const char *inet_sockaddr_to_str(const struct sockaddr *sa, char *buf, socklen_t buf_len);
+
+// public:
+
+PacketIngester::PacketIngester()
+    :PacketSource()
+    ,m_ssm()
+    ,m_socket(-1)
+    ,m_encapsulatedPackets(false)
+    ,m_localAddr()
+    ,m_remoteAddr()
+    ,m_worker()
+{
+    //ogs_debug("Construct empty ingester");
+}
+
+PacketIngester::PacketIngester(const std::shared_ptr<struct sockaddr> &listen_address,
+                               const std::shared_ptr<struct sockaddr> &remote_endpoint,
+                               bool encapsulated_packets) // Unicast ingester
+    :PacketSource()
+    ,m_ssm()
+    ,m_socket(-1)
+    ,m_encapsulatedPackets(encapsulated_packets)
+    ,m_localAddr(listen_address)
+    ,m_remoteAddr(remote_endpoint)
+    ,m_worker()
+{
+    //ogs_debug("Construct unicast ingester");
+    int family = AF_INET;
+    if (m_localAddr) family = m_localAddr->sa_family;
+    else if (m_remoteAddr) family = m_remoteAddr->sa_family;
+
+    if (m_localAddr && m_remoteAddr && m_localAddr->sa_family != m_remoteAddr->sa_family) {
+        throw std::out_of_range("Remote and local network address must be in the same family");
+    }
+
+    m_socket = socket(family, SOCK_DGRAM, IPPROTO_UDP);
+    if (m_socket < 0) throw std::generic_category().default_error_condition(errno);
+
+    if (family == AF_INET) {
+        int yes = 1;
+        setsockopt(m_socket, IPPROTO_IP, IP_PKTINFO, &yes, sizeof(yes));
+    } else if (family == AF_INET6) {
+        int yes = 1;
+        setsockopt(m_socket, IPPROTO_IPV6, IPV6_RECVPKTINFO, &yes, sizeof(yes));
+    }
+
+    if (m_localAddr) {
+        socklen_t listen_length = 0;
+        if (listen_address->sa_family == AF_INET) listen_length = sizeof(struct sockaddr_in);
+        else if (listen_address->sa_family == AF_INET6) listen_length = sizeof(struct sockaddr_in6);
+        if (listen_length> 0) {
+            if (bind(m_socket, listen_address.get(), listen_length) == -1) {
+                throw std::generic_category().default_error_condition(errno);
+            }
+        }
+    }
+
+    if (m_remoteAddr) {
+        socklen_t remote_length = 0;
+        if (m_remoteAddr->sa_family == AF_INET) remote_length = sizeof(struct sockaddr_in);
+        else if (m_remoteAddr->sa_family == AF_INET6) remote_length = sizeof(struct sockaddr_in6);
+        if (remote_length > 0) {
+            if (connect(m_socket, m_remoteAddr.get(), remote_length) == -1) {
+                throw std::generic_category().default_error_condition(errno);
+            }
+            std::shared_ptr<struct sockaddr_storage> ss{new struct sockaddr_storage};
+            socklen_t ss_len = static_cast<socklen_t>(sizeof(*ss));
+            auto sa = std::reinterpret_pointer_cast<struct sockaddr>(ss);
+            if (!getsockname(m_socket, sa.get(), &ss_len)) {
+                m_localAddr = sa;
+            }
+        }
+    }
+    
+    {
+        static const char unknown[] = "Unknown";
+        char src_buf[INET6_ADDRSTRLEN + 6];
+        auto src_str = inet_sockaddr_to_str(m_remoteAddr.get(), src_buf, sizeof(src_buf));
+        if (!src_str) src_str = unknown;
+        char dest_buf[INET6_ADDRSTRLEN + 6];
+        auto dest_str = inet_sockaddr_to_str(m_localAddr.get(), dest_buf, sizeof(dest_buf));
+        if (!dest_str) dest_str = unknown;
+        ogs_debug("Opened unicast packet socket %s => %s", src_str, dest_str);
+    }
+
+    startWorker();
+}
+
+PacketIngester::PacketIngester(const SsmPort &multicast_source) // Multicast ingester
+    :PacketSource()
+    ,m_ssm(multicast_source)
+    ,m_socket(-1)
+    ,m_encapsulatedPackets(false)
+    ,m_localAddr()
+    ,m_remoteAddr()
+    ,m_worker()
+{
+    //ogs_debug("Construct multicast ingester");
+    m_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (m_socket < 0) throw std::generic_category().default_error_condition(errno);
+
+    if (multicast_source.hasSourceAddress()) {
+        struct group_source_req mreq = {};
+        fill_sockaddr_by_hostname(&mreq.gsr_group, multicast_source.destinationAddress(), AF_UNSPEC);
+        fill_sockaddr_by_hostname(&mreq.gsr_source, multicast_source.sourceAddress().value(), mreq.gsr_group.ss_family);
+        setsockopt(m_socket, mreq.gsr_group.ss_family, MCAST_JOIN_SOURCE_GROUP, &mreq, sizeof(mreq));
+        if (mreq.gsr_source.ss_family == AF_INET) {
+            m_remoteAddr = std::reinterpret_pointer_cast<struct sockaddr>(std::make_shared<struct sockaddr_in>(*reinterpret_cast<struct sockaddr_in*>(&mreq.gsr_source)));
+        } else if (mreq.gsr_source.ss_family == AF_INET6) {
+            m_remoteAddr = std::reinterpret_pointer_cast<struct sockaddr>(std::make_shared<struct sockaddr_in6>(*reinterpret_cast<struct sockaddr_in6*>(&mreq.gsr_source)));
+        }
+    } else {
+        struct group_req mreq = {};
+        fill_sockaddr_by_hostname(&mreq.gr_group, multicast_source.destinationAddress(), AF_UNSPEC);
+        setsockopt(m_socket, mreq.gr_group.ss_family, MCAST_JOIN_GROUP, &mreq, sizeof(mreq));
+    }
+
+    {
+        char src_buf[INET6_ADDRSTRLEN + 6];
+        inet_sockaddr_to_str(m_remoteAddr.get(), src_buf, sizeof(src_buf));
+        ogs_debug("Opened multicast packet socket from %s for group %s:%i", src_buf, multicast_source.destinationAddress().c_str(), multicast_source.port());
+    }
+
+    startWorker();
+}
+
+PacketIngester::PacketIngester(PacketIngester &&other)
+    :PacketSource(std::move(other))
+    ,m_ssm(std::move(other.m_ssm))
+    ,m_socket(other.m_socket)
+    ,m_encapsulatedPackets(other.m_encapsulatedPackets)
+    ,m_localAddr(std::move(other.m_localAddr))
+    ,m_remoteAddr(std::move(other.m_remoteAddr))
+    ,m_worker()
+{
+    //ogs_debug("Move constructor");
+    other.stopWorker();
+    other.m_socket = -1;
+}
+
+PacketIngester::~PacketIngester()
+{
+    //ogs_debug("Destroy ingester");
+    closeSocket();
+    stopWorker();
+}
+
+PacketIngester &PacketIngester::operator=(PacketIngester &&other)
+{
+    //ogs_debug("Move operator");
+    stopWorker();
+    bool worker_cancel = other.m_worker.isCancelled();
+    other.stopWorker();
+    PacketSource::operator=(std::move(other));
+    m_ssm = std::move(other.m_ssm);
+    closeSocket();
+    m_socket = other.m_socket;
+    other.m_socket = -1;
+    m_encapsulatedPackets = other.m_encapsulatedPackets;
+    m_localAddr = std::move(other.m_localAddr);
+    m_remoteAddr = std::move(other.m_remoteAddr);
+    if (!worker_cancel) startWorker();
+    return *this;
+}
+
+bool PacketIngester::processEvent(const std::shared_ptr<PacketEvent> &event)
+{
+    //ogs_debug("PacketIngester::processEvent: event type = %i", event->eventType());
+    if (event->eventType() == PacketEvent::PACKET_TOO_LARGE) {
+        auto too_large_event = std::dynamic_pointer_cast<PacketTooLargeEvent>(event);
+        if (!too_large_event) return false;
+
+        auto packet = too_large_event->packet();
+        sendICMPNeedSmallerMTU(too_large_event->expectedMTU(), packet);
+    }
+    return false;
+}
+
+bool PacketIngester::start()
+{
+    //ogs_debug("Start ingester");
+    startWorker();
+    return true;
+}
+
+bool PacketIngester::isStarted() const
+{
+    return m_worker.isRunning();
+}
+
+bool PacketIngester::stop()
+{
+    //ogs_debug("Stop ingester");
+    stopWorker();
+    return true;
+}
+
+bool PacketIngester::flush()
+{
+    return true;
+}
+
+bool PacketIngester::reconfigure()
+{
+    return true;
+}
+
+const struct sockaddr &PacketIngester::localSockAddr() const
+{
+    return *m_localAddr;
+}
+
+// private:
+
+bool PacketIngester::startWorker()
+{
+    //ogs_debug("Start worker");
+    m_worker.startWorker("PacketIngester receiver", [this](std::function<void()> check_cancelled) {
+        // Wait for socket to open
+        //ogs_debug("Ingester: wait for socket");
+        while (m_socket < 0) {
+            std::this_thread::sleep_for(10ms);
+            check_cancelled();
+        }
+        //ogs_debug("Ingester: got socket");
+
+        // Receive packets and push them
+        while (m_socket >= 0) {
+            //ogs_debug("Ingester: wait for data");
+            struct pollfd read_poll = {
+                .fd = m_socket,
+                .events = POLLIN,
+                .revents = 0
+            };
+            auto presult = poll(&read_poll, 1, 10);
+            if (presult > 0) {
+                //ogs_debug("Ingester: data pending");
+                check_cancelled();
+                struct sockaddr_storage from_addr;
+                auto *from_sa = reinterpret_cast<struct sockaddr*>(&from_addr);
+                std::array<uint8_t, 65536> buffer;
+                struct iovec iov = {
+                    .iov_base = buffer.data(),
+                    .iov_len = buffer.size()
+                };
+                std::array<uint8_t, 65536> control_buffer;
+                struct msghdr msg = {
+                    .msg_name = from_sa,
+                    .msg_namelen = sizeof(from_addr),
+                    .msg_iov = &iov,
+                    .msg_iovlen = 1,
+                    .msg_control = control_buffer.data(),
+                    .msg_controllen = control_buffer.size(),
+                    .msg_flags = 0
+                };
+                auto bytes = recvmsg(m_socket, &msg, 0);
+                check_cancelled();
+                if (bytes>0) {
+                    //ogs_debug("Received %zu bytes", bytes);
+                    if (match_sockaddrs(from_sa, m_remoteAddr.get())) {
+                        //ogs_debug("Packet matches expected source, sending onward");
+                        msg.msg_iov->iov_len = bytes;
+                        Packet pkt{&msg, m_localAddr, m_encapsulatedPackets};
+                        sendPacket(pkt);
+                    } else {
+                        char buf[INET6_ADDRSTRLEN + 6];
+                        if (inet_sockaddr_to_str(from_sa, buf, sizeof(buf))) {
+                            ogs_warn("Packet from unexpected source dropped: %s", buf);
+                        } else {
+                            ogs_warn("Packet from unexpected source dropped: Unknown address");
+                        }
+                    }
+                } else { // Error or EOF
+                    ogs_error("Error in stream, closing receiving socket: %s", strerror(errno));
+                    closeSocket();
+                }
+            } else if (presult < 0) {
+                // error on poll
+                closeSocket();
+            }
+            check_cancelled();
+        }
+    });
+    return true;
+};
+
+bool PacketIngester::stopWorker()
+{
+    //ogs_debug("Stop worker");
+    if (!m_worker.isRunning()) return true;
+    m_worker.cancel();
+    return m_worker.join();
+}
+
+void PacketIngester::closeSocket()
+{
+    if (m_socket >= 0) {
+        if (m_ssm) {
+            if (m_ssm.hasSourceAddress()) {
+                struct group_source_req mreq = {};
+                fill_sockaddr_by_hostname(&mreq.gsr_group, m_ssm.destinationAddress(), AF_UNSPEC);
+                fill_sockaddr_by_hostname(&mreq.gsr_source, m_ssm.sourceAddress().value(), mreq.gsr_group.ss_family);
+                setsockopt(m_socket, mreq.gsr_group.ss_family, MCAST_LEAVE_SOURCE_GROUP, &mreq, sizeof(mreq));
+            } else {
+                struct group_req mreq = {};
+                fill_sockaddr_by_hostname(&mreq.gr_group, m_ssm.destinationAddress(), AF_UNSPEC);
+                setsockopt(m_socket, mreq.gr_group.ss_family, MCAST_JOIN_GROUP, &mreq, sizeof(mreq));
+            }
+        }
+        close(m_socket);
+        m_socket = -1;
+    }
+}
+
+void PacketIngester::sendICMPNeedSmallerMTU(uint16_t mtu, const Packet &pkt)
+{
+    if (pkt.sendICMPNeedSmallerMTU(mtu) < 0) {
+        ogs_warn("Sending ICMP failed: %s", strerror(errno));
+    }
+} 
+
+/**** Local functions ****/
+
+static bool fill_sockaddr_by_hostname(void /*struct sockaddr*/ *addr, const std::string &hostname, int af_family)
+{
+    struct addrinfo *ai = nullptr;
+    getaddrinfo(hostname.c_str(), nullptr, nullptr, &ai);
+    if (ai) {
+        for (const auto *it = ai; it; it = it->ai_next) {
+            if ((af_family == AF_UNSPEC && (it->ai_family == AF_INET || it->ai_family == AF_INET6)) ||
+                (af_family == it->ai_family)) {
+                memcpy(addr, it->ai_addr, it->ai_addrlen);
+                freeaddrinfo(ai);
+                return true;
+            }
+        }
+        freeaddrinfo(ai);
+    }
+    return false;
+}
+
+static bool match_sockaddrs(const struct sockaddr *a, const struct sockaddr *b)
+{
+    if (!a || !b) return true; // match if either is NULL
+    if (a->sa_family == AF_UNSPEC || b->sa_family == AF_UNSPEC) return true; // match if either is AF_UNSPEC
+    if (a->sa_family != b->sa_family) return false; // Address families don't match
+    if (a->sa_family == AF_INET) {
+        const auto *a_sin = reinterpret_cast<const struct sockaddr_in*>(a);
+        const auto *b_sin = reinterpret_cast<const struct sockaddr_in*>(b);
+        if (a_sin->sin_addr.s_addr == INADDR_ANY || b_sin->sin_addr.s_addr == INADDR_ANY ||
+            a_sin->sin_addr.s_addr == b_sin->sin_addr.s_addr) {
+
+            return (a_sin->sin_port == 0 || b_sin->sin_port == 0 || a_sin->sin_port == b_sin->sin_port);
+        }
+    } else if (a->sa_family == AF_INET6) {
+        const auto *a_sin6 = reinterpret_cast<const struct sockaddr_in6*>(a);
+        const auto *b_sin6 = reinterpret_cast<const struct sockaddr_in6*>(b);
+        if (IN6_IS_ADDR_UNSPECIFIED(&a_sin6->sin6_addr.s6_addr) || IN6_IS_ADDR_UNSPECIFIED(&b_sin6->sin6_addr.s6_addr) ||
+            IN6_ARE_ADDR_EQUAL(&a_sin6->sin6_addr.s6_addr32, &b_sin6->sin6_addr.s6_addr32)) {
+
+            return (a_sin6->sin6_port == 0 || b_sin6->sin6_port == 0 || a_sin6->sin6_port == b_sin6->sin6_port);
+        }
+    }
+
+    return false;
+}
+
+static const char *inet_sockaddr_to_str(const struct sockaddr *sa, char *buf, socklen_t buf_len)
+{
+    if (!sa) return nullptr;
+
+    const void *sa_addr = nullptr;
+    const in_port_t *sa_port = nullptr;
+
+    if (sa->sa_family == AF_INET) {
+        const auto *sin = reinterpret_cast<const struct sockaddr_in*>(sa);
+        sa_addr = &sin->sin_addr;
+        sa_port = &sin->sin_port;
+    } else if (sa->sa_family == AF_INET6) {
+        const auto *sin6 = reinterpret_cast<const struct sockaddr_in6*>(sa);
+        sa_addr = &sin6->sin6_addr;
+        sa_port = &sin6->sin6_port;
+    }
+
+    if (sa_addr) {
+        const char *ret = inet_ntop(sa->sa_family, sa_addr, buf, buf_len);
+        if (ret && *sa_port) {
+            strcat(buf, std::format(":{}", ntohs(*sa_port)).c_str());
+        }
+        return ret;
+    }
+
+    return nullptr;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketIngester.cc
+++ b/src/mbstf/PacketIngester.cc
@@ -15,10 +15,13 @@
 #include <netinet/in.h>
 #include <netinet/ip_icmp.h>
 #include <net/ethernet.h>
+#include <net/if.h>
 #include <poll.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
+#include <ifaddrs.h>
 
 #include <chrono>
 #include <cstring>
@@ -42,6 +45,7 @@ MBSTF_NAMESPACE_START
 static bool fill_sockaddr_by_hostname(void /*struct sockaddr*/ *addr, const std::string &hostname, int family);
 static bool match_sockaddrs(const struct sockaddr *a, const struct sockaddr *b);
 static const char *inet_sockaddr_to_str(const struct sockaddr *sa, char *buf, socklen_t buf_len);
+static int get_interface_for_sockaddr(const struct sockaddr *sa);
 
 // public:
 
@@ -140,28 +144,49 @@ PacketIngester::PacketIngester(const SsmPort &multicast_source) // Multicast ing
     ,m_worker()
 {
     //ogs_debug("Construct multicast ingester");
-    m_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (m_socket < 0) throw std::generic_category().default_error_condition(errno);
-
     if (multicast_source.hasSourceAddress()) {
         struct group_source_req mreq = {};
         fill_sockaddr_by_hostname(&mreq.gsr_group, multicast_source.destinationAddress(), AF_UNSPEC);
         fill_sockaddr_by_hostname(&mreq.gsr_source, multicast_source.sourceAddress().value(), mreq.gsr_group.ss_family);
-        setsockopt(m_socket, mreq.gsr_group.ss_family, MCAST_JOIN_SOURCE_GROUP, &mreq, sizeof(mreq));
+        mreq.gsr_interface = get_interface_for_sockaddr(reinterpret_cast<struct sockaddr*>(&mreq.gsr_source));
+        int yes = 1;
+        m_socket = socket(mreq.gsr_source.ss_family, SOCK_DGRAM, IPPROTO_UDP);
+        if (m_socket < 0) throw std::generic_category().default_error_condition(errno);
         if (mreq.gsr_source.ss_family == AF_INET) {
+            struct sockaddr_in any = {.sin_family = AF_INET, .sin_port = htons(multicast_source.port())};
+            bind(m_socket, reinterpret_cast<struct sockaddr*>(&any), sizeof(any));
+            setsockopt(m_socket, SOL_IP, IP_PKTINFO, &yes, sizeof(yes));
+            setsockopt(m_socket, SOL_IP, MCAST_JOIN_SOURCE_GROUP, &mreq, sizeof(mreq));
             m_remoteAddr = std::reinterpret_pointer_cast<struct sockaddr>(std::make_shared<struct sockaddr_in>(*reinterpret_cast<struct sockaddr_in*>(&mreq.gsr_source)));
         } else if (mreq.gsr_source.ss_family == AF_INET6) {
+            struct sockaddr_in6 any = {.sin6_family = AF_INET6, .sin6_port = htons(multicast_source.port())};
+            bind(m_socket, reinterpret_cast<struct sockaddr*>(&any), sizeof(any));
+            setsockopt(m_socket, SOL_IPV6, IPV6_RECVPKTINFO, &yes, sizeof(yes));
+            setsockopt(m_socket, SOL_IPV6, MCAST_JOIN_SOURCE_GROUP, &mreq, sizeof(mreq));
             m_remoteAddr = std::reinterpret_pointer_cast<struct sockaddr>(std::make_shared<struct sockaddr_in6>(*reinterpret_cast<struct sockaddr_in6*>(&mreq.gsr_source)));
         }
     } else {
         struct group_req mreq = {};
         fill_sockaddr_by_hostname(&mreq.gr_group, multicast_source.destinationAddress(), AF_UNSPEC);
-        setsockopt(m_socket, mreq.gr_group.ss_family, MCAST_JOIN_GROUP, &mreq, sizeof(mreq));
+        int yes = 1;
+        m_socket = socket(mreq.gr_group.ss_family, SOCK_DGRAM, IPPROTO_UDP);
+        if (m_socket < 0) throw std::generic_category().default_error_condition(errno);
+        if (mreq.gr_group.ss_family == AF_INET) {
+            struct sockaddr_in any = {.sin_family = AF_INET, .sin_port = htons(multicast_source.port())};
+            bind(m_socket, reinterpret_cast<struct sockaddr*>(&any), sizeof(any));
+            setsockopt(m_socket, SOL_IP, IP_PKTINFO, &yes, sizeof(yes));
+            setsockopt(m_socket, SOL_IP, MCAST_JOIN_GROUP, &mreq, sizeof(mreq));
+        } else if (mreq.gr_group.ss_family == AF_INET6) {
+            struct sockaddr_in6 any = {.sin6_family = AF_INET6, .sin6_port = htons(multicast_source.port())};
+            bind(m_socket, reinterpret_cast<struct sockaddr*>(&any), sizeof(any));
+            setsockopt(m_socket, SOL_IPV6, IPV6_RECVPKTINFO, &yes, sizeof(yes));
+            setsockopt(m_socket, SOL_IPV6, MCAST_JOIN_GROUP, &mreq, sizeof(mreq));
+        }
     }
 
     {
-        char src_buf[INET6_ADDRSTRLEN + 6];
-        inet_sockaddr_to_str(m_remoteAddr.get(), src_buf, sizeof(src_buf));
+        char src_buf[INET6_ADDRSTRLEN + 8] = "Unspecified";
+        if (m_remoteAddr) inet_sockaddr_to_str(m_remoteAddr.get(), src_buf, sizeof(src_buf));
         ogs_debug("Opened multicast packet socket from %s for group %s:%i", src_buf, multicast_source.destinationAddress().c_str(), multicast_source.port());
     }
 
@@ -344,11 +369,12 @@ void PacketIngester::closeSocket()
                 struct group_source_req mreq = {};
                 fill_sockaddr_by_hostname(&mreq.gsr_group, m_ssm.destinationAddress(), AF_UNSPEC);
                 fill_sockaddr_by_hostname(&mreq.gsr_source, m_ssm.sourceAddress().value(), mreq.gsr_group.ss_family);
+                mreq.gsr_interface = get_interface_for_sockaddr(reinterpret_cast<struct sockaddr*>(&mreq.gsr_source));
                 setsockopt(m_socket, mreq.gsr_group.ss_family, MCAST_LEAVE_SOURCE_GROUP, &mreq, sizeof(mreq));
             } else {
                 struct group_req mreq = {};
                 fill_sockaddr_by_hostname(&mreq.gr_group, m_ssm.destinationAddress(), AF_UNSPEC);
-                setsockopt(m_socket, mreq.gr_group.ss_family, MCAST_JOIN_GROUP, &mreq, sizeof(mreq));
+                setsockopt(m_socket, mreq.gr_group.ss_family, MCAST_LEAVE_GROUP, &mreq, sizeof(mreq));
             }
         }
         close(m_socket);
@@ -368,19 +394,20 @@ void PacketIngester::sendICMPNeedSmallerMTU(uint16_t mtu, const Packet &pkt)
 static bool fill_sockaddr_by_hostname(void /*struct sockaddr*/ *addr, const std::string &hostname, int af_family)
 {
     struct addrinfo *ai = nullptr;
+    bool result = false;
     getaddrinfo(hostname.c_str(), nullptr, nullptr, &ai);
     if (ai) {
         for (const auto *it = ai; it; it = it->ai_next) {
             if ((af_family == AF_UNSPEC && (it->ai_family == AF_INET || it->ai_family == AF_INET6)) ||
-                (af_family == it->ai_family)) {
+                (af_family != AF_UNSPEC && af_family == it->ai_family)) {
                 memcpy(addr, it->ai_addr, it->ai_addrlen);
-                freeaddrinfo(ai);
-                return true;
+                result = true;
+                break;
             }
         }
         freeaddrinfo(ai);
     }
-    return false;
+    return result;
 }
 
 static bool match_sockaddrs(const struct sockaddr *a, const struct sockaddr *b)
@@ -435,6 +462,54 @@ static const char *inet_sockaddr_to_str(const struct sockaddr *sa, char *buf, so
     }
 
     return nullptr;
+}
+
+static int get_interface_for_sockaddr(const struct sockaddr *sa)
+{
+    int s = socket(sa->sa_family, SOCK_DGRAM, 0);
+    if (s < 0) return 0;
+
+    // connect the socket to get the kernel to find the best interface
+    if (sa->sa_family==AF_INET) {
+        connect(s, sa, sizeof(struct sockaddr_in));
+    } else if (sa->sa_family==AF_INET6) {
+        connect(s, sa, sizeof(struct sockaddr_in6));
+    }
+
+    // ask socket for the local address for the interface
+    struct sockaddr_storage local_addr;
+    socklen_t local_len = sizeof(local_addr);
+    getsockname(s, reinterpret_cast<struct sockaddr*>(&local_addr), &local_len);
+
+    // Now search network interfaces for an interface matching the local address
+    struct ifaddrs *ifa = nullptr;
+    struct ifreq ifr = {};
+    if (!getifaddrs(&ifa)) {
+        for (auto *it = ifa; it; it = it->ifa_next) {
+            if (!it->ifa_addr) continue;
+            if (it->ifa_addr->sa_family == local_addr.ss_family) {
+                if (local_addr.ss_family == AF_INET) {
+                    struct sockaddr_in *a = reinterpret_cast<struct sockaddr_in*>(it->ifa_addr);
+                    struct sockaddr_in *b = reinterpret_cast<struct sockaddr_in*>(&local_addr);
+                    if (a->sin_addr.s_addr == b->sin_addr.s_addr) {
+                        strcpy(ifr.ifr_name, it->ifa_name);
+                        break;
+                    }
+                } else if (local_addr.ss_family == AF_INET6) {
+                    struct sockaddr_in6 *a = reinterpret_cast<struct sockaddr_in6*>(it->ifa_addr);
+                    struct sockaddr_in6 *b = reinterpret_cast<struct sockaddr_in6*>(&local_addr);
+                    if (IN6_ARE_ADDR_EQUAL(&a->sin6_addr, &b->sin6_addr)) {
+                        strcpy(ifr.ifr_name, it->ifa_name);
+                        break;
+                    }
+                }
+            }
+        }
+        freeifaddrs(ifa);
+    }
+    ioctl(s, SIOCGIFINDEX, &ifr);
+    close(s);
+    return ifr.ifr_ifindex;
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/PacketIngester.hh
+++ b/src/mbstf/PacketIngester.hh
@@ -1,0 +1,68 @@
+#ifndef _MBS_TF_PACKET_INGESTER_HH_
+#define _MBS_TF_PACKET_INGESTER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Ingest base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <memory>
+
+#include "common.hh"
+#include "PacketProcessing.hh"
+#include "ThreadedWorker.hh"
+#include "SsmPort.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketIngester : public PacketSource {
+public:
+    PacketIngester();
+    PacketIngester(const std::shared_ptr<struct sockaddr> &listen_address, const std::shared_ptr<struct sockaddr> &remote_endpoint,
+                   bool encapsulated_packets = false); // Unicast ingester
+    PacketIngester(const SsmPort &multicast_source);   // Multicast ingester (not used with encapsulation)
+    PacketIngester(const PacketIngester &other) = delete;
+    PacketIngester(PacketIngester &&other);
+
+    virtual ~PacketIngester();
+
+    PacketIngester &operator=(const PacketIngester &) = delete;
+    PacketIngester &operator=(PacketIngester &&);
+
+    virtual bool processEvent(const std::shared_ptr<PacketEvent> &event);
+
+    const struct sockaddr &localSockAddr() const;
+    
+    bool start();
+    bool isStarted() const;
+    bool stop();
+    bool flush();
+    bool reconfigure();
+
+    operator bool() const { return m_socket >= 0; };
+
+private:
+    bool startWorker();
+    bool stopWorker();
+    void closeSocket();
+    void sendICMPNeedSmallerMTU(uint16_t mtu, const Packet &pkt);
+
+    SsmPort m_ssm;
+    int m_socket;
+    bool m_encapsulatedPackets;
+    std::shared_ptr<struct sockaddr> m_localAddr;
+    std::shared_ptr<struct sockaddr> m_remoteAddr;
+    ThreadedWorker m_worker;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_INGESTER_HH_ */

--- a/src/mbstf/PacketPacketisation.cc
+++ b/src/mbstf/PacketPacketisation.cc
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packetisation base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+
+#include "PacketPacketisation.hh"
+
+MBSTF_NAMESPACE_START
+
+PacketPacketisation::PacketPacketisation(uint16_t mtu)
+    :m_mtu(mtu)
+{
+    ogs_debug("Created packetisation with mtu = %u", m_mtu);
+}
+
+bool PacketPacketisation::processPacket(Packet &buffer)
+{
+    //ogs_debug("Packetising %zu bytes", buffer.size());
+    if (modifyPacket(buffer)) {
+        if (buffer.size() > m_mtu) {
+            ogs_debug("Packetising: Packet too big (%zu > %u) trying fragmentation", buffer.size(), m_mtu);
+            if (buffer.doNotFragment()) {
+                ogs_debug("Packetising: Do not fragment set, try to send ICMP response");
+                sendEvent(PacketEvent::packetTooLargeEvent(m_mtu, buffer));
+                return false;
+            }
+
+            while (buffer.size() > 0) {
+                auto fragment = buffer.fragmentData(mtu());
+                ogs_debug("Packetising: Sending fragment of %zu bytes", fragment.size());
+                sendPacket(fragment);
+            }
+        } else {
+            sendPacket(buffer);
+        }
+    } else {
+        ogs_warn("Packetising: Packet modification failed, dropping packet");
+    }
+    return true;
+}
+
+PacketPacketisation &PacketPacketisation::mtu(uint16_t mtu)
+{
+    m_mtu = mtu;
+
+    ogs_debug("Packetisation MTU changed to %u", m_mtu);
+
+    return *this;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketPacketisation.hh
+++ b/src/mbstf/PacketPacketisation.hh
@@ -1,0 +1,56 @@
+#ifndef _MBS_TF_PACKET_PACKETISATION_HH_
+#define _MBS_TF_PACKET_PACKETISATION_HH_
+/*********************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Packetisation base class
+ *********************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "common.hh"
+#include "PacketProcessing.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketPacketisation : public PacketProcessing {
+public:
+    PacketPacketisation(uint16_t mtu = 1500);
+    PacketPacketisation(const PacketPacketisation &other) :m_mtu(other.m_mtu) {};
+    PacketPacketisation(PacketPacketisation &&other) :m_mtu(other.m_mtu) {};
+
+    virtual ~PacketPacketisation() {};
+
+    PacketPacketisation &operator=(const PacketPacketisation &other) { m_mtu = other.m_mtu; return *this; };
+    PacketPacketisation &operator=(PacketPacketisation &&other) { m_mtu = other.m_mtu; return *this; };
+
+    virtual bool processPacket(Packet &buffer);
+
+    virtual bool start() = 0;
+    virtual bool isStarted() = 0;
+    virtual bool stop() = 0;
+    virtual bool flush() = 0;
+    virtual bool reconfigure() = 0;
+    virtual bool modifyPacket(Packet &buffer) { return true; };
+
+    uint16_t mtu() const { return m_mtu; };
+    PacketPacketisation &mtu(uint16_t mtu);
+
+private:
+    uint16_t m_mtu;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_PACKETISATION_HH_ */

--- a/src/mbstf/PacketProcessing.cc
+++ b/src/mbstf/PacketProcessing.cc
@@ -1,0 +1,209 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Processing base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+#include "Packet.hh"
+
+#include "PacketProcessing.hh"
+
+MBSTF_NAMESPACE_START
+
+/*** class PacketSource ***/
+
+PacketSource::PacketSource(PacketSink *sink)
+    :m_sink(sink)
+{
+    if (m_sink) m_sink->attachSource(this);
+}
+
+PacketSource::PacketSource(PacketSource &&other)
+    :m_sink(other.m_sink)
+{
+    other.m_sink = nullptr;
+    if (m_sink) m_sink->attachSource(this);
+}
+
+PacketSource::~PacketSource()
+{
+    attachSink(nullptr);
+}
+
+PacketSource &PacketSource::operator=(PacketSource &&other)
+{
+    attachSink(other.m_sink);
+    other.m_sink = nullptr;
+    return *this;
+}
+
+bool PacketSource::attachSink(PacketSink *sink)
+{
+    if (m_sink == sink) return true;
+    if (m_sink) {
+        auto tmp_sink = m_sink;
+        m_sink = nullptr;
+        tmp_sink->attachSource(nullptr);
+        processEvent(PacketEvent::sinkDetachedEvent());
+    }
+    m_sink = sink;
+    if (m_sink) {
+        m_sink->attachSource(this);
+        processEvent(PacketEvent::sinkAttachedEvent());
+    }
+    return true;
+}
+
+// class PacketSource protected
+
+bool PacketSource::sendPacket(Packet &buffer)
+{
+    if (m_sink) {
+        return m_sink->processPacket(buffer);
+    } else {
+        ogs_error("Attempt to send packet down the chain when not attached to a sink");
+    }
+    return false;
+}
+
+bool PacketSource::detach()
+{
+    if (m_sink) {
+        m_sink->attachSource(nullptr);
+        processEvent(PacketEvent::sinkDetachedEvent());
+        m_sink = nullptr;
+        return true;
+    }
+    return false;
+}
+
+/*** class PacketSink ***/
+
+PacketSink::PacketSink(PacketSource *source)
+    :m_source(source)
+{
+    if (m_source) m_source->attachSink(this);
+}
+
+PacketSink::PacketSink(PacketSink &&other)
+    :m_source(other.m_source)
+{
+    other.m_source = nullptr;
+    if (m_source) m_source->attachSink(this);
+}
+
+PacketSink::~PacketSink()
+{
+    attachSource(nullptr);
+}
+
+PacketSink &PacketSink::operator=(PacketSink &&other)
+{
+    attachSource(other.m_source);
+    other.m_source = nullptr;
+    return *this;
+}
+
+bool PacketSink::attachSource(PacketSource *source)
+{
+    if (source == m_source) return true;
+    if (m_source) {
+        auto tmp_src = m_source;
+        m_source = nullptr;
+        tmp_src->attachSink(nullptr);
+    }
+    m_source = source;
+    if (m_source) {
+        m_source->attachSink(this);
+    }
+    return true;
+}
+
+// class PacketSink protected
+
+bool PacketSink::sendEvent(const std::shared_ptr<PacketEvent> &event)
+{
+    if (m_source) return m_source->processEvent(event);
+    return false;
+}
+
+bool PacketSink::detach()
+{
+    if (m_source) {
+        m_source->attachSink(nullptr);
+        m_source = nullptr;
+        return true;
+    }
+    return false;
+}
+
+/*** class PacketProcessing ***/
+
+bool PacketProcessing::insertAfter(PacketSource *source)
+{
+    if (!source) return false;
+    if (source == m_source) return true;
+
+    detach();
+
+    if (source->sink()) source->sink()->attachSource(this);
+    source->attachSink(this);
+
+    return true;    
+}
+
+bool PacketProcessing::insertBefore(PacketSink *sink)
+{
+    if (!sink) return false;
+    if (sink == m_sink) return true;
+
+    detach();
+
+    if (sink->source()) sink->source()->attachSink(this);
+    sink->attachSource(this);
+
+    return true;
+}
+
+bool PacketProcessing::processEvent(const std::shared_ptr<PacketEvent> &event)
+{
+    // send event upstream
+    return sendEvent(event);
+}
+
+// class PacketProcessing protected
+
+bool PacketProcessing::detach()
+{
+    bool retval = false;
+    if (m_source) {
+        m_source->attachSink(m_sink);
+        retval = true;
+    } else if (m_sink) {
+        m_sink->attachSource(nullptr);
+        retval = true;
+    }
+    m_source = nullptr;
+    m_sink = nullptr;
+    return retval;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketProcessing.hh
+++ b/src/mbstf/PacketProcessing.hh
@@ -1,0 +1,195 @@
+#ifndef _MBS_TF_PACKET_PROCESSING_HH_
+#define _MBS_TF_PACKET_PROCESSING_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Processing base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <netinet/in.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common.hh"
+#include "Packet.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketSink;
+
+class PacketCommsEvent;
+class PacketTooLargeEvent;
+
+class PacketEvent {
+public:
+    enum EventType {
+        PACKET_BUFFER_OVERFLOW,
+        PACKET_TOO_LARGE,
+        SINK_ATTACHED,
+        SINK_DETACHED
+    };
+
+    PacketEvent() = delete;
+    PacketEvent(EventType typ) :m_eventType(typ) {};
+    PacketEvent(const PacketEvent &other) :m_eventType(other.m_eventType) {};
+    PacketEvent(PacketEvent &&other) :m_eventType(other.m_eventType) {};
+
+    virtual ~PacketEvent() {};
+
+    PacketEvent &operator=(const PacketEvent &other) { m_eventType = other.m_eventType; return *this; };
+    PacketEvent &operator=(PacketEvent &&other) { m_eventType = other.m_eventType; return *this; };
+
+    bool operator==(const PacketEvent &other) const {
+        return m_eventType == other.m_eventType;
+    };
+
+    EventType eventType() const { return m_eventType; };
+
+    static std::shared_ptr<PacketEvent> bufferOverflowEvent(const Packet &packet) { return std::static_pointer_cast<PacketEvent>(std::make_shared<PacketCommsEvent>(PACKET_BUFFER_OVERFLOW, packet)); };
+    static std::shared_ptr<PacketEvent> packetTooLargeEvent(uint16_t expected_mtu, const Packet &packet) { return std::static_pointer_cast<PacketEvent>(std::make_shared<PacketTooLargeEvent>(expected_mtu, packet)); };
+    static std::shared_ptr<PacketEvent> sinkAttachedEvent() { return std::make_shared<PacketEvent>(SINK_ATTACHED); };
+    static std::shared_ptr<PacketEvent> sinkDetachedEvent() { return std::make_shared<PacketEvent>(SINK_DETACHED); };
+
+private:
+    EventType m_eventType;
+};
+
+class PacketCommsEvent : public PacketEvent {
+public:
+    PacketCommsEvent() = delete;
+    PacketCommsEvent(EventType typ, const Packet &packet) :PacketEvent(typ) ,m_packet(&packet) {};
+    PacketCommsEvent(const PacketCommsEvent &other) :PacketEvent(other), m_packet(other.m_packet) {};
+    PacketCommsEvent(PacketCommsEvent &&other) :PacketEvent(other), m_packet(other.m_packet) {};
+
+    virtual ~PacketCommsEvent() {};
+
+    PacketCommsEvent &operator=(const PacketCommsEvent &other) { PacketEvent::operator=(other); m_packet = other.m_packet; return *this; };
+    PacketCommsEvent &operator=(PacketCommsEvent &&other) { PacketEvent::operator=(std::move(other)); m_packet = other.m_packet; return *this; };
+
+    bool operator==(const PacketCommsEvent &other) const {
+        return PacketEvent::operator==(other) && (m_packet == other.m_packet || *m_packet == *other.m_packet);
+    };
+
+    const Packet &packet() const { return *m_packet; };
+
+private:
+    const Packet *m_packet;
+};
+
+class PacketTooLargeEvent : public PacketCommsEvent {
+public:
+    PacketTooLargeEvent() = delete;
+    PacketTooLargeEvent(uint16_t expected_mtu, const Packet &packet) :PacketCommsEvent(PacketEvent::PACKET_TOO_LARGE, packet), m_expectedMTU(expected_mtu) {};
+    PacketTooLargeEvent(const PacketTooLargeEvent &other) :PacketCommsEvent(other), m_expectedMTU(other.m_expectedMTU) {};
+    PacketTooLargeEvent(PacketTooLargeEvent &&other) :PacketCommsEvent(std::move(other)), m_expectedMTU(other.m_expectedMTU) {};
+
+    virtual ~PacketTooLargeEvent() {};
+
+    PacketTooLargeEvent &operator=(const PacketTooLargeEvent &other) {
+        PacketCommsEvent::operator=(other);
+        m_expectedMTU = other.m_expectedMTU;
+        return *this;
+    };
+    PacketTooLargeEvent &operator=(PacketTooLargeEvent &&other) {
+        PacketCommsEvent::operator=(std::move(other));
+        m_expectedMTU = other.m_expectedMTU;
+        return *this;
+    };
+
+    bool operator==(const PacketTooLargeEvent &other) const {
+        return m_expectedMTU == other.m_expectedMTU && PacketCommsEvent::operator==(other);
+    }
+
+    uint16_t expectedMTU() const { return m_expectedMTU; };
+
+private:
+    uint16_t m_expectedMTU;
+};
+
+class PacketSource {
+public:
+    PacketSource(PacketSink *sink = nullptr);
+    PacketSource(const PacketSource &other) = delete;
+    PacketSource(PacketSource &&other);
+
+    virtual ~PacketSource();
+
+    PacketSource &operator=(const PacketSource &other) = delete;
+    PacketSource &operator=(PacketSource &&other);
+
+    bool attachSink(PacketSink *sink);
+    virtual bool processEvent(const std::shared_ptr<PacketEvent> &event) = 0;
+
+    PacketSink *sink() { return m_sink; };
+    const PacketSink *sink() const { return m_sink; };
+
+protected:
+    bool sendPacket(Packet &buffer);
+    virtual bool detach();
+
+    PacketSink *m_sink;
+};
+
+class PacketSink {
+public:
+    PacketSink(PacketSource *source = nullptr);
+    PacketSink(const PacketSink &other) = delete;
+    PacketSink(PacketSink &&other);
+
+    virtual ~PacketSink();
+
+    PacketSink &operator=(const PacketSink &other) = delete;
+    PacketSink &operator=(PacketSink &&other);
+
+    bool attachSource(PacketSource *source);
+    virtual bool processPacket(Packet &buffer) = 0;
+
+    PacketSource *source() { return m_source; };
+    const PacketSource *source() const { return m_source; };
+
+protected:
+    virtual bool detach();
+    bool sendEvent(const std::shared_ptr<PacketEvent> &event);
+
+    PacketSource *m_source;
+};
+
+class PacketProcessing : public PacketSource, public PacketSink {
+public:
+    PacketProcessing(PacketSource *source = nullptr, PacketSink *sink = nullptr) :PacketSource(sink), PacketSink(source) {};
+    PacketProcessing(const PacketProcessing &other) = delete;
+    PacketProcessing(PacketProcessing &&other) :PacketSource(std::move(other)), PacketSink(std::move(other)) {};
+
+    virtual ~PacketProcessing() { detach(); };
+
+    PacketProcessing &operator=(const PacketProcessing &other) = delete;
+    PacketProcessing &operator=(PacketProcessing &&other) {
+        PacketSource::operator=(std::move(other));
+        PacketSink::operator=(std::move(other));
+        return *this;
+    };
+
+    bool insertAfter(PacketSource *source);
+    bool insertBefore(PacketSink *sink);
+
+    virtual bool processEvent(const std::shared_ptr<PacketEvent> &event);
+
+protected:
+    virtual bool detach();
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_PROCESSING_HH_ */

--- a/src/mbstf/PacketProxyController.cc
+++ b/src/mbstf/PacketProxyController.cc
@@ -1,0 +1,139 @@
+/**************************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Proxy Packet Controller class
+ **************************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <netinet/udp.h>
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+#include "ControllerFactory.hh"
+#include "DistributionSession.hh"
+#include "PacketController.hh"
+#include "PacketProxyPacketisation.hh"
+#include "PacketIngester.hh"
+#include "PacketScheduler.hh"
+#include "utilities.hh"
+#include "openapi/model/CreateReqData.h"
+#include "openapi/model/PktDistributionOperatingMode.h"
+
+#include "PacketProxyController.hh"
+
+using fiveg_mag_reftools::ModelException;
+using fiveg_mag_reftools::ProblemCause;
+using reftools::mbstf::PktDistributionOperatingMode;
+
+MBSTF_NAMESPACE_START
+
+// public:
+
+PacketProxyController::PacketProxyController(DistributionSession &distributionSession)
+    :PacketController(distributionSession)
+{
+    validateProxyDistributionSession(distributionSession);
+}
+
+PacketProxyController::~PacketProxyController()
+{
+}
+
+// protected:
+void PacketProxyController::setPacketFEC()
+{
+    // no FEC implemented yet
+}
+
+void PacketProxyController::unsetPacketFEC()
+{
+    // no FEC implemented yet
+}
+
+void PacketProxyController::reconfigurePacketFEC()
+{
+    // no FEC implemented yet
+}
+
+// GTP + UDP header overhead
+#define OVERHEAD (2 + sizeof(udphdr))
+
+void PacketProxyController::setPacketPacketisation()
+{
+    const auto &dist_session = distributionSession();
+    SsmPort ssm = dist_session.getSsmPort();
+    const auto &tun_endpoint = dist_session.getTunnelAddr();
+    in_port_t tun_port = dist_session.getTunnelPortNumber();
+    uint16_t mtu = static_cast<uint16_t>(get_tunnelled_path_mtu(ssm, tun_endpoint, tun_port, GET_MTU_IP_PAYLOAD)) - OVERHEAD;
+    packetPacketiser(new PacketProxyPacketisation(mtu, ssm));
+}
+
+void PacketProxyController::unsetPacketPacketisation()
+{
+    packetPacketiser(nullptr);
+}
+
+void PacketProxyController::reconfigurePacketPacketisation()
+{
+    auto packetiser = std::dynamic_pointer_cast<PacketProxyPacketisation>(packetPacketiser());
+    if (packetiser) {
+        SsmPort ssm;
+        const auto &dist_session = distributionSession();
+        const auto &tun_endpoint = dist_session.getTunnelAddr();
+        in_port_t tun_port = dist_session.getTunnelPortNumber();
+        uint16_t mtu = static_cast<uint16_t>(get_tunnelled_path_mtu(ssm, tun_endpoint, tun_port, GET_MTU_IP_PAYLOAD)) - OVERHEAD;
+        packetiser->mtu(mtu);
+        packetiser->reconfigure();
+    }
+}
+
+// private:
+
+void PacketProxyController::validateProxyDistributionSession(const DistributionSession &dist_session)
+{
+    const auto &create_req_data = dist_session.distributionSessionReqData();
+    const auto &dist_sess = create_req_data->getDistSession();
+    const auto &pkt_distr_data = dist_sess->getPktDistributionData();
+
+    const auto &pkt_dist_oper_mode = pkt_distr_data.value()->getPktDistributionOperatingMode();
+    if (pkt_dist_oper_mode->getValue() != PktDistributionOperatingMode::VAL_PACKET_PROXY) {
+        throw std::logic_error("Expected pktDistributionOperatingMode to be PACKET_PROXY");
+    }
+
+    // Controller match found, now check the DistSession for Proxy mode irregularities
+
+    const auto &up_traf_flow_info = dist_sess->getUpTrafficFlowInfo();
+    if (!up_traf_flow_info) {
+        throw ModelException("upTrafficFlowInfo missing in Packet Proxy mode", "PacketProxyController", "distSession.upTrafficFlowInfo", ProblemCause::MANDATORY_IE_MISSING);
+    }
+    const auto &utfi_src_addr = up_traf_flow_info.value()->getSrcIpAddr();
+    if (!utfi_src_addr) {
+        throw ModelException("upTrafficFlowInfo.srcIpAddr missing in Packet Proxy mode", "PacketProxyController", "distSession.upTrafficFlowInfo.srcIpAddr", ProblemCause::MANDATORY_IE_MISSING);
+    }
+    if (up_traf_flow_info.value()->getTransportSessionId()) {
+        ogs_warn("upTrafficFlowInfo.transportSessionId ignored in Packet Proxy mode");
+    }
+}
+
+namespace {
+static const struct init {
+    init() {
+        ControllerFactory::registerController(new ControllerConstructor<PacketProxyController>);
+    };
+} g_init;
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketProxyController.hh
+++ b/src/mbstf/PacketProxyController.hh
@@ -1,0 +1,69 @@
+#ifndef _MBS_TF_PACKET_PROXY_CONTROLLER_HH_
+#define _MBS_TF_PACKET_PROXY_CONTROLLER_HH_
+/**************************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Proxy Packet Controller class
+ **************************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <memory>
+#include <mutex>
+#include <list>
+
+#include "common.hh"
+#include "PacketController.hh"
+#include "PacketIngester.hh"
+#include "PacketScheduler.hh"
+
+MBSTF_NAMESPACE_START
+
+class DistributionSession;
+
+class PacketProxyController : public PacketController {
+public:
+    PacketProxyController() = delete;
+    PacketProxyController(DistributionSession &distributionSession);
+    PacketProxyController(const PacketProxyController &) = delete;
+    PacketProxyController(PacketProxyController &&) = delete;
+
+    virtual ~PacketProxyController();
+
+    PacketProxyController &operator=(const PacketProxyController &) = delete;
+    PacketProxyController &operator=(PacketProxyController &&) = delete;
+
+    // Controller virtual functions
+    //virtual void reconfigure() //implemented in PacketController
+    //virtual void establishInactiveInputs(); //implemented in PacketController
+    //virtual void establishActiveInputs(); //implemented in PacketController
+    //virtual void activateOutput(); //implemented in PacketController
+    //virtual void deactivateOutput(); //implemented in PacketController
+    //virtual void flushPacketisationQueue(); //implemented in PacketController
+
+    static unsigned int factoryPriority() { return 100; };
+
+protected:
+    virtual void setPacketFEC();
+    virtual void unsetPacketFEC();
+    virtual void reconfigurePacketFEC();
+
+    virtual void setPacketPacketisation();
+    virtual void unsetPacketPacketisation();
+    virtual void reconfigurePacketPacketisation();
+
+    virtual bool expectEncapsulatedPackets() const { return false; };
+
+private:
+    static void validateProxyDistributionSession(const DistributionSession &dist_session);
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_PROXY_CONTROLLER_HH_ */

--- a/src/mbstf/PacketProxyPacketisation.cc
+++ b/src/mbstf/PacketProxyPacketisation.cc
@@ -1,0 +1,143 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet ProxyPacketisation base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+#include <netinet/udp.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+#include "PacketPacketisation.hh"
+#include "utilities.hh"
+
+#include "PacketProxyPacketisation.hh"
+
+MBSTF_NAMESPACE_START
+
+// public:
+
+bool PacketProxyPacketisation::modifyPacket(Packet &buffer)
+{
+    auto opt_src_str = m_ssm.sourceAddress();
+    if (!opt_src_str) return false; // Need a source address
+
+    auto src_str = opt_src_str.value();
+    auto dest_str = m_ssm.destinationAddress();
+    auto port = m_ssm.port();
+
+    auto src_addr = make_shared_sockaddr(AF_UNSPEC, src_str, port);
+    if (!src_addr) return false;
+    auto dest_addr = make_shared_sockaddr(src_addr->sa_family, dest_str, port);
+    if (!dest_addr) return false;
+
+    if (src_addr->sa_family == AF_INET) {
+        auto src_sin = std::reinterpret_pointer_cast<struct sockaddr_in>(src_addr);
+        auto dest_sin = std::reinterpret_pointer_cast<struct sockaddr_in>(dest_addr);
+
+        buffer.setEncapsulatedUdpHeader(&src_sin->sin_addr, port, &dest_sin->sin_addr, port);
+        return true;
+    } else if (src_addr->sa_family == AF_INET6) {
+        auto src_sin6 = std::reinterpret_pointer_cast<struct sockaddr_in6>(src_addr);
+        auto dest_sin6 = std::reinterpret_pointer_cast<struct sockaddr_in6>(dest_addr);
+
+        buffer.setEncapsulatedUdpHeader(&src_sin6->sin6_addr, port, &dest_sin6->sin6_addr, port);
+        return true;
+    }
+
+    return false;
+}
+
+bool PacketProxyPacketisation::start()
+{
+    // Always started
+    return true;
+}
+
+bool PacketProxyPacketisation::isStarted()
+{
+    // Always started
+    return true;
+}
+
+bool PacketProxyPacketisation::stop()
+{
+    // We don't stop the packetisation as it's a throughput
+    return true;
+}
+
+bool PacketProxyPacketisation::flush()
+{
+    // No queue, packetisation is always flushed
+    return true;
+}
+
+bool PacketProxyPacketisation::reconfigure()
+{
+    // No resources to change
+    return true;
+}
+
+// private:
+
+void PacketProxyPacketisation::ssmToAddrs()
+{
+    m_srcAddr.reset();
+    m_destAddr.reset();
+    auto opt_src_str = m_ssm.sourceAddress();
+    if (!opt_src_str) return;
+
+    auto src_str = opt_src_str.value();
+    auto dest_str = m_ssm.destinationAddress();
+    auto port = m_ssm.port();
+
+    // At the end of this m_srcAddr & m_destAddr will both have the same address family or will both be nullptr
+
+    // Find any IPv4 or IPv6 address for the source
+    m_srcAddr = make_shared_sockaddr(AF_UNSPEC, src_str, port);
+    // If unresolvable return wil both addresses as nullptr
+    if (!m_srcAddr) return;
+
+    // Find a destination address of the same family as the source address
+    m_destAddr = make_shared_sockaddr(m_srcAddr->sa_family, dest_str, port);
+    if (!m_destAddr) {
+        // if unable to find, then we try the other way around...
+        m_srcAddr.reset();
+        // get any IPv4 or IPv6 address for destination
+        m_destAddr = make_shared_sockaddr(AF_UNSPEC, dest_str, port);
+        // If unresolvable then return with both addresses as nullptr
+        if (!m_destAddr) return;
+        // Find a source address of the same family as the destination address
+        m_srcAddr = make_shared_sockaddr(m_destAddr->sa_family, src_str, port);
+        // If unable to find, then we give up and return with both addresses as nullptr
+        if (!m_srcAddr) m_destAddr.reset();
+    }
+
+    if (m_srcAddr) {
+        if (m_srcAddr->sa_family == AF_INET) {
+            mtu(m_outerMTU - sizeof(iphdr) - sizeof(udphdr));
+        } else if (m_srcAddr->sa_family == AF_INET) {
+            mtu(m_outerMTU - sizeof(ip6_hdr) - sizeof(udphdr));
+        }
+    }
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketProxyPacketisation.hh
+++ b/src/mbstf/PacketProxyPacketisation.hh
@@ -1,0 +1,81 @@
+#ifndef _MBS_TF_PACKET_PROXY_PACKETISATION_HH_
+#define _MBS_TF_PACKET_PROXY_PACKETISATION_HH_
+/**********************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Proxy Packetisation class
+ **********************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "common.hh"
+#include "PacketPacketisation.hh"
+#include "SsmPort.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketProxyPacketisation : public PacketPacketisation {
+public:
+    PacketProxyPacketisation() = delete;
+    PacketProxyPacketisation(uint16_t mtu, const SsmPort &ssm) :PacketPacketisation(mtu), m_outerMTU(mtu), m_ssm(ssm), m_srcAddr(), m_destAddr() {
+        ssmToAddrs();
+    };
+    PacketProxyPacketisation(uint16_t mtu, SsmPort &&ssm) :PacketPacketisation(mtu), m_outerMTU(mtu), m_ssm(std::move(ssm)), m_srcAddr(), m_destAddr() {
+        ssmToAddrs();
+    };
+    PacketProxyPacketisation(const PacketProxyPacketisation &other) = delete;
+    PacketProxyPacketisation(PacketProxyPacketisation &&other)
+        :PacketPacketisation(std::move(other))
+        ,m_ssm(std::move(other.m_ssm))
+        ,m_srcAddr(std::move(other.m_srcAddr))
+        ,m_destAddr(std::move(other.m_destAddr))
+    {};
+
+    virtual ~PacketProxyPacketisation() {};
+
+    PacketProxyPacketisation &operator=(const PacketProxyPacketisation &other) = delete;
+    PacketProxyPacketisation &operator=(PacketProxyPacketisation &&other) {
+        PacketPacketisation::operator=(std::move(other));
+        m_ssm = std::move(other.m_ssm);
+        m_srcAddr = std::move(other.m_srcAddr);
+        m_destAddr = std::move(other.m_destAddr);
+        return *this;
+    };
+
+    virtual bool modifyPacket(Packet &buffer);
+
+    PacketProxyPacketisation &ssm(const SsmPort &ssm) { m_ssm = ssm; ssmToAddrs(); return *this; };
+    PacketProxyPacketisation &ssm(SsmPort &&ssm) { m_ssm = std::move(ssm); ssmToAddrs(); return *this; };
+    const SsmPort &ssm() const { return m_ssm; };
+    const std::shared_ptr<struct sockaddr> &sourceSockaddr() const { return m_srcAddr; };
+    const std::shared_ptr<struct sockaddr> &destinationSockaddr() const { return m_destAddr; };
+
+    virtual bool start();
+    virtual bool isStarted();
+    virtual bool stop();
+    virtual bool flush();
+    virtual bool reconfigure();
+
+private:
+    void ssmToAddrs();
+
+    uint16_t m_outerMTU;
+    SsmPort m_ssm;
+    std::shared_ptr<struct sockaddr> m_srcAddr;
+    std::shared_ptr<struct sockaddr> m_destAddr;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_PROXY_PACKETISATION_HH_ */

--- a/src/mbstf/PacketScheduler.cc
+++ b/src/mbstf/PacketScheduler.cc
@@ -1,0 +1,326 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Scheduler base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <sys/socket.h>
+
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "common.hh"
+#include "Packet.hh"
+#include "PacketProcessing.hh"
+
+#include "PacketScheduler.hh"
+
+using namespace std::literals::chrono_literals;
+
+MBSTF_NAMESPACE_START
+
+PacketScheduler::PacketScheduler()
+    :PacketSink()
+    ,m_abr(0)
+    ,m_burstBits(0)
+    ,m_bitBucketMutex(new decltype(m_bitBucketMutex)::element_type)
+    ,m_bitBucketCondVar()
+    ,m_bitBucket(0)
+    ,m_bucketFillerThread()
+    ,m_maxBufferSize(0)
+    ,m_queueMutex(new decltype(m_queueMutex)::element_type)
+    ,m_queueCondVar()
+    ,m_queuedPackets()
+    ,m_queuedBytes(0)
+    ,m_sendThread()
+    ,m_sendSocket(-1)
+    ,m_sendAddress()
+{
+}
+
+
+PacketScheduler::PacketScheduler(uint64_t burst_bits, uint64_t abr, size_t max_buffer, const struct sockaddr *tunnel_endpoint, PacketSource *source)
+    :PacketSink(source)
+    ,m_abr(abr)
+    ,m_burstBits(burst_bits)
+    ,m_bitBucketMutex(new decltype(m_bitBucketMutex)::element_type)
+    ,m_bitBucketCondVar()
+    ,m_bitBucket(burst_bits)
+    ,m_bucketFillerThread()
+    ,m_maxBufferSize(max_buffer)
+    ,m_queueMutex(new decltype(m_queueMutex)::element_type)
+    ,m_queueCondVar()
+    ,m_queuedPackets()
+    ,m_queuedBytes(0)
+    ,m_sendThread()
+    ,m_sendSocket(-1)
+    ,m_sendAddress()
+{
+    if (tunnel_endpoint) {
+        socklen_t addr_len = 0;
+        switch (tunnel_endpoint->sa_family) {
+        case AF_INET:
+            addr_len = sizeof(sockaddr_in);
+            break;
+        case AF_INET6:
+            addr_len = sizeof(sockaddr_in6);
+            break;
+        default:
+            break;
+        }
+        if (addr_len) {
+            memcpy(&m_sendAddress, tunnel_endpoint, addr_len);
+            m_sendSocket = socket(tunnel_endpoint->sa_family, SOCK_DGRAM, IPPROTO_UDP);
+            if (m_sendSocket >= 0) {
+                connect(m_sendSocket, tunnel_endpoint, addr_len);
+            }
+        }
+    }
+}
+
+PacketScheduler::PacketScheduler(PacketScheduler &&other)
+    :PacketSink(std::move(other))
+    ,m_abr(other.m_abr)
+    ,m_burstBits(other.m_burstBits)
+    ,m_bitBucketMutex(new decltype(m_bitBucketMutex)::element_type)
+    ,m_bitBucketCondVar()
+    ,m_bitBucket(0)
+    ,m_bucketFillerThread()
+    ,m_maxBufferSize(other.m_maxBufferSize)
+    ,m_queueMutex(new decltype(m_queueMutex)::element_type)
+    ,m_queueCondVar()
+    ,m_queuedPackets()
+    ,m_queuedBytes(0)
+    ,m_sendThread()
+    ,m_sendSocket(other.m_sendSocket)
+    ,m_sendAddress(other.m_sendAddress)
+{
+    other.haltThreads();
+    other.m_sendSocket = -1;
+
+    m_bitBucket = other.m_bitBucket.load();
+
+    {
+        std::lock_guard<decltype(m_queueMutex)::element_type> bucket_lock(*other.m_queueMutex);
+        m_queuedPackets = std::move(other.m_queuedPackets);
+        m_queuedBytes = other.m_queuedBytes.exchange(0);
+    }
+
+    startThreads();
+}
+
+PacketScheduler::~PacketScheduler()
+{
+    //stop();
+    haltThreads();
+}
+
+PacketScheduler &PacketScheduler::operator=(PacketScheduler &&other)
+{
+    PacketSink::operator=(std::move(other));
+
+    if (m_sendSocket >= 0) close(m_sendSocket);
+    m_sendSocket = other.m_sendSocket;
+    other.m_sendSocket = -1;
+
+    m_sendAddress = other.m_sendAddress;
+
+    m_abr = other.m_abr;
+    m_burstBits = other.m_burstBits;
+    m_maxBufferSize = other.m_maxBufferSize;
+
+    m_bitBucket = other.m_bitBucket.load();
+
+    {
+        std::lock_guard<decltype(m_queueMutex)::element_type> other_queue_lock(*other.m_queueMutex);
+        std::lock_guard<decltype(m_queueMutex)::element_type> queue_lock(*m_queueMutex);
+        m_queuedPackets = std::move(other.m_queuedPackets);
+        m_queuedBytes = other.m_queuedBytes.exchange(0);
+    }
+
+    m_bucketFillerThread = std::move(other.m_bucketFillerThread);
+    m_sendThread = std::move(other.m_sendThread);
+
+    return *this;
+}
+
+bool PacketScheduler::processPacket(Packet &packet)
+{
+    ogs_debug("Scheduling packet of %zu bytes", packet.size());
+    std::lock_guard<decltype(m_queueMutex)::element_type> queue_lock(*m_queueMutex);
+    if (m_queuedBytes + packet.size() > m_maxBufferSize) {
+        ogs_debug("Scheduling: Buffer overflow, discarding packet");
+        sendEvent(PacketEvent::bufferOverflowEvent(packet));
+        return false;
+    }
+
+    m_queuedBytes += packet.size();
+    m_queuedPackets.push_back(std::move(packet));
+    m_queueCondVar.notify_all();
+    return true;
+}
+
+bool PacketScheduler::start()
+{
+    startThreads();
+    return true;
+}
+
+bool PacketScheduler::stop()
+{
+    haltThreads();
+    return true;
+}
+
+bool PacketScheduler::flush()
+{
+    std::lock_guard<decltype(m_queueMutex)::element_type> queue_lock(*m_queueMutex);
+
+    // Wait for the queue to empty or the sending thread to stop
+    while (m_sendThread.isRunning() && m_queuedPackets.size() > 0) {
+        m_queueCondVar.wait_for(*m_queueMutex, 10ms);
+    }
+
+    // Tidy up queue if thread cancelled
+    if (m_queuedPackets.size() > 0) {
+        m_queuedPackets.clear();
+        m_queuedBytes = 0;
+    }
+
+    return true;
+}
+
+bool PacketScheduler::reconfigure()
+{
+    return true;
+}
+
+// private:
+
+void PacketScheduler::startThreads()
+{
+    if (m_abr > 0 && m_burstBits > 0) {
+        m_bucketFillerThread.startWorker("bucket-bit-filler", [this](auto check_cancelled) -> void {
+            bucketFillerWorker(check_cancelled);
+        });
+    }
+
+    if (m_sendSocket >= 0) {
+        std::lock_guard<decltype(m_queueMutex)::element_type> bucket_lock(*m_queueMutex);
+
+        m_sendThread.startWorker("packet-send", [this](auto check_cancelled) -> void {
+            sendWorker(check_cancelled);
+        });
+    }
+}
+
+void PacketScheduler::haltThreads()
+{
+    haltBucketFillerThread();
+    haltSendThread();
+}
+
+void PacketScheduler::haltBucketFillerThread()
+{
+    m_bucketFillerThread.cancel();
+    m_bucketFillerThread.join();
+}
+
+void PacketScheduler::haltSendThread()
+{
+    m_sendThread.cancel();
+    m_sendThread.join();
+}
+
+void PacketScheduler::bucketFillerWorker(std::function<void()> check_cancelled)
+{
+    double counter = 0;
+    double increment = m_abr / 100; // increment needed each 10ms
+    auto next_fill = std::chrono::system_clock::now() + 10ms;
+    while (true) {
+        counter += increment;
+        uint64_t bits = floor(counter);
+        counter -= bits;
+
+        {
+            std::lock_guard<decltype(m_bitBucketMutex)::element_type> bucket_lock(*m_bitBucketMutex);
+            bits = std::min(bits, m_burstBits - m_bitBucket);
+            m_bitBucket += bits;
+            m_bitBucketCondVar.notify_all();
+        }
+
+        std::this_thread::sleep_until(next_fill);
+        next_fill += 10ms;
+        check_cancelled();
+    }
+}
+
+void PacketScheduler::sendWorker(std::function<void()> check_cancelled)
+{
+    while (true) {
+        const auto &packet = waitForNextPacket(check_cancelled);
+        ogs_debug("Scheduler: got packet of %zu bytes", packet.size());
+        waitForBitsAvailable(check_cancelled, packet.size() * 8);
+        ogs_debug("Scheduler: bucket has enough bits");
+
+        {
+            std::lock_guard<decltype(m_bitBucketMutex)::element_type> bucket_lock(*m_bitBucketMutex);
+
+            m_bitBucket -= packet.size() * 8;
+            m_bitBucketCondVar.notify_all();
+        }
+
+        auto pl = packet.payload();
+        ogs_debug("Scheduler: transmitting %zu bytes", pl.size());
+        auto res = send(m_sendSocket, pl.data(), pl.size(), 0);
+        if (res < 0) {
+            ogs_warn("Scheduler: send failed: %s", strerror(errno));
+        }
+
+        {
+            std::lock_guard<decltype(m_queueMutex)::element_type> queue_lock(*m_queueMutex);
+            m_queuedBytes -= packet.size();
+            m_queuedPackets.pop_front(); // Invalidates packet
+            m_queueCondVar.notify_all();
+        }
+
+        check_cancelled();
+    }
+}
+
+const Packet& PacketScheduler::waitForNextPacket(std::function<void()> check_cancelled)
+{
+    std::lock_guard<decltype(m_queueMutex)::element_type> queue_lock(*m_queueMutex);
+
+    while (m_queuedPackets.size() == 0) {
+        m_queueCondVar.wait_for(*m_queueMutex, 10ms);
+        check_cancelled();
+    }
+
+    return m_queuedPackets.front();
+}
+
+void PacketScheduler::waitForBitsAvailable(std::function<void()> check_cancelled, size_t bits)
+{
+    std::lock_guard<decltype(m_bitBucketMutex)::element_type> bucket_lock(*m_bitBucketMutex);
+
+    while(m_bitBucket < bits) {
+        m_bitBucketCondVar.wait_for(*m_bitBucketMutex,10ms);
+        check_cancelled();
+    }
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/PacketScheduler.hh
+++ b/src/mbstf/PacketScheduler.hh
@@ -1,0 +1,86 @@
+#ifndef _MBS_TF_PACKET_SCHEDULER_HH_
+#define _MBS_TF_PACKET_SCHEDULER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Packet Scheduler base class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <condition_variable>
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <thread>
+
+#include "common.hh"
+#include "Packet.hh"
+#include "PacketProcessing.hh"
+#include "ThreadedWorker.hh"
+
+MBSTF_NAMESPACE_START
+
+class PacketScheduler : public PacketSink {
+public:
+    PacketScheduler();
+    PacketScheduler(uint64_t burst_bits, uint64_t abr, size_t max_buffer, const struct sockaddr *tunnnel_endpoint, PacketSource *source = nullptr);
+    PacketScheduler(const PacketScheduler &) = delete;
+    PacketScheduler(PacketScheduler &&other);
+
+    virtual ~PacketScheduler();
+
+    PacketScheduler &operator=(const PacketScheduler &) = delete;
+    PacketScheduler &operator=(PacketScheduler &&other);
+
+    operator bool() const {
+        return m_abr != 0 && m_burstBits != 0 && m_maxBufferSize != 0 && m_sendAddress.ss_family != AF_UNSPEC;
+    };
+
+    virtual bool processPacket(Packet &packet);
+
+    bool start();
+    bool stop();
+    bool flush();
+    bool reconfigure();
+
+private:
+    void startThreads();
+    void haltThreads();
+    void haltBucketFillerThread();
+    void haltSendThread();
+    void bucketFillerWorker(std::function<void()>);
+    void sendWorker(std::function<void()>);
+    const Packet& waitForNextPacket(std::function<void()>);
+    void waitForBitsAvailable(std::function<void()>, size_t bits);
+
+    uint64_t m_abr;
+    uint64_t m_burstBits;
+    std::shared_ptr<std::recursive_mutex> m_bitBucketMutex;
+    std::condition_variable_any m_bitBucketCondVar;
+    std::atomic<uint64_t> m_bitBucket;
+    ThreadedWorker m_bucketFillerThread;
+
+    size_t m_maxBufferSize;
+    std::shared_ptr<std::recursive_mutex> m_queueMutex;
+    std::condition_variable_any m_queueCondVar;
+    std::list<Packet> m_queuedPackets;
+    std::atomic<size_t> m_queuedBytes;
+    ThreadedWorker m_sendThread;
+
+    int m_sendSocket;
+    struct sockaddr_storage m_sendAddress;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_PACKET_SCHEDULER_HH_ */

--- a/src/mbstf/SsmPort.cc
+++ b/src/mbstf/SsmPort.cc
@@ -102,13 +102,9 @@ static std::string _conv_IpAddr_to_string(const std::shared_ptr<IpAddr> &ip_addr
     const auto &ipv4_addr = ip_addr->getIpv4Addr();
     if (ipv4_addr) return ipv4_addr.value();
     const auto &ipv6_addr = ip_addr->getIpv6Addr();
-    if (ipv6_addr && ipv6_addr.value()) {
-        return *ipv6_addr.value();
-    }
+    if (ipv6_addr) return ipv6_addr.value();
     const auto &ipv6_prefix = ip_addr->getIpv6Prefix();
-    if (ipv6_prefix && ipv6_prefix.value()) {
-        return *ipv6_prefix.value();
-    }
+    if (ipv6_prefix) return ipv6_prefix.value();
     return std::string();
 }
 

--- a/src/mbstf/ThreadedWorker.cc
+++ b/src/mbstf/ThreadedWorker.cc
@@ -1,0 +1,146 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Threaded Worker class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <chrono>
+#include <exception>
+#include <format>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include "ogs-core.h"
+#include "ogs-sbi.h"
+
+#include "common.hh"
+
+#include "ThreadedWorker.hh"
+
+using namespace std::literals::chrono_literals;
+
+MBSTF_NAMESPACE_START
+
+ThreadedWorker::ThreadedWorker()
+    :m_threadState()
+{
+    //ogs_debug("Empty threaded worker %p", this);
+}
+
+ThreadedWorker::ThreadedWorker(ThreadedWorker &&other)
+    :m_threadState(std::move(other.m_threadState))
+{
+    //ogs_debug("Move construct threaded worker %p (%p) to %p", &other, m_threadState.get(), this);
+}
+
+ThreadedWorker::~ThreadedWorker()
+{
+    //ogs_debug("Destroy threaded worker %p (%p)", this, m_threadState.get());
+}
+
+ThreadedWorker &ThreadedWorker::operator=(ThreadedWorker &&other)
+{
+    //ogs_debug("Move threaded worker %p (%p) to %p (%p)", &other, other.m_threadState.get(), this, m_threadState.get());
+    m_threadState = std::move(other.m_threadState);
+    return *this;
+}
+
+ThreadedWorker &ThreadedWorker::cancel()
+{
+    if (m_threadState) {
+        //ogs_debug("Cancelling threaded worker %p (%p) [%s]", this, m_threadState.get(), m_threadState->m_name.c_str());
+        m_threadState->m_isCancelled.store(true);
+    }
+    return *this;
+}
+
+ThreadedWorker &ThreadedWorker::join()
+{
+    if (m_threadState) {
+        if (m_threadState->m_thread.joinable()) {
+            if (m_threadState->m_thread.get_id() != std::this_thread::get_id()) {
+                //ogs_debug("Join threaded worker %p (%p) [%s]", this, m_threadState.get(), m_threadState->m_name.c_str());
+                m_threadState->m_thread.join();
+            } else {
+                // if we are trying to join this thread from itself, just detach
+                //ogs_debug("Detach threaded worker %p (%p) [%s]", this, m_threadState.get(), m_threadState->m_name.c_str());
+                m_threadState->m_thread.detach();
+            }
+        } else {
+            //ogs_debug("Threaded worker %p (%p) [%s] not joinable", this, m_threadState.get(), m_threadState->m_name.c_str());
+        }
+    } else {
+        //ogs_debug("Threaded worker %p has no state, not joinable", this);
+    }
+    return *this;
+}
+
+ThreadedWorker &ThreadedWorker::startWorker(const std::string &name, std::function<void(std::function<void()>)> workload)
+{
+    if (!m_threadState) m_threadState.reset(new ThreadedWorkerState);
+    //ogs_debug("Attempt thread start for worker %p (%p) [%s]", this, m_threadState.get(), name.c_str());
+    if (!m_threadState->m_isRunning.load()) {
+        m_threadState->m_isRunning.store(true);
+        m_threadState->m_isCancelled.store(false);
+        //ogs_debug("Threaded worker %p (%p) [%s] not running, starting...", this, m_threadState.get(), name.c_str());
+        m_threadState->m_name = name;
+        if (m_threadState->m_thread.joinable()) m_threadState->m_thread.detach();
+        auto state = m_threadState.get();
+        m_threadState->m_thread = std::thread([state, workload]() {
+                state->m_hasCompleted.store(false);
+                try {
+                    workload([state]() -> void { state->checkCancelled(); });
+                } catch (ThreadedWorkerCancelled &ex) {
+                    // cancelled is ok
+                } catch (std::exception &ex) {
+                    ogs_error("%s", std::format("The {} thread failed: {}", state->m_name, ex.what()).c_str());
+                    state->m_hasFailed.store(true);
+                }
+                state->m_hasCompleted.store(true);
+                state->m_isRunning.store(false);
+        });
+        //ogs_debug("Threaded worker %p (%p) [%s] started", this, m_threadState.get(), name.c_str());
+    }
+    return *this;
+}
+
+ThreadedWorker::ThreadedWorkerState::~ThreadedWorkerState()
+{
+    if (m_isRunning) {
+        //{
+        //    std::ostringstream oss;
+        //    oss << "Stopping running thread " << m_thread.get_id() << " for worker state " << this;
+        //    ogs_debug("%s", oss.str().c_str());
+        //}
+        m_isCancelled.store(true);
+        if (m_thread.joinable()) {
+            if (m_thread.get_id() != std::this_thread::get_id()) {
+                m_thread.join();
+            } else {
+                // if we are trying to join this thread from itself, just detach
+                m_thread.detach();
+            }
+        }
+    }
+}
+
+void ThreadedWorker::ThreadedWorkerState::checkCancelled() const
+{
+    //ogs_debug("Checking for cancelled thread on state %p", this);
+    if (m_isCancelled.load()) {
+        //ogs_debug("Thread cancelled on state %p", this);
+        throw ThreadedWorker::ThreadedWorkerCancelled();
+    }
+}
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/ThreadedWorker.hh
+++ b/src/mbstf/ThreadedWorker.hh
@@ -1,0 +1,88 @@
+#ifndef _MBS_TF_THREADED_WORKER_HH_
+#define _MBS_TF_THREADED_WORKER_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: Threaded Worker class
+ ******************************************************************************
+ * Copyright: (C)2026 British Broadcasting Corporation
+ * Author(s): David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <exception>
+#include <format>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include <ogs-core.h>
+#include <ogs-sbi.h>
+
+#include "common.hh"
+
+MBSTF_NAMESPACE_START
+
+class ThreadedWorker {
+public:
+    class ThreadedWorkerCancelled : public std::exception {
+    public:
+        using std::exception::exception;
+    };
+
+    ThreadedWorker();
+    ThreadedWorker(const std::string &name, std::function<void(std::function<void()>)> workload)
+        :m_threadState(new ThreadedWorkerState)
+    {
+        startWorker(name, workload);
+    }
+    template<class... Args>
+    ThreadedWorker(const std::string &name, std::function<void(std::function<void()>, Args&&...)> workload, Args&&... args)
+        :m_threadState(new ThreadedWorkerState)
+    {
+        startWorker(name, workload, std::forward<Args>(args)...);
+    };
+    ThreadedWorker(const ThreadedWorker&) = delete;
+    ThreadedWorker(ThreadedWorker &&other);
+
+    virtual ~ThreadedWorker();
+
+    ThreadedWorker &operator=(const ThreadedWorker &) = delete;
+    ThreadedWorker &operator=(ThreadedWorker &&);
+
+    operator bool() const { return isRunning(); };
+
+    bool isRunning() const { return m_threadState?m_threadState->m_isRunning.load():false; };
+    bool isCancelled() const { return m_threadState?m_threadState->m_isCancelled.load():false; };
+    bool hasCompleted() const { return m_threadState?m_threadState->m_hasCompleted.load():false; };
+
+    ThreadedWorker &cancel();
+    ThreadedWorker &join();
+
+    void checkCancelled() const { if (m_threadState) m_threadState->checkCancelled(); };
+
+    ThreadedWorker &startWorker(const std::string &name, std::function<void(std::function<void()>)> workload);
+
+private:
+    struct ThreadedWorkerState {
+        ~ThreadedWorkerState();
+
+        std::thread m_thread;
+        std::atomic<bool> m_isRunning;
+        std::atomic<bool> m_isCancelled;
+        std::atomic<bool> m_hasCompleted;
+        std::atomic<bool> m_hasFailed;
+        std::string m_name;
+
+        void checkCancelled() const;
+    };
+    std::unique_ptr<ThreadedWorkerState> m_threadState;
+};
+
+MBSTF_NAMESPACE_STOP
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif /* _MBS_TF_THREADED_WORKER_HH_ */

--- a/src/mbstf/generator-mbstf
+++ b/src/mbstf/generator-mbstf
@@ -181,7 +181,7 @@ if [ -x "$scriptdir/post-process.sh" ]; then
     CPP_POST_PROCESS_FILE="$scriptdir/post-process.sh" export CPP_POST_PROCESS_FILE
 fi
 
-if ! "$rt_common_shared_dir/open5gs-tools/scripts/generate_openapi" -a "${APIS}" -o "$rt_common_shared_dir/mbstf/5G_APIs-overrides" -b "${BRANCH}" -c "$templates_dir/config.yaml" -l cpp-restbed-server -d "$scriptdir/openapi" -g 6.4.0 -P "reftools.mbstf" $DEBUG_FLAG ${CACHE_DIR:+-C "$CACHE_DIR"}; then
+if ! "$rt_common_shared_dir/open5gs-tools/scripts/generate_openapi" -a "${APIS}" -o "$rt_common_shared_dir/mbs/5G_APIs-overrides" -b "${BRANCH}" -c "$templates_dir/config.yaml" -l cpp-restbed-server -d "$scriptdir/openapi" -g 7.23.0 -P "reftools.mbstf" $DEBUG_FLAG ${CACHE_DIR:+-C "$CACHE_DIR"}; then
     echo "Error: Failed to generate OpenAPI model" 1>&2
     exit 1
 fi

--- a/src/mbstf/mbstf.yaml.in
+++ b/src/mbstf/mbstf.yaml.in
@@ -189,6 +189,7 @@ mbstf:
         port: 0 # ephemeral
     totalMaxBitRateSoftLimit: 1000 # 1Gbps
     consecutiveIngestFailuresBeforeDeactivate: 5
+    packetModeSchedulingQueueSize: 131072 # 128KB queue per packet mode DistSession
     serverResponseCacheControl:
       - distMaxAge: 60
         ObjectMaxAge: 60

--- a/src/mbstf/mbstf.yaml.in
+++ b/src/mbstf/mbstf.yaml.in
@@ -1,6 +1,7 @@
 # License: 5G-MAG Public License (v1.0)
-# Author: Dev Audsin
-# Copyright: (C) 2022-2025 British Broadcasting Corporation
+# Author(s): Dev Audsin <dev.audsin@bbc.co.uk>
+#            David Waring <david.waring2@bbc.co.uk>
+# Copyright: (C) 2022-2026 British Broadcasting Corporation
 #
 # Licensed under the License terms and conditions for use, reproduction, and
 # distribution of 5G-MAG software (the “License”).  You may not use this file

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -157,6 +157,28 @@ libmbstf_dist_sources = files('''
     Open5GSYamlDocument.hh
     Open5GSYamlIter.cc
     Open5GSYamlIter.hh
+    PacketController.cc
+    PacketController.hh
+    PacketFEC.cc
+    PacketFEC.hh
+    PacketForwardPacketisation.cc
+    PacketForwardPacketisation.hh
+    Packet.cc
+    Packet.hh
+    PacketIngester.cc
+    PacketIngester.hh
+    PacketForwardOnlyController.cc
+    PacketForwardOnlyController.hh
+    PacketPacketisation.cc
+    PacketPacketisation.hh
+    PacketProcessing.cc
+    PacketProcessing.hh
+    PacketProxyController.cc
+    PacketProxyController.hh
+    PacketProxyPacketisation.cc
+    PacketProxyPacketisation.hh
+    PacketScheduler.cc
+    PacketScheduler.hh
     PullObjectIngester.cc
     PullObjectIngester.hh
     PushObjectIngester.cc
@@ -167,6 +189,8 @@ libmbstf_dist_sources = files('''
     SubscriptionService.hh
     Subscriber.cc
     Subscriber.hh
+    ThreadedWorker.cc
+    ThreadedWorker.hh
     TimerFunc.hh
     utilities.cc
     utilities.hh

--- a/src/mbstf/openapi-generator-templates/model-header.mustache
+++ b/src/mbstf/openapi-generator-templates/model-header.mustache
@@ -8,8 +8,8 @@
  * Template file
  * =============
  * License: 5G-MAG Public License (v1.0)
- * Author: David Waring
- * Copyright: (C)2023 British Broadcasting Corporation
+ * Author: David Waring <david.waring2@bbc.co.uk>
+ * Copyright: (C)2023-2026 British Broadcasting Corporation
  *
  * For full license terms please see the LICENSE file distributed with this
  * program. If this file is missing then the license can be retrieved from

--- a/src/mbstf/openapi-generator-templates/model-header.mustache
+++ b/src/mbstf/openapi-generator-templates/model-header.mustache
@@ -1,0 +1,53 @@
+{{#models}}{{#model}}/**************************************************************************
+ * {{classname}}.h : {{classname}} object model prototypes
+ *    generated from openapi-generator C++ language Mustache template
+ *    for object model implementation
+ **************************************************************************
+    ///{{#lambda.multiline_comment_4}}{{appDescriptionWithNewLines}}{{/lambda.multiline_comment_4}}
+ **************************************************************************
+ * Template file
+ * =============
+ * License: 5G-MAG Public License (v1.0)
+ * Author: David Waring
+ * Copyright: (C)2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#ifndef _{{#modelPackage}}{{#lambda.uppercase}}{{#lambda.snakecase}}{{#lambda.camelcase}}{{modelPackage}}{{/lambda.camelcase}}{{/lambda.snakecase}}{{/lambda.uppercase}}_{{/modelPackage}}{{classname}}_H_
+#define _{{#modelPackage}}{{#lambda.uppercase}}{{#lambda.snakecase}}{{#lambda.camelcase}}{{modelPackage}}{{/lambda.camelcase}}{{/lambda.snakecase}}{{/lambda.uppercase}}_{{/modelPackage}}{{classname}}_H_
+
+#include <list>
+#include <map>
+#include <optional>
+#include <string>
+#include "CJson.hh"
+#include "ModelObject.hh"
+#include "ModelException.hh"
+#include "OgsAllocator.hh"
+#include "Validator.hh"
+#include "ModelMacros.hh"
+{{#imports}}{{{this}}}
+{{/imports}}
+{{#interfaces}}
+#include "{{{this}}}.h"
+{{/interfaces}}
+{{#modelNamespace}}
+
+namespace {{modelNamespace}} {
+{{/modelNamespace}}
+
+{{^hasVars}}{{^isEnum}}{{#isString}}{{>model-header-string}}{{/isString}}{{^isString}}{{#composedSchemas}}{{#anyOf.0.name}}{{^anyOf.2.name}}{{#anyOf.1.isString}}{{#anyOf.0.isEnum}}{{>model-header-enum-fallback}}{{/anyOf.0.isEnum}}{{^anyOf.0.isEnum}}{{>model-header-object}}{{/anyOf.0.isEnum}}{{/anyOf.1.isString}}{{^anyOf.1.isString}}{{>model-header-object}}{{/anyOf.1.isString}}{{/anyOf.2.name}}{{#anyOf.2.name}}{{>model-header-object}}{{/anyOf.2.name}}{{/anyOf.0.name}}{{^anyOf.0.name}}{{>model-header-object}}{{/anyOf.0.name}}{{/composedSchemas}}{{^composedSchemas}}{{>model-header-object}}{{/composedSchemas}}{{/isString}}{{/isEnum}}{{#isEnum}}{{#allowableValues}}{{>model-header-enum}}{{/allowableValues}}{{^allowableValues}}{{>model-header-object}}{{/allowableValues}}{{/isEnum}}{{/hasVars}}{{#hasVars}}{{>model-header-object}}{{/hasVars}}
+{{#modelNamespace}}
+
+} /* end namespace */
+{{/modelNamespace}}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* _{{#modelPackage}}{{#lambda.uppercase}}{{#lambda.snakecase}}{{#lambda.camelcase}}{{modelPackage}}{{/lambda.camelcase}}{{/lambda.snakecase}}{{/lambda.uppercase}}_{{/modelPackage}}{{classname}}_HH_ */
+{{/model}}
+{{/models}}

--- a/src/mbstf/openapi-generator-templates/model-source.mustache
+++ b/src/mbstf/openapi-generator-templates/model-source.mustache
@@ -8,8 +8,8 @@
  * Template file
  * =============
  * License: 5G-MAG Public License (v1.0)
- * Author: David Waring
- * Copyright: (C)2023 British Broadcasting Corporation
+ * Author: David Waring <david.waring2@bbc.co.uk>
+ * Copyright: (C)2023-2026 British Broadcasting Corporation
  *
  * For full license terms please see the LICENSE file distributed with this
  * program. If this file is missing then the license can be retrieved from

--- a/src/mbstf/openapi-generator-templates/model-source.mustache
+++ b/src/mbstf/openapi-generator-templates/model-source.mustache
@@ -1,0 +1,46 @@
+{{#models}}{{#model}}/**************************************************************************
+ * {{classname}}.cc : {{classname}} object model implementation
+ *    generated from openapi-generator C++ language Mustache template
+ *    for object model implementation
+ **************************************************************************
+ * {{description}}
+ **************************************************************************
+ * Template file
+ * =============
+ * License: 5G-MAG Public License (v1.0)
+ * Author: David Waring
+ * Copyright: (C)2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+#include <sstream>
+#include <string>
+#include <memory>
+
+#include "CJson.hh"
+#include "ModelObject.hh"
+#include "ModelException.hh"
+#include "OgsAllocator.hh"
+#include "ProblemCause.hh"
+
+#include "{{classname}}.h"
+
+using namespace fiveg_mag_reftools;
+{{#modelNamespace}}
+
+namespace {{modelNamespace}} {
+{{/modelNamespace}}
+
+{{^hasVars}}{{^isEnum}}{{#isString}}{{>model-source-string}}{{/isString}}{{^isString}}{{#composedSchemas}}{{#anyOf.0.name}}{{^anyOf.2.name}}{{#anyOf.1.isString}}{{#anyOf.0.isEnum}}{{>model-source-enum-fallback}}{{/anyOf.0.isEnum}}{{^anyOf.0.isEnum}}{{>model-source-object}}{{/anyOf.0.isEnum}}{{/anyOf.1.isString}}{{^anyOf.1.isString}}{{>model-source-object}}{{/anyOf.1.isString}}{{/anyOf.2.name}}{{#anyOf.2.name}}{{>model-source-object}}{{/anyOf.2.name}}{{/anyOf.0.name}}{{^anyOf.0.name}}{{>model-source-object}}{{/anyOf.0.name}}{{/composedSchemas}}{{^composedSchemas}}{{>model-source-object}}{{/composedSchemas}}{{/isString}}{{/isEnum}}{{#isEnum}}{{#allowableValues}}{{>model-source-enum}}{{/allowableValues}}{{^allowableValues}}{{>model-source-object}}{{/allowableValues}}{{/isEnum}}{{/hasVars}}{{#hasVars}}{{>model-source-object}}{{/hasVars}}
+{{#modelNamespace}}
+
+} /* end namespace */
+{{/modelNamespace}}
+
+{{/model}}
+{{/models}}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/post-process.sh
+++ b/src/mbstf/post-process.sh
@@ -26,6 +26,8 @@ file="$1"
 
 case "$file" in
 *.cc|*.cpp)
-        sed -i '/StringValidator[^(]*("[^"]*", nullptr, "[^\/]/ {h;s/.*StringValidator[^(]*("[^"]*", nullptr, "//;s/\([^\\]\)".*/\1/;s/\\/\\\\/;s/^/\//;s/$/\//;H;x;s/\(StringValidator[^(]*("[^"]*", nullptr, "\)[^\n]*\("[^\n]*\)\n\(.*\)/\1\3\2/}' "$file"
+        sed -i '/StringValidator[^(]*("[^"]*", nullptr, "[^\/]/ {h;s/.*StringValidator[^(]*("[^"]*", nullptr, "//;s/\([^\\]\)".*/\1/;s/\\/\\\\/;s/^/\//;s/$/\//;H;x;s/\(StringValidator[^(]*("[^"]*", nullptr, "\)[^\n]*\("[^\n]*\)\n\(.*\)/\1\3\2/}
+               /_validator("[^"]*", "[^"]*", "[^"]*\\\// {s@\\/@\\\\/@g}
+               ' "$file"
         ;;
 esac

--- a/src/mbstf/post-process.sh
+++ b/src/mbstf/post-process.sh
@@ -2,7 +2,7 @@
 ##############################################################################
 # 5G-MAG Reference Tools: MBS Transport Function: OpenAPI-Generator post process
 ##############################################################################
-# Copyright: (C)2024 British Broadcasting Corporation
+# Copyright: (C)2024-2026 British Broadcasting Corporation
 # Author(s): David Waring <david.waring2@bbc.co.uk>
 # License: 5G-MAG Public License v1
 #

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -19,6 +19,8 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
 
 #include "ogs-core.h"
 
@@ -89,7 +91,7 @@ std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std:
     return retval;
 }
 
-int get_path_mtu(const ogs_sockaddr_t &sock_addr)
+int get_path_mtu(const ogs_sockaddr_t &sock_addr, int minus_level_hdrs)
 {
     ogs_sock_t *sock = ogs_sock_socket(sock_addr.ogs_sa_family, SOCK_DGRAM, 0);
     ogs_sock_connect(sock, const_cast<ogs_sockaddr_t*>(&sock_addr));
@@ -97,33 +99,57 @@ int get_path_mtu(const ogs_sockaddr_t &sock_addr)
     socklen_t mtu_size = sizeof(mtu);
     if (sock_addr.ogs_sa_family == AF_INET) {
         getsockopt(sock->fd, IPPROTO_IP, IP_MTU, &mtu, &mtu_size);
+        if (minus_level_hdrs >= GET_MTU_IP_PAYLOAD) mtu -= sizeof(iphdr);
     } else if (sock_addr.ogs_sa_family == AF_INET6) {
         getsockopt(sock->fd, IPPROTO_IPV6, IPV6_MTU, &mtu, &mtu_size);
+        if (minus_level_hdrs >= GET_MTU_IP_PAYLOAD) mtu -= sizeof(ip6_hdr);
     }
     ogs_sock_destroy(sock);
     return mtu;
 }
 
-int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port)
+int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port, int minus_level_hdrs)
 {
     int mtu = 1500; // default to 1500 if no MTU can be found.
 
     if (tunnel_ip) { // Use MTU of tunnel if provided
         ogs_sockaddr_t *sa = nullptr;
         if (ogs_addaddrinfo(&sa, AF_UNSPEC, tunnel_ip.value().c_str(), tunnel_port, AI_NUMERICSERV) == OGS_OK) {
-            mtu = get_path_mtu(*sa);
+            mtu = get_path_mtu(*sa, minus_level_hdrs);
             ogs_freeaddrinfo(sa);
         } // else error already reported
     } else { // No tunnel provided so try MTU of direct destination
         if (ssm_port) {
             ogs_sockaddr_t *sa = nullptr;
             if (ogs_addaddrinfo(&sa, AF_UNSPEC, ssm_port.destinationAddress().c_str(), ssm_port.port(), AI_NUMERICSERV) == OGS_OK) {
-                mtu = get_path_mtu(*sa);
+                mtu = get_path_mtu(*sa, minus_level_hdrs);
                 ogs_freeaddrinfo(sa);
             }
         }
     }
     return mtu;
+}
+
+std::shared_ptr<struct sockaddr> make_shared_sockaddr(int family_hint, const std::string &hostname, in_port_t port)
+{
+    std::shared_ptr<struct sockaddr> ret;
+    if (!hostname.empty()) {
+        struct addrinfo *ai = nullptr;
+        getaddrinfo(hostname.c_str(), std::format("{}", port).c_str(), nullptr, &ai);
+        if (ai) {
+            for (const auto *it = ai; it; it = it->ai_next) {
+                if ((family_hint == AF_UNSPEC && (it->ai_family == AF_INET || it->ai_family == AF_INET6)) ||
+                    (family_hint == it->ai_family)) {
+                    auto sa_data = std::make_shared<uint8_t[]>(static_cast<size_t>(it->ai_addrlen));
+                    memcpy(sa_data.get(), it->ai_addr, it->ai_addrlen);
+                    ret = std::reinterpret_pointer_cast<struct sockaddr>(sa_data);
+                    break;
+                }
+            }
+            freeaddrinfo(ai);
+        }
+    }
+    return ret;
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/utilities.hh
+++ b/src/mbstf/utilities.hh
@@ -18,7 +18,11 @@
  * See the License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <netinet/in.h>
+#include <sys/socket.h>
+
 #include <chrono>
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -35,8 +39,15 @@ std::string time_point_to_iso8601_utc_str(const std::chrono::system_clock::time_
 std::chrono::system_clock::time_point iso8601_utc_str_to_time_point(const std::string &iso8601_str);
 std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std::string &rfc9110_str);
 
-int get_path_mtu(const ogs_sockaddr_t &sock_addr);
-int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port);
+enum GetMTULevels {
+    GET_MTU_ETHERNET_PAYLOAD = 0,
+    GET_MTU_IP_PAYLOAD = 1
+};
+
+int get_path_mtu(const ogs_sockaddr_t &sock_addr, int minus_level_hdrs = GET_MTU_ETHERNET_PAYLOAD);
+int get_tunnelled_path_mtu(const SsmPort &ssm_port, const std::optional<std::string> &tunnel_ip, in_port_t tunnel_port, int minus_level_hdrs = GET_MTU_ETHERNET_PAYLOAD);
+
+std::shared_ptr<struct sockaddr> make_shared_sockaddr(int family_hint, const std::string &hostname, in_port_t port);
 
 MBSTF_NAMESPACE_STOP
 

--- a/tests/packet_stream_gen.py
+++ b/tests/packet_stream_gen.py
@@ -159,7 +159,7 @@ class StreamClientProtocol:
 
     def connection_made(self, transport):
         self.__transport = transport
-self.__send_task = asyncio.get_running_loop().create_task(self.send_loop(), eager_start=True)
+        self.__send_task = asyncio.get_running_loop().create_task(self.send_loop())
         
     def datagram_received(self, data, addr):
         print(f"Unexpected packet of {len(data)} bytes from: {addr}")

--- a/tests/packet_stream_gen.py
+++ b/tests/packet_stream_gen.py
@@ -159,7 +159,7 @@ class StreamClientProtocol:
 
     def connection_made(self, transport):
         self.__transport = transport
-        self.__send_task = asyncio.create_task(self.send_loop(), eager_start=True)
+self.__send_task = asyncio.get_running_loop().create_task(self.send_loop(), eager_start=True)
         
     def datagram_received(self, data, addr):
         print(f"Unexpected packet of {len(data)} bytes from: {addr}")

--- a/tests/packet_stream_gen.py
+++ b/tests/packet_stream_gen.py
@@ -219,8 +219,8 @@ async def main():
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MTU_DISCOVER, socket.IP_PMTUDISC_PROBE)
         else:
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MTU_DISCOVER, socket.IP_PMTUDISC_DONT)
-        (host, port) = sock.getsockname()
-        if ipaddress.ip_address(host).is_multicast:
+        if ipaddress.ip_address(remote_addr_port[0]).is_multicast:
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton(local_addr_port[0]))
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
     elif sock.family == socket.AF_INET6:
@@ -229,8 +229,7 @@ async def main():
             sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MTU_DISCOVER, socket.IPV6_PMTUDISC_PROBE)
         else:
             sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MTU_DISCOVER, socket.IPV6_PMTUDISC_DONT)
-        (host, port, flowinfo, scope_id) = sock.getsockname()
-        if ipaddress.ip_address(host).is_multicast:
+        if ipaddress.ip_address(remote_addr_port[0]).is_multicast:
             sock.setsockopt(socket.IPPROTO_IPv6, socket.IPV6_MULTICAST_HOPS, ttl)
             sock.setsockopt(socket.IPPROTO_IPv6, socket.IPV6_MULTICAST_LOOP, 1)
 

--- a/tests/packet_stream_gen.py
+++ b/tests/packet_stream_gen.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python3
+############################################################################################################
+# Copyright: 2026 British Broadcasting Corporation
+# Author(s): David Waring <david.waring2@bbc.co.uk>
+# License: 5G-MAG Public License v1.0
+#
+# Licensed under the License terms and conditions for use, reproduction, and distribution of 5G-MAG
+# software (the “License”).
+#
+# You may not use this file except in compliance with the License. You may obtain a copy of the License
+# at https://www.5g-mag.com/reference-tools.
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+# See the License for the specific language governing permissions and limitations under the License.
+############################################################################################################
+
+import argparse
+import asyncio
+import functools
+import ipaddress
+import os.path
+import socket
+import struct
+import sys
+
+g_this_script = os.path.basename(__file__)
+
+socket_consts = [
+    ('IP_MTU_DISCOVER', 10),
+
+    ('IPV6_MTU_DISCOVER', 23),
+
+    ('IP_PMTUDISC_DONT', 0),
+    ('IP_PMTUDISC_PROBE', 3),
+
+    ('IPV6_PMTUDISC_DONT', 0),
+    ('IPV6_PMTUDISC_PROBE', 3),
+]
+for (attr, value) in socket_consts:
+    if not hasattr(socket, attr):
+        setattr(socket, attr, value)
+
+class StreamClientProtocol:
+    def __init__(self, loop, encap_dest, encap_src, packet_size, packet_rate_ms, ttl, do_not_fragment):
+        self.__loop = loop
+        self.__conn_end_future = self.__loop.create_future()
+        if encap_dest is None:
+            self.__encap_dest = None
+            self.__encap_src = None
+            self.__encap_family = None
+        else:
+            for (family, _, _, _, sockaddr) in socket.getaddrinfo(*encap_dest):
+                if family in [socket.AF_INET, socket.AF_INET6]:
+                    self.__encap_dest = (socket.inet_pton(family, sockaddr[0]), sockaddr[1])
+                    self.__encap_family = family
+                    break
+            for (_, _, _, _, sockaddr) in socket.getaddrinfo(*encap_src, family=self.__encap_family):
+                self.__encap_src = (socket.inet_pton(self.__encap_family, sockaddr[0]), sockaddr[1])
+        self.__packet_size = packet_size
+        self.__packet_rate_ms = packet_rate_ms
+        self.__ttl = ttl
+        self.__do_not_fragment = do_not_fragment
+        self.__pkt_counter = 1
+        self.__transport = None
+
+    async def checksum_raw(self, buffer):
+        if len(buffer) % 2 == 1:
+            cksum = functools.reduce(lambda x,y: x + y[0], struct.iter_unpack('H', buffer[0:-1]), 0) + (struct.unpack_from('B', buffer, len(buffer)-1) << 16)
+        else:
+            cksum = functools.reduce(lambda x,y: x + y[0], struct.iter_unpack('H', buffer), 0)
+        while cksum > 0xffff:
+            cksum = (cksum & 0xffff) + (cksum >> 16)
+        return cksum
+
+    async def checksum(self, buffer):
+        cksum = await self.checksum_raw(buffer)
+        return ~cksum & 0xffff
+
+    async def ip_header(self, payload_len, ttl=64, do_not_fragment=False):
+        iph = b'\x45\x00'
+        iph += struct.pack("!H", payload_len + 20)
+        iph += b'\x00\x00'
+        if (do_not_fragment):
+            iph += b'\x40\x00'
+        else:
+            iph += b'\x00\x00'
+        iph += struct.pack("!B", ttl)
+        iph += struct.pack("!B", socket.IPPROTO_UDP)
+        cksum_offset = len(iph)
+        iph += b'\x00\x00'
+        #print(f"IP SRC {self.__encap_src[0]!r}")
+        iph += self.__encap_src[0]
+        #print(f"IP DEST {self.__encap_dest[0]!r}")
+        iph += self.__encap_dest[0]
+        iph = iph[0:cksum_offset] + struct.pack("H", await self.checksum(iph)) + iph[cksum_offset+2:]
+        return iph
+
+    async def ip6_header(self, payload_len, ttl=64):
+        iph = b'\x60\x00\x00\x00'
+        iph += struct.pack("!H", payload_len)
+        iph += struct.pack("!B", socket.IPPROTO_UDP)
+        iph += struct.pack("!B", ttl)
+        #print(f"IP6 SRC {self.__encap_src[0]!r}")
+        iph += self.__encap_src[0]
+        #print(f"IP6 DEST {self.__encap_dest[0]!r}")
+        iph += self.__encap_dest[0]
+        return iph
+
+    async def udp_header_and_payload(self, payload):
+        udp = struct.pack("!H", self.__encap_src[1])
+        udp += struct.pack("!H", self.__encap_dest[1])
+        udp += struct.pack("!H", len(payload) + 8)
+        cksum_offset = len(udp)
+        udp += b'\x00\x00'
+        udp += payload
+
+        pseudo_ip = self.__encap_src[0]
+        pseudo_ip += self.__encap_dest[0]
+        pseudo_ip += b'\x00'
+        pseudo_ip += struct.pack("!B", socket.IPPROTO_UDP)
+        pseudo_ip += struct.pack("!H", len(payload) + 8)
+
+        cksum = await self.checksum_raw(pseudo_ip) + await self.checksum_raw(udp)
+        while cksum > 0xffff:
+            cksum = (cksum & 0xffff) + (cksum >> 16)
+        cksum = ~cksum & 0xffff
+
+        udp = udp[0:cksum_offset] + struct.pack("H", cksum) + udp[cksum_offset+2:]
+
+        return udp
+
+    async def udp_packet(self, payload, ttl=64, do_not_fragment=False):
+        if self.__encap_family is not None:
+            if self.__encap_family == socket.AF_INET:
+                packet = await self.ip_header(len(payload) + 8, ttl, do_not_fragment)
+            elif self.__encap_family == socket.AF_INET6:
+                packet = await self.ip6_header(len(payload) + 8, ttl)
+            else:
+                packet = b''
+            packet += await self.udp_header_and_payload(payload)
+        else:
+            packet = payload
+        return packet
+
+    async def make_packet(self):
+        packet_body = bytes([self.__pkt_counter & 0xff] * self.__packet_size)
+        self.__pkt_counter += 1
+        return await self.udp_packet(packet_body, self.__ttl, self.__do_not_fragment)
+
+    async def send_loop(self):
+        while True:
+            self.__transport.sendto(await self.make_packet())
+            await asyncio.sleep(self.__packet_rate_ms/1000.0)
+
+    async def on_con_lost(self):
+        return await self.__conn_end_future
+
+    def connection_made(self, transport):
+        self.__transport = transport
+        self.__send_task = asyncio.create_task(self.send_loop(), eager_start=True)
+        
+    def datagram_received(self, data, addr):
+        print(f"Unexpected packet of {len(data)} bytes from: {addr}")
+        #self.__transport.close()
+
+    def error_received(self, exc):
+        #print('Error received: ', exc)
+        pass
+
+    def connection_lost(self, exc):
+        print("\nConnection closed")
+        if not self.__conn_end_future.cancelled():
+            self.__conn_end_future.set_result(True)
+
+def to_addr_port(ap_str):
+    if ap_str is None:
+        return None
+    (addr, _, port) = ap_str.rpartition(':')
+    if addr[0] == '[' and addr[-1] == ']':
+        addr = addr[1:-1]
+    return (addr, int(port))
+
+async def main():
+    parser = argparse.ArgumentParser(description='Test script to stream UDP packets to the MBSTF.')
+    parser.add_argument('-s', '--size', metavar='BYTES', help='Size of packets to send. (default: %(default)s)', type=int, default=1428)
+    parser.add_argument('-t', '--ttl', help='TTL to use on packets. (default: %(default)s)', type=int, default=64)
+    parser.add_argument('-r', '--packet-rate', metavar='PACKET-RATE', help='The number of packets per second to send. (default: %(default)s)', type=int, default=100)
+    parser.add_argument('-d', '--do-not-fragment', help='Flag packets as "Do not fragment" (only applies to IPv4). (default: fragmentation allowed)', action='store_true')
+    parser.add_argument('tunnel_source', metavar='local-address:port', type=to_addr_port, help='Local address and port that packets will be sent from.')
+    parser.add_argument('tunnel_dest', metavar='destination-address:port', type=to_addr_port, help='Remote address and port that packets will be sent to.')
+    parser.add_argument('encap_dest', nargs='?', metavar='encap-dest-address:port', type=to_addr_port, help='Encapsulated destination address and port that packet payloads will contain. If omitted then there\'s no encapsulation.', default=None)
+    parser.add_argument('encap_source', nargs='?', metavar='encap-src-address:port', type=to_addr_port, help='Encapsulated source address and port that packet payloads will contain. If omitted then the <local-address:port> is used if appropriate.', default=None)
+
+    opts = parser.parse_args()
+
+    local_addr_port = opts.tunnel_source
+    remote_addr_port = opts.tunnel_dest
+    encap_dest_addr_port = opts.encap_dest
+    encap_src_addr_port = opts.encap_source
+    packet_size = opts.size
+    packet_rate = opts.packet_rate
+    do_not_fragment = opts.do_not_fragment
+    ttl = opts.ttl
+    if encap_src_addr_port is None:
+        encap_src_addr_port = local_addr_port
+
+    loop = asyncio.get_running_loop()
+
+    transport, protocol = await loop.create_datagram_endpoint(
+      lambda: StreamClientProtocol(loop, encap_dest_addr_port, encap_src_addr_port, packet_size, packet_rate, ttl, do_not_fragment),
+      local_addr=local_addr_port, remote_addr=remote_addr_port)
+
+    sock = transport.get_extra_info('socket')
+    if sock.family == socket.AF_INET:
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_TTL, ttl)
+        if do_not_fragment:
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MTU_DISCOVER, socket.IP_PMTUDISC_PROBE)
+        else:
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MTU_DISCOVER, socket.IP_PMTUDISC_DONT)
+        (host, port) = sock.getsockname()
+        if ipaddress.ip_address(host).is_multicast:
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
+    elif sock.family == socket.AF_INET6:
+        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_UNICAST_HOPS, ttl)
+        if do_not_fragment:
+            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MTU_DISCOVER, socket.IPV6_PMTUDISC_PROBE)
+        else:
+            sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_MTU_DISCOVER, socket.IPV6_PMTUDISC_DONT)
+        (host, port, flowinfo, scope_id) = sock.getsockname()
+        if ipaddress.ip_address(host).is_multicast:
+            sock.setsockopt(socket.IPPROTO_IPv6, socket.IPV6_MULTICAST_HOPS, ttl)
+            sock.setsockopt(socket.IPPROTO_IPv6, socket.IPV6_MULTICAST_LOOP, 1)
+
+    try:
+        await protocol.on_con_lost()
+    except asyncio.exceptions.CancelledError:
+        pass
+    finally:
+        transport.close()
+
+    return 0
+
+sys.exit(asyncio.run(main()))


### PR DESCRIPTION
This adds the packet operating mode for the MBSTF.

**Note:** This requires the fixes in PR 5G-MAG/rt-common-shared#68 to compile properly.

Closes #62

The packet distribution mode works in two operating modes `PACKET_PROXY` and `PACKET_FORWARD_ONLY`.

## `PACKET_PROXY` operating mode

In this operating mode, the MBSTF receives UDP payloads via either a unicast UDP port or from a multicast service.

- In **unicast ingest mode** only the MBSTF indicates its end of the unicast UDP port in its response to the *DistSession* creation request. The MBSTF is provided with User Plane addressing information for the network via the `upTrafficFlowInfo` field in the *DistSession*.

The MBSTF receives the payloads, encapsulates them with appropriate UDP/IP headers using the `upTrafficFlowInfo` data, and schedules them for delivery to the UPF at the maximum rate requested in the *DistSession*.

If the input bit rate exceeds the maximum bit rate requested then packets are dropped (a warning is logged in the MBSTF log output, but no feedback to the Application Provider).

If the incoming packets are larger than the UPF UDP tunnel MTU and the `upTrafficFlowInfo` indicates IPv4 encapsulation, then the MBSTF sends the payload as a series of fragmented packets with the appropriate encapsulated IP and UDP headers derived from the `upTrafficFlowInfo`. If the `upTrafficFlowInfo` indicates IPv6 encapsulation then a Packet Too Big ICMPv6 message to the AP is attempted with a revised MTU as payload.

## `PACKET_FORWARD_ONLY` operating mode

In this operating mode, the MBSTF receives encapsulated packets via a unicast UDP tunnel.

The MBSTF indicates its end of the unicast UDP tunnel in its response to the *DistSession* creation request. The *DistSession* does not contain any `upTrafficFlowInfo` because the multicast header is already present as encapsulated headers.

Ingested packets are passed on directly to the UPF.

If the incoming packets are larger than the UPF UDP tunnel MTU and the encapsulated packets are IPv4 then the MBSTF will attempt to fragment the encapsulated packets.

If the encapsulated IP header has the *Do Not Fragment* (DF) bit set then the packet is discarded and an attempt is made to respond to the MBS Application Provider with a Destination Unreachable ICMP message with a revised MTU in the payload (for MTU discovery).

If the encapsulated packets are IPv6 then a *Packet Too Big* ICMPv6 message is attempted with a revised MTU as payload.