### PR TITLE
Fix null-pointer crash when a STREAMING object isn't a manifest

### DIFF
--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -133,6 +133,17 @@ void ObjectStreamingController::processEvent(Event &event, SubscriptionService &
 
             } else {
                 std::unique_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
+                if (!manifest_handler) {
+                    // No registered handler recognised this object's media type as a manifest
+                    // (e.g. it matched getManifestUrl() spuriously, or genuinely isn't a
+                    // supported manifest format). Storing/using a null handler here crashes
+                    // later at the first manifestHandler()->... call, which asserts rather
+                    // than null-checks (see LibFlute/shared_ptr_deref) -- mirror
+                    // ObjectCarouselController's handling of this exact case instead.
+                    ogs_error("Could not find suitable manifest handler for object %s", object_id.c_str());
+                    sendToPackager(object);
+                    return;
+                }
                 manifestHandler(std::move(manifest_handler));
                 sendToPackager(object);
             }


### PR DESCRIPTION
## Summary
`ManifestHandlerFactory::makeManifestHandler()` correctly returns `nullptr` for non-manifest media types (e.g. `audio/mp4`, `video/mp4` media segments), but `ObjectStreamingController` (used for `STREAMING` operating mode) stored that result without checking it, crashing on the first subsequent `manifestHandler()->...` call.

Adds the same null-check `ObjectCarouselController` (used for `CAROUSEL` mode) already has for this exact case: log and forward the object to the packager instead of trying to track it as a manifest.

## Test plan
- Rebuilt and confirmed the fix compiles cleanly
- Reproduced the crash before the fix (STREAMING/PULL ingest session with real DASH audio/video segments) and confirmed it no longer occurs afterward, in a full end-to-end run against a live rt-mbs-function + rt-mbs-client