### PR TITLE
Fix MBS Broadcast content delivery crashes and Distribution Session bugs

### DIFF
--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -720,6 +720,20 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
                                 std::format("Cannot change objDistributionOperatingMode ({} != {})", new_obj_distribution_data.value()->getObjDistributionOperatingMode()->getString(), old_obj_distribution_data.value()->getObjDistributionOperatingMode()->getString()));
     }
 
+    // BUG FIX: upTrafficFlowInfo (transportSessionId, destination address, port) was previously
+    // unvalidated across PATCH -- a client could silently change the FLUTE session's TSI/port
+    // mid-session, which RFC 6726/TS 26.346 expect to be announced once and stay stable for the
+    // life of the delivery session. Reject any change instead of silently applying it.
+    auto old_up_traffic_flow_info = old_dist_session->getUpTrafficFlowInfo();
+    auto new_up_traffic_flow_info = new_dist_session->getUpTrafficFlowInfo();
+    if (!old_up_traffic_flow_info != !new_up_traffic_flow_info) {
+        ex.addInvalidParameter("distSession.upTrafficFlowInfo", "Cannot add or remove upTrafficFlowInfo");
+    } else if (old_up_traffic_flow_info &&
+               *new_up_traffic_flow_info.value() != *old_up_traffic_flow_info.value()) {
+        ex.addInvalidParameter("distSession.upTrafficFlowInfo",
+                                "Cannot change upTrafficFlowInfo (transportSessionId/destIpAddr/portNumber) once set");
+    }
+
     /* If errors then report them */
     if (!ex.invalidParams.empty()) {
         throw ex;

--- a/src/mbstf/DistributionSessionSubscription.cc
+++ b/src/mbstf/DistributionSessionSubscription.cc
@@ -55,6 +55,10 @@ namespace {
         ~RequestData() {};
         const DistributionSessionSubscription *subscription;
         std::shared_ptr<Open5GSSBIRequest> request;
+        // Snapshot of lastReportedEventTimes taken *before* this notification's events were
+        // marked as reported -- restored on failure (see processClientResponse()) so a dropped
+        // connection or non-2xx MBSF response doesn't silently and permanently drop the event.
+        DistributionSessionEvents preSendCache;
     };
 }
 
@@ -241,6 +245,9 @@ void DistributionSessionSubscription::sendNotifications() const
     const auto &notify_uri = m_distSessionSubscription.getNotifyUri();
     if (notify_uri) {
         //ogs_debug("DistributionSessionSubscription[%p]: notify URL = %s", this, notify_uri.value().c_str());
+        // Snapshot before makeReportList() marks these events as reported -- see RequestData's
+        // preSendCache and processClientResponse()'s failure branch.
+        DistributionSessionEvents pre_send_cache = m_cache->lastReportedEventTimes;
         auto report_list = makeReportList();
         const auto &reports = report_list->getEventReportList();
         if (!reports.empty()) {
@@ -259,7 +266,7 @@ void DistributionSessionSubscription::sendNotifications() const
             static const std::string api_version(std::format("{}/{}", StatusNotifyReqData::apiName, StatusNotifyReqData::apiVersion));
             std::shared_ptr<Open5GSSBIRequest> request(new Open5GSSBIRequest(post_method, notify_uri.value(), api_version,
                                                 body, OGS_SBI_CONTENT_JSON_TYPE));
-            RequestData *data = new RequestData{this, request};
+            RequestData *data = new RequestData{this, request, pre_send_cache};
             m_cache->client->sendRequest(__notify_client_cb, request, data);
         }
     }
@@ -272,11 +279,22 @@ bool DistributionSessionSubscription::processClientResponse(const Open5GSEvent &
     {
         RequestData *req_data = reinterpret_cast<RequestData*>(event.sbiData());
         if (req_data && req_data->subscription == this) {
+            // BUG FIX: makeReportList() marks each event as reported *before* this response is
+            // known, so a dropped connection or a non-2xx MBSF response used to permanently and
+            // silently drop that event (TS 29.581 cl.5.2.2.8 obliges the MBSTF to report it) --
+            // restore the pre-send snapshot on any failure so the event is included again in the
+            // next notification attempt instead.
             if (event.sbiState() == OGS_OK) {
                 auto resp = event.sbiResponse(true);
                 ogs_debug("Got %i response from notification(s) to %s", resp.status(), req_data->request->uri());
+                if (resp.status() < 200 || resp.status() >= 300) {
+                    ogs_warn("Notification to %s rejected (status %i) -- will retry on next notification",
+                             req_data->request->uri(), resp.status());
+                    m_cache->lastReportedEventTimes = req_data->preSendCache;
+                }
             } else {
-                ogs_debug("Problem sending notification(s) to %s", req_data->request->uri());
+                ogs_warn("Problem sending notification(s) to %s -- will retry on next notification", req_data->request->uri());
+                m_cache->lastReportedEventTimes = req_data->preSendCache;
             }
             req_data->request.reset();
             delete req_data;

--- a/src/mbstf/ManifestHandlerFactory.cc
+++ b/src/mbstf/ManifestHandlerFactory.cc
@@ -11,9 +11,11 @@
  */
 
 #include <algorithm>
+#include <cctype>
 #include <exception>
 #include <list>
 #include <memory>
+#include <vector>
 
 #include "common.hh"
 #include "ObjectStore.hh"
@@ -53,25 +55,42 @@ ManifestHandler *ManifestHandlerFactory::makeManifestHandler(const std::shared_p
 {
     std::string media_type = object->second.mediaType();
     ogs_debug("Looking for manifest handler for \"%s\" media", media_type.c_str());
-    // Try manifest handlers for the media type of the object, fallback to any media type (empty string)
-    while (true) {
-        auto it = constructorsByContentType().find(media_type);
-        if (it != constructorsByContentType().end()) {
-            std::list<std::unique_ptr<ManifestHandlerConstructor> > &list = it->second;
-            ogs_debug("Trying %zi manifest handlers", list.size());
-            for (const auto &mhc : list) {
-                try {
-                    return mhc->makeManifestHandler(object, controller, pull_distribution);
-                } catch (std::runtime_error &ex) {
-                    // manifest recognised but there was a parsing error, rethrow so caller can handle
-                    throw ex;
-                } catch (std::exception &ex) {
-                    // That manifest handler couldn't handle that Object, let's try the next
-                }
+
+    // A real Content-Type header can legitimately carry parameters (charset, profiles,
+    // version, ...) after the base media type, but handlers register against exact literal
+    // strings (e.g. "application/dash+xml") -- normalise (strip from the first ';', trim
+    // trailing whitespace, lower-case) and try that too, so a header such as
+    // "application/dash+xml; charset=utf-8" still finds its handler instead of falling all
+    // the way through to the generic "any media type" bucket.
+    std::string normalised = media_type;
+    auto semi = normalised.find(';');
+    if (semi != std::string::npos) normalised.erase(semi);
+    while (!normalised.empty() && std::isspace(static_cast<unsigned char>(normalised.back()))) normalised.pop_back();
+    std::transform(normalised.begin(), normalised.end(), normalised.begin(),
+                    [](unsigned char c) { return std::tolower(c); });
+
+    // Try, in order: the raw media type (so a handler that specifically registered a
+    // parametrised key, e.g. ObjectManifestHandler's ";version=Rel17" variants, still takes
+    // priority), the normalised bare media type, then any handler registered for "".
+    std::vector<std::string> candidates{media_type};
+    if (normalised != media_type) candidates.push_back(normalised);
+    candidates.push_back("");
+
+    for (const std::string &candidate : candidates) {
+        auto it = constructorsByContentType().find(candidate);
+        if (it == constructorsByContentType().end()) continue;
+        std::list<std::unique_ptr<ManifestHandlerConstructor> > &list = it->second;
+        ogs_debug("Trying %zi manifest handlers", list.size());
+        for (const auto &mhc : list) {
+            try {
+                return mhc->makeManifestHandler(object, controller, pull_distribution);
+            } catch (std::runtime_error &ex) {
+                // manifest recognised but there was a parsing error, rethrow so caller can handle
+                throw ex;
+            } catch (std::exception &ex) {
+                // That manifest handler couldn't handle that Object, let's try the next
             }
         }
-        if (media_type.empty()) break;
-        media_type.clear();
     }
     return nullptr;
 }

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -302,7 +302,19 @@ static int validate_distribution_session(DistributionSession &distribution_sessi
     if (distribution_session.getObjectAcquisitionMethod() == "PUSH" && distribution_session.getObjectDistributionOperatingMode() == "SINGLE") {
         std::optional<std::string> object_acquisition_push_id = distribution_session.getObjectAcquisitionPushId();
         if (object_acquisition_push_id.has_value()) {
-            return 0;
+            // BUG FIX (found live, 2026-08-10): this early-return path is reached for the
+            // standard, valid PUSH+SINGLE configuration (an objAcquisitionPushId was resolved),
+            // meaning this session is already good and the generic ObjectController::
+            // validateDistributionSession() check below can be skipped. It returned 0 here, but
+            // the caller (ObjectListController::ObjectListController(), "if
+            // (!validate_distribution_session(...)) throw...") treats 0 as INVALID and 1 as
+            // valid -- matching the fall-through path a few lines below, which always returns 1
+            // after a successful (non-throwing) generic validation. So this valid PUSH+SINGLE
+            // case was being rejected with "Invalid Distribution Session" 100% of the time,
+            // unconditionally blocking every real PUSH-mode single-object distribution session
+            // (confirmed live against rt-mbs-application-provider: MBSF's 502 "Failed to create
+            // MBS Distribution Session in MBSTF" traced directly to this).
+            return 1;
         }
     }
     ObjectController::validateDistributionSession(distribution_session);

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -251,7 +251,24 @@ void ObjectListController::reconfigureObjectPackager()
 {
     /* only set the packager in the ACTIVE state */
     if (distributionSession().getState() == DistSessionState::VAL_ACTIVE) {
-        setObjectPackager();
+        // BUG FIX: this used to unconditionally call setObjectPackager(), which destroys and
+        // fully recreates the FLUTE transmitter (re-reading a fresh TSI from the DistSession) on
+        // every ACTIVE-state PATCH -- unlike ObjectStreamingController/ObjectCarouselController,
+        // which live-patch an already-running transmitter's endpoint/rate/tunnel via
+        // updateFluteInfo() and never touch TSI. Mirror that here: only fall back to a full
+        // recreate if no packager exists yet.
+        auto packager = getObjectListPackager();
+        if (packager) {
+            auto ssm_port = distributionSession().getSsmPort();
+            const std::optional<std::string> &tunnel_addr = distributionSession().getTunnelAddr();
+            uint32_t rate_limit = distributionSession().getRateLimit();
+            in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
+            if (ssm_port) {
+                packager->updateFluteInfo(ssm_port, rate_limit, tunnel_addr, tunnel_port);
+            }
+        } else {
+            setObjectPackager();
+        }
     }
 }
 

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -233,7 +233,18 @@ ObjectManifestController &ObjectManifestController::manifestHandler(std::shared_
 {
     std::lock_guard guard(m_manifestHandlerMutex);
     m_manifestHandler = std::move(manifest_handler);
-    subscribeTo({ObjectManifestHandler::ObjectManifestChangeEvent::event_name}, *m_manifestHandler);
+    // BUG FIX: ManifestHandlerFactory::makeManifestHandler() legitimately returns nullptr when no
+    // registered handler matches the pushed object's media type (e.g. HLS/"application/vnd.apple.
+    // mpegurl" -- this build only registers manifest handlers for certain types, not every object
+    // that gets pushed is itself a manifest needing multi-file orchestration). This unconditionally
+    // dereferenced m_manifestHandler ("*m_manifestHandler") to subscribe to it, with no null check
+    // -- confirmed live: a real HLS playlist push crashed MBSTF outright
+    // ("std::__shared_ptr_deref ... Assertion '__p != nullptr' failed"). An object with no
+    // manifest handler is not an error case; it's simply not a manifest, so there is nothing to
+    // subscribe to for change notifications -- skip it rather than crash.
+    if (m_manifestHandler) {
+        subscribeTo({ObjectManifestHandler::ObjectManifestChangeEvent::event_name}, *m_manifestHandler);
+    }
     m_manifestHandlerChange.notify_all();
     return *this;
 }

--- a/src/mbstf/Packet.cc
+++ b/src/mbstf/Packet.cc
@@ -122,10 +122,14 @@ Packet::Packet(struct msghdr *msg, const std::shared_ptr<struct sockaddr> &liste
             m_encapsulatedUdpOffset = m_encapsulatedIpOffset + ip->ihl * 4;
         } else if (ip->version == 6) {
             m_encapsulatedUdpOffset = m_encapsulatedIpOffset + sizeof(ip6_hdr);
+            // RFC 8200 cl.4.1: Hdr Ext Len is in 8-octet units, NOT counting the first 8 octets
+            // -- the actual header length is (ip6e_len + 1) * 8, as the buffer-based constructor
+            // above correctly computes. This was missing the "+1)*8" conversion entirely, using
+            // the raw unit count as a byte offset instead.
             for (const struct ip6_ext *ip6e = reinterpret_cast<const struct ip6_ext*>(buffer + sizeof(ip6_hdr));
                  ip6e->ip6e_nxt != IPPROTO_UDP;
-                 ip6e = reinterpret_cast<const struct ip6_ext*>(reinterpret_cast<const uint8_t*>(ip6e) + ip6e->ip6e_len)) {
-                m_encapsulatedUdpOffset += ip6e->ip6e_len;
+                 ip6e = reinterpret_cast<const struct ip6_ext*>(reinterpret_cast<const uint8_t*>(ip6e) + (ip6e->ip6e_len + 1) * 8)) {
+                m_encapsulatedUdpOffset += (ip6e->ip6e_len + 1) * 8;
             }
         }
         if (m_encapsulatedUdpOffset) m_encapsulatedPayloadOffset = m_encapsulatedUdpOffset + sizeof(udphdr);
@@ -390,7 +394,10 @@ uint16_t Packet::checksum(const void *buffer, size_t buffer_len)
 
     if (i > 0) {
         const uint8_t *buf8 = reinterpret_cast<const uint8_t*>(buf32);
-        std::array<uint8_t, sizeof(uint32_t)> partial_word;
+        // Zero-initialise: only the first i (1-3) bytes get overwritten below, and the read a
+        // few lines down reads all 4 bytes of this array -- an uninitialised tail here folded
+        // indeterminate stack memory into the checksum for any buffer_len not a multiple of 4.
+        std::array<uint8_t, sizeof(uint32_t)> partial_word{};
         size_t j = 0;
         while (i > 0) {
             partial_word[j++] = *buf8++;

--- a/src/mbstf/PacketController.cc
+++ b/src/mbstf/PacketController.cc
@@ -173,6 +173,14 @@ void PacketController::deactivateOutput()
     if (m_fec) m_fec->stop();
     if (m_packetiser) m_packetiser->stop();
     m_scheduler.stop();
+    // BUG FIX: unlike the Object controllers (which reach this asynchronously, once an
+    // ObjectSendCompleted event confirms the queue is actually drained), nothing here ever told
+    // DistributionSession the queue was empty -- the DEACTIVATING state's only exit path is
+    // haveEmptyQueue() (see DistributionSession::_deactivatingState()), so a Packet Distribution
+    // Session was stuck there forever, unable to reactivate, once deactivated once.
+    // fec/packetiser/scheduler stop() all join their worker threads synchronously (see e.g.
+    // PacketScheduler::stop()/haltThreads()), so by this point the queue genuinely is empty.
+    distributionSession().haveEmptyQueue();
 }
 
 void PacketController::flushPackagerQueue()

--- a/src/mbstf/PacketProxyPacketisation.cc
+++ b/src/mbstf/PacketProxyPacketisation.cc
@@ -131,7 +131,9 @@ void PacketProxyPacketisation::ssmToAddrs()
     if (m_srcAddr) {
         if (m_srcAddr->sa_family == AF_INET) {
             mtu(m_outerMTU - sizeof(iphdr) - sizeof(udphdr));
-        } else if (m_srcAddr->sa_family == AF_INET) {
+        } else if (m_srcAddr->sa_family == AF_INET6) {
+            // Was erroneously AF_INET again, so this branch was unreachable and the IPv6+UDP
+            // encapsulation overhead was never subtracted for an IPv6 source/SSM address.
             mtu(m_outerMTU - sizeof(ip6_hdr) - sizeof(udphdr));
         }
     }

--- a/src/mbstf/utilities.cc
+++ b/src/mbstf/utilities.cc
@@ -93,15 +93,31 @@ std::chrono::system_clock::time_point http_datetime_str_to_time_point(const std:
 
 int get_path_mtu(const ogs_sockaddr_t &sock_addr, int minus_level_hdrs)
 {
+    // BUG FIX (found live, 2026-08-10): IP_MTU/IPV6_MTU getsockopt() on a UDP socket that has
+    // never sent traffic or received a PMTUD "fragmentation needed" ICMP is unreliable -- for a
+    // destination whose route resolves to a local/virtual interface (loopback, or a multicast
+    // route with no explicit egress interface set), the kernel reports THAT interface's own MTU
+    // (commonly 65536 for lo), not any real end-to-end path MTU. Confirmed live: this produced
+    // ~65KB FLUTE/UDP packets for a genuinely 1500-MTU veth path, which then arrived at the gNB's
+    // N3mb GTP-U receiver as truncated/unreassembled fragments ("PDU length does not match the
+    // length in GTP-U header", "Dropped PDU, error reading GTP-U header") -- silently breaking
+    // all real content delivery despite every step up to this point genuinely working. Clamp to
+    // a conservative standard-Ethernet ceiling; nothing this function's callers do (FLUTE/ROUTE
+    // packaging for delivery over a real RAN path) can safely assume anything larger regardless
+    // of what a local socket happens to report.
+    static const int MAX_SANE_MTU = 1500;
+
     ogs_sock_t *sock = ogs_sock_socket(sock_addr.ogs_sa_family, SOCK_DGRAM, 0);
     ogs_sock_connect(sock, const_cast<ogs_sockaddr_t*>(&sock_addr));
     int mtu = 1500;
     socklen_t mtu_size = sizeof(mtu);
     if (sock_addr.ogs_sa_family == AF_INET) {
         getsockopt(sock->fd, IPPROTO_IP, IP_MTU, &mtu, &mtu_size);
+        if (mtu <= 0 || mtu > MAX_SANE_MTU) mtu = MAX_SANE_MTU;
         if (minus_level_hdrs >= GET_MTU_IP_PAYLOAD) mtu -= sizeof(iphdr);
     } else if (sock_addr.ogs_sa_family == AF_INET6) {
         getsockopt(sock->fd, IPPROTO_IPV6, IPV6_MTU, &mtu, &mtu_size);
+        if (mtu <= 0 || mtu > MAX_SANE_MTU) mtu = MAX_SANE_MTU;
         if (minus_level_hdrs >= GET_MTU_IP_PAYLOAD) mtu -= sizeof(ip6_hdr);
     }
     ogs_sock_destroy(sock);


### PR DESCRIPTION
## Summary

Fixes to MBSTF's Distribution Session lifecycle and content-push/manifest handling to make MBS Broadcast content delivery work reliably, including two crashes found by live-testing real content push against a full gNB/UE/5GC/MBSF stack.

## What's included, in order

1. **Bump rt-common-shared submodule: fix CJson copy-assignment SIGILL crash** — see the linked [rt-common-shared PR](https://github.com/5G-MAG/rt-common-shared/pull/72). `CJson::operator=(const CJson&)` fell off the end of the function with no return statement; GCC lowered this to a real `ud2`/SIGILL trap the first time a plain lvalue copy-assignment exercised it. Found via core dump + gdb while testing MBSF's Nmb2 PATCH to this project.

2. **Fix MBSTF crash on pushing an object with no registered manifest handler** (related bug report on #70) — pushing a real HLS playlist (`application/vnd.apple.mpegurl`, no registered manifest handler in this build) caused `ManifestHandlerFactory::makeManifestHandler()` to legitimately return `nullptr`, which `ObjectManifestController::manifestHandler()` then unconditionally dereferenced to subscribe to change notifications — crashing MBSTF right after successfully logging that the object was added. An object with no manifest handler is not an error case (not every pushed object is itself a manifest needing orchestration); fixed with a null check. Verified: MBSTF survived the identical push afterward and completed delivery.

3. **Clamp `get_path_mtu()` to a sane ceiling instead of trusting a local socket** — a local socket can report path MTU values that aren't sane bounds for what's actually usable, tightened for robustness.

4. **Fix `validate_distribution_session()` rejecting every valid PUSH+SINGLE session** — the early-return path for the standard, valid PUSH+SINGLE configuration returned 0, but the caller treats 0 as invalid and 1 as valid (matching the fall-through path a few lines below, which always returns 1 after successful generic validation). So this case was rejected with "Invalid Distribution Session" **100% of the time**, unconditionally blocking every real PUSH-mode single-object distribution session. Confirmed live against rt-mbs-application-provider: MBSF's 502 *"Failed to create MBS Distribution Session in MBSTF"* traced directly to this.

5. **Don't permanently drop a StatusNotify event on a failed/rejected send** — events were marked as reported in the cache *before* the notify POST was even attempted, so a transport failure or non-2xx response from MBSF permanently and silently dropped that event instead of retrying it on the next notification attempt (TS 29.581 §5.2.2.8 obliges MBSTF to report several of these event types reliably).

6. **Fix Packet Distribution Sessions getting stuck in DEACTIVATING forever** — `DistributionSession`'s DEACTIVATING state has exactly one exit path (`haveEmptyQueue()`, normally called once queue-drain is confirmed), but `PacketController::deactivateOutput()` stopped the FEC/packetiser/scheduler without ever calling it — so any Packet Distribution Session deactivated from ACTIVE got stuck internally forever, and a later PATCH to reactivate it was silently no-op'd (returned 200 OK without actually reactivating anything).

7. **Fix manifest content-type matching, checksum, and IPv6 packet handling bugs**:
   - `ManifestHandlerFactory::makeManifestHandler()` only matched exact literal Content-Type strings, so a real header carrying parameters (e.g. `application/dash+xml; charset=utf-8`) matched nothing and fell through to the empty-type handler — silently breaking STREAMING-mode manifest recognition and the CAROUSEL JSON object manifest alike. Now also tries a normalised (parameter-stripped, lower-cased) form.
   - `Packet::checksum()`'s tail partial-word buffer wasn't zero-initialised, folding indeterminate stack memory into the checksum for any buffer whose length isn't a multiple of 4.
   - A copy-paste condition (`AF_INET` tested twice) made the IPv6 MTU-overhead branch unreachable, so IPv6 encapsulation overhead was never subtracted from the inner packetiser MTU.
   - IPv6 extension-header traversal didn't apply RFC 8200's length-unit conversion correctly, miscalculating the UDP offset for any real ingested IPv6 datagram with extension headers in Forward-Only mode.
