### PR TITLE
Feature: Improvements to manifest handling while streaming

### DIFF
--- a/src/mbstf/App.cc
+++ b/src/mbstf/App.cc
@@ -24,6 +24,7 @@
 
 #include "common.hh"
 #include "Context.hh"
+#include "ManifestHandlerFactory.hh"
 #include "MBSTFEventHandler.hh"
 #include "MBSTFNetworkFunction.hh"
 #include "Open5GSFSM.hh"
@@ -130,6 +131,7 @@ App::~App()
 {
     m_context.reset();
     m_app.reset();
+    ManifestHandlerFactory::tidyConfigurations();
 }
 
 const App &App::self()

--- a/src/mbstf/Context.cc
+++ b/src/mbstf/Context.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
@@ -28,6 +29,7 @@
 #include "common.hh"
 #include "App.hh"
 #include "DistributionSession.hh"
+#include "ManifestHandlerFactory.hh"
 #include "Open5GSNetworkFunction.hh"
 #include "Open5GSSBIServer.hh"
 #include "Open5GSSockAddr.hh"
@@ -48,6 +50,7 @@ Context::Context()
     ,totalMaxBitRateSoftLimit(100)
     ,consecutiveIngestFailuresBeforeDeactivate(5)
     ,packetModeSchedulingQueueSize(128*1024) // 128KB queue for rate smoothing
+    ,manifestGlobals()
 {
 }
 
@@ -105,8 +108,9 @@ bool Context::parseConfig()
                     } while (distSess_array.type() == YAML_SEQUENCE_NODE);
 
                 } else if (mbstf_key == "totalMaxBitRateSoftLimit") {
-                    if (mbstf_iter.type() == YAML_MAPPING_NODE) {
-                        std::string limit_val(mbstf_iter.value());
+                    Open5GSYamlIter total_max_iter(mbstf_iter);
+                    if (total_max_iter.type() == YAML_SCALAR_NODE) {
+                        std::string limit_val(total_max_iter.value());
                         size_t idx = 0;
                         totalMaxBitRateSoftLimit = std::stoi(limit_val, &idx);
                         if (idx != limit_val.size()) {
@@ -116,8 +120,9 @@ bool Context::parseConfig()
                         throw std::out_of_range("Bad configuration node at mbstf.totalMaxBitRateSoftLimit");
                     }
                 } else if (mbstf_key == "consecutiveIngestFailuresBeforeDeactivate") {
-                    if (mbstf_iter.type() == YAML_MAPPING_NODE) {
-                        std::string num_val(mbstf_iter.value());
+                    Open5GSYamlIter failures_iter(mbstf_iter);
+                    if (failures_iter.type() == YAML_SCALAR_NODE) {
+                        std::string num_val(failures_iter.value());
                         size_t idx = 0;
                         consecutiveIngestFailuresBeforeDeactivate = std::stoi(num_val, &idx);
                         if (idx != num_val.size()) {
@@ -127,7 +132,8 @@ bool Context::parseConfig()
                         throw std::out_of_range("Bad configuration node at mbstf.consecutiveIngestFailuresBeforeDeactivate");
                     }
                 } else if (mbstf_key == "packetModeSchedulingQueueSize") {
-                    if (mbstf_iter.type() == YAML_MAPPING_NODE) {
+                    Open5GSYamlIter queue_size_iter(mbstf_iter);
+                    if (queue_size_iter.type() == YAML_SCALAR_NODE) {
                         std::string num_val(mbstf_iter.value());
                         size_t idx = 0;
                         packetModeSchedulingQueueSize = std::stoi(num_val, &idx);
@@ -137,7 +143,14 @@ bool Context::parseConfig()
                     } else {
                         throw std::out_of_range("Bad configuration node at mbstf.packetModeSchedulingQueueSize");
                     }
-                } else {
+                } else if (mbstf_key == "manifestHandler") {
+                    Open5GSYamlIter manifest_handler_iter(mbstf_iter);
+                    if (manifest_handler_iter.type() == YAML_MAPPING_NODE) {
+                        parseManifestHandlerGlobals(mbstf_key, manifest_handler_iter);
+                    } else {
+                        throw std::out_of_range("Bad configuration node at mbstf.manifestHandler");
+                    }
+                } else if (!ManifestHandlerFactory::parseConfiguration(mbstf_key, mbstf_iter)) {
                     ogs_warn("Unknown key `mbstf.%s` in configuration", mbstf_key.c_str());
                 }
             }
@@ -195,6 +208,26 @@ void Context::parseCacheControl(Open5GSYamlIter &iter) {
             ogs_error("Cache control value for %s of \"%s\" is too big for integer storage.", cc_key.c_str(), cc_val.c_str());
         } catch (std::invalid_argument &ex) {
             ogs_error("Cache control value for %s of \"%s\" is not understood as an integer.", cc_key.c_str(), cc_val.c_str());
+        }
+    }
+}
+
+void Context::parseManifestHandlerGlobals(const std::string &pc_key, Open5GSYamlIter &iter)   {
+    while (iter.next()) {
+        std::string mhg_key(iter.key());
+        if (mhg_key == "manifestRepetitionRate") {
+            Open5GSYamlIter man_rep_iter(iter);
+            if (man_rep_iter.type() == YAML_SCALAR_NODE) {
+                try {
+                    manifestGlobals.manifestRepetitionRate = parseDuration(man_rep_iter.value());
+                } catch (std::out_of_range &ex) {
+                    throw std::out_of_range(std::format("Bad configuration data type for mbstf.{}.{}: {}", pc_key, mhg_key, ex.what()));
+                }
+            } else {
+                throw std::out_of_range(std::format("Bad configuration data type for mbstf.{}.{}: Value is not a duration", pc_key, mhg_key));
+            }
+        } else {
+            ogs_warn("Unknown configuration key mbstf.%s.%s", pc_key.c_str(), mhg_key.c_str());
         }
     }
 }
@@ -407,6 +440,29 @@ void Context::updateNFLoad()
             svc->load += new_load;
         }
     }
+}
+
+std::chrono::milliseconds Context::parseDuration(const std::string &duration_string)
+{
+    char *ext = NULL;
+    unsigned long long val = strtoull(duration_string.c_str(), &ext, 10);
+    if (ext == duration_string.c_str()) throw std::out_of_range("duration must be an integer with optional units");
+    std::string units(ext);
+    if (units == "ms") {
+        return std::chrono::milliseconds(val);
+    } else if (units.empty() || units == "s") {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(val));
+    } else if (units == "m") {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::minutes(val));
+    } else if (units == "h") {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::hours(val));
+    } else if (units == "d") {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::days(val));
+    } else if (units == "w") {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::weeks(val));
+    }
+
+    throw std::out_of_range("duration units must be either omitted, \"ms\", \"s\", \"m\", \"h\", \"d\" or \"w\"");
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/Context.hh
+++ b/src/mbstf/Context.hh
@@ -19,8 +19,10 @@
  * under the License.
  */
 
+#include <chrono>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "ogs-sbi.h"
@@ -70,12 +72,33 @@ public:
         unsigned int distMaxAge;
         unsigned int defaultObjectMaxAge; // Use if not given by push/pull resource Cache-Control.
     } cacheControl;
-    int totalMaxBitRateSoftLimit; // total maximum bit rate this MBSTF ought to asked to handle
-    int consecutiveIngestFailuresBeforeDeactivate; // The number of consecutive ingest failures allowed before the session aborts
-    size_t packetModeSchedulingQueueSize; // The maximum queue size for packet mode scheduling per DistSession
+    int totalMaxBitRateSoftLimit; //< total maximum bit rate this MBSTF ought to asked to handle
+    int consecutiveIngestFailuresBeforeDeactivate; //< The number of consecutive ingest failures allowed before the session aborts
+    size_t packetModeSchedulingQueueSize; //< The maximum queue size for packet mode scheduling per DistSession
+    struct {
+        /** The maximum time allowed before the manifest will be transmitted again
+         *
+         * This may be overridden my ManifestHandler specific class configuration.
+         */
+        std::optional<std::chrono::milliseconds> manifestRepetitionRate = std::nullopt;
+    } manifestGlobals; //< ManifestHandler global configuration (can be overridden by ManifestHandler implement specific config)
+
+    /** Parse a configuration time duration string
+     *
+     * Format:
+     *     <INTEGER>[<UNITS>]
+     *     Where INTEGER is any positive whole number in decimal and UNITS is optional and either "w", "d", "h", "m", "s" or "ms"
+     *     for weeks, days, hours, minutes, seconds or milliseconds respectively. UNITS will be assumed to be seconds if not given.
+     *
+     * @param duration_string The duration in the format described.
+     * @return The duration in milliseconds.
+     * @throw std::out_of_range If the duration string cannnot be parsed into a duration.
+     */
+    static std::chrono::milliseconds parseDuration(const std::string &duration_string);
 
 private:
     void parseCacheControl(Open5GSYamlIter &iter);
+    void parseManifestHandlerGlobals(const std::string &pc_key, Open5GSYamlIter &iter);
     void parseConfiguration(std::string &pc_key, Open5GSYamlIter &iter);
     int checkForAddr(ogs_socknode_t *node);
     void updateNFLoad();

--- a/src/mbstf/DASHManifestHandler.cc
+++ b/src/mbstf/DASHManifestHandler.cc
@@ -30,11 +30,14 @@
 #include "ogs-sbi.h" // include before "common.hh" to ensure correct logging domain
 
 #include "common.hh"
+#include "App.hh"
+#include "Context.hh"
 #include "DistributionSession.hh"
 #include "ManifestHandler.hh"
 #include "ManifestHandlerFactory.hh"
 #include "ObjectController.hh"
 #include "ObjectStore.hh"
+#include "Open5GSYamlIter.hh"
 #include "PullObjectIngester.hh"
 
 #include "DASHManifestHandler.hh"
@@ -44,6 +47,48 @@ using namespace std::literals::chrono_literals;
 LIBMPDPP_NAMESPACE_USING_ALL;
 
 MBSTF_NAMESPACE_START
+
+namespace {
+static struct {
+    std::optional<std::chrono::milliseconds> mpdRepetitionRate = std::nullopt;
+    bool compressMpd = false;
+} g_config;
+
+static void __tidy_config() {
+    g_config.mpdRepetitionRate = std::nullopt;
+    g_config.compressMpd = false;
+}
+
+static const std::chrono::milliseconds &__get_repetition_rate() {
+    if (g_config.mpdRepetitionRate) {
+        return g_config.mpdRepetitionRate.value();
+    }
+    auto &context = App::self().context();
+    if (context && context->manifestGlobals.manifestRepetitionRate) {
+        return context->manifestGlobals.manifestRepetitionRate.value();
+    }
+    static const std::chrono::milliseconds no_repetition_rate(-1);
+    return no_repetition_rate;
+}
+
+static bool __set_repetition_rate(const std::string &value) {
+    try {
+        g_config.mpdRepetitionRate = Context::parseDuration(value);
+    } catch (std::out_of_range &ex) {
+        return false;
+    }
+    return true;
+}
+
+static bool __get_compress_mpd() {
+    return g_config.compressMpd;
+}
+
+static bool __set_compress_mpd(bool compress_mpd) {
+    g_config.compressMpd = compress_mpd;
+    return true;
+}
+}
 
 using time_type = std::chrono::system_clock::time_point;
 
@@ -56,13 +101,8 @@ DASHManifestHandler::DASHManifestHandler(const std::shared_ptr<ObjectStore::Obje
     ,m_manifest(object)
     ,m_refreshMpd(false)
 {
-    std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
-    m_mpd.selectAllRepresentations();
-
-    //Use selectedInitializationSegments() to fetch Initialization Segments
-
-    m_extraPullObjects = m_mpd.selectedInitializationSegments();
     addMPDRefreshToExtraPullObjects();
+
     ogs_debug("Extra Objects to pull: %zu", m_extraPullObjects.size());
     for (auto &is : m_extraPullObjects) {
       std::ostringstream oss;
@@ -73,6 +113,8 @@ DASHManifestHandler::DASHManifestHandler(const std::shared_ptr<ObjectStore::Obje
 
 DASHManifestHandler::~DASHManifestHandler()
 {
+    m_mpd.presentationType(MPD::STATIC);
+    m_mpd.minimumUpdatePeriod(std::nullopt); // no more updates
 }
 
 std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifestHandler::nextIngestItems()
@@ -84,10 +126,10 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
     std::string manifest_url;
     time_type fetch_time;
 
-    std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> media_segments;
+    std::list<SegmentEntry> media_segments;
     {
         std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
-        media_segments = m_mpd.selectedSegmentAvailability();
+        media_segments = std::move(augmentSegmentAvailabilityList(m_mpd.selectedSegmentAvailability(), false, false, false));
     }
     media_segments.insert(media_segments.end(), m_extraPullObjects.begin(), m_extraPullObjects.end());
     for (auto &ms: media_segments) {
@@ -120,13 +162,13 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
         const auto &object_store = m_controller->objectStore();
         const auto &obj_ingest_base_url = m_controller->distributionSession().getObjectIngestBaseUrl();
         const auto &obj_dist_base_url = m_controller->distributionSession().objectDistributionBaseUrl();
-        auto existing_obj = object_store.findMetadataByURL(segment_url);
+        auto existing_obj = object_store->findMetadataByURL(segment_url);
 
         if (existing_obj) {
-            ingest_items.emplace_back(*existing_obj, first_media_segment.availabilityEndTime());
+            ingest_items.emplace_back(*existing_obj, first_media_segment.availabilityEndTime(), first_media_segment.forceRecache(), first_media_segment.keepAfterSend(), first_media_segment.compressEntry());
         } else {
             ingest_items.emplace_back(nextObjectId(), first_media_segment.segmentURL(), empty, obj_ingest_base_url,
-                                      obj_dist_base_url, first_media_segment.availabilityEndTime());
+                                      obj_dist_base_url, first_media_segment.availabilityEndTime(), first_media_segment.forceRecache(), first_media_segment.keepAfterSend(), first_media_segment.compressEntry());
         }
         removeExtraPullObjectsEntry(first_media_segment);
 
@@ -141,13 +183,13 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
         for ( ++it; it != media_segments.end(); ++it ) {
             if (it->availabilityStartTime() != fetch_time) break;
             segment_url = it->segmentURL();
-            existing_obj = object_store.findMetadataByURL(segment_url);
+            existing_obj = object_store->findMetadataByURL(segment_url);
             removeExtraPullObjectsEntry(*it);
             if (existing_obj) {
-                ingest_items.emplace_back(*existing_obj, it->availabilityEndTime());
+                ingest_items.emplace_back(*existing_obj, it->availabilityEndTime(), it->forceRecache(), it->keepAfterSend(), it->compressEntry());
             } else {
                 ingest_items.emplace_back(nextObjectId(), segment_url, empty, obj_ingest_base_url, obj_dist_base_url,
-                                          it->availabilityEndTime());
+                                          it->availabilityEndTime(), it->forceRecache(), it->keepAfterSend(), it->compressEntry());
             }
             if (it->segmentURL() == manifest_url) m_refreshMpd = true;
         }
@@ -159,18 +201,39 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> DASHManifest
 void DASHManifestHandler::addMPDRefreshToExtraPullObjects()
 {
     std::lock_guard<std::recursive_mutex> guard(m_mpdMutex);
+
+    m_mpd.selectAllRepresentations();
+    //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
+    m_extraPullObjects = std::move(augmentSegmentAvailabilityList(m_mpd.selectedInitializationSegments(), false, true, false));
+
+    std::chrono::system_clock::time_point resend_at;
+    bool force_recache = false;
+
+    auto repetition_rate = __get_repetition_rate();
+    if (repetition_rate.count() > 0) {
+        auto resend_base_time = m_manifest->second.lastSent();
+        if (resend_base_time.time_since_epoch().count() == 0) {
+            // Use last received time if we don't have a record of the last send time
+            resend_base_time = m_manifest->second.receivedTime();
+        }
+        resend_at = resend_base_time + repetition_rate;
+    }
     if (m_pullDistribution && m_mpd.hasMinimumUpdatePeriod()) {
         auto min_update_time = m_manifest->second.receivedTime() + m_mpd.minimumUpdatePeriod().value();
-        auto time_to_update = m_manifest->second.hasExpiryTime()?std::max(min_update_time, m_manifest->second.ExpiryTime())
-                                                                :min_update_time;
-        m_extraPullObjects.push_back(SegmentAvailability(time_to_update, 0s, m_manifest->second.getFetchedUrl(),
-                                                         m_mpd.availabilityEndTime()));
+        if (resend_at.time_since_epoch().count() == 0 || min_update_time < resend_at) {
+            resend_at = min_update_time;
+            force_recache = true; // always force update fetch at update period
+        }
+    }
+    if (resend_at.time_since_epoch().count() != 0) {
+        m_extraPullObjects.emplace_back(resend_at, 0s, m_manifest->second.getFetchedUrl(),
+                                        m_mpd.availabilityEndTime(), force_recache, true, __get_compress_mpd());
     }
 }
 
-void DASHManifestHandler::removeExtraPullObjectsEntry(const SegmentAvailability &segment)
+void DASHManifestHandler::removeExtraPullObjectsEntry(const DASHManifestHandler::SegmentEntry &segment)
 {
-    m_extraPullObjects.remove_if([&segment](const SegmentAvailability &item){ return item.segmentURL() == segment.segmentURL(); });
+    m_extraPullObjects.remove_if([&segment](const SegmentEntry &item){ return item.segmentURL() == segment.segmentURL(); });
 }
 
 std::string DASHManifestHandler::nextObjectId()
@@ -204,14 +267,135 @@ bool DASHManifestHandler::update(const std::shared_ptr<ObjectStore::Object> &new
             ogs_debug("New MPD update, changing MPD");
             m_mpd = new_mpd;
             m_manifest = new_manifest;
-            m_mpd.selectAllRepresentations();
-            //SelectedInitialistionSegments(): For everything init segments in the list schedule an ingester.
-            m_extraPullObjects = m_mpd.selectedInitializationSegments();
         }
     }
     addMPDRefreshToExtraPullObjects();
 
     return true; // update completed successfully
+}
+
+bool DASHManifestHandler::parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter)
+{
+    if (section_name == "dashManifestHandler") {
+        Open5GSYamlIter dash_iter(iter);
+        while (dash_iter.next()) {
+            std::string dash_key(dash_iter.key());
+            if (dash_key == "compressMPDOnSend") {
+                Open5GSYamlIter dash_compress_iter(dash_iter);
+                if (dash_compress_iter.type() == YAML_SCALAR_NODE) {
+                    __set_compress_mpd(dash_compress_iter.valueBool());
+                } else {
+                    throw std::out_of_range("Bad data type in configuration at mbstf.dashManifestHandler.compressMPDOnSend");
+                }
+            } else if (dash_key == "mpdRepetitionRate") {
+                Open5GSYamlIter dash_rep_rate_iter(dash_iter);
+                if (dash_rep_rate_iter.type() == YAML_SCALAR_NODE) {
+                    __set_repetition_rate(dash_rep_rate_iter.value());
+                } else {
+                    throw std::out_of_range("Bad data type in configuration at mbstf.dashManifestHandler.mpdRepetitionRate");
+                }
+            } else {
+                ogs_warn("Unknown key `mbstf.dashManifestHandler.%s` in configuration", dash_key.c_str());
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+void DASHManifestHandler::tidyConfiguration()
+{
+    __tidy_config();
+}
+
+bool DASHManifestHandler::compressManifestOnSend() const
+{
+    return __get_compress_mpd();
+}
+
+std::list<DASHManifestHandler::SegmentEntry> DASHManifestHandler::augmentSegmentAvailabilityList(
+                                                        std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> &&segments,
+                                                        bool force_recache, bool keep_after_send, bool compress_entry)
+{
+    std::list<SegmentEntry> result;
+    while (!segments.empty()) {
+        auto &seg = segments.front();
+        result.emplace_back(std::move(seg), force_recache, keep_after_send, compress_entry);
+        segments.pop_front();
+    }
+    return result;
+}
+
+/********** DASHManifestHandler::SegmentEntry ************/
+DASHManifestHandler::SegmentEntry::SegmentEntry()
+    :LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)()
+    ,m_forceRecache(false)
+    ,m_keepAfterSend(false)
+    ,m_compressFile(false)
+{
+}
+
+DASHManifestHandler::SegmentEntry::SegmentEntry(const DASHManifestHandler::SegmentEntry &other)
+    :LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)(other)
+    ,m_forceRecache(other.m_forceRecache)
+    ,m_keepAfterSend(other.m_keepAfterSend)
+    ,m_compressFile(other.m_compressFile)
+{
+}
+
+DASHManifestHandler::SegmentEntry::SegmentEntry(DASHManifestHandler::SegmentEntry &&other)
+    :LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)(std::move(other))
+    ,m_forceRecache(other.m_forceRecache)
+    ,m_keepAfterSend(other.m_keepAfterSend)
+    ,m_compressFile(other.m_compressFile)
+{
+}
+
+DASHManifestHandler::SegmentEntry::SegmentEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &seg_avail, bool force_recache,
+                                                bool keep_after_send, bool compress_entry)
+    :LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)(seg_avail)
+    ,m_forceRecache(force_recache)
+    ,m_keepAfterSend(keep_after_send)
+    ,m_compressFile(compress_entry)
+{
+}
+
+DASHManifestHandler::SegmentEntry::SegmentEntry(LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &&seg_avail, bool force_recache,
+                                                bool keep_after_send, bool compress_entry)
+    :LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)(std::move(seg_avail))
+    ,m_forceRecache(force_recache)
+    ,m_keepAfterSend(keep_after_send)
+    ,m_compressFile(compress_entry)
+{
+}
+
+DASHManifestHandler::SegmentEntry::SegmentEntry(
+                                const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::time_type) &availability_start,
+                                const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::duration_type) &segment_length,
+                                const LIBMPDPP_NAMESPACE_CLASS(URI) &segment_url,
+                                const std::optional<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::time_type)> &availability_end,
+                                bool force_recache, bool keep_after_send, bool compress_entry)
+    :LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)(availability_start, segment_length, segment_url, availability_end)
+    ,m_forceRecache(force_recache)
+    ,m_keepAfterSend(keep_after_send)
+    ,m_compressFile(compress_entry)
+{
+}
+
+DASHManifestHandler::SegmentEntry &DASHManifestHandler::SegmentEntry::operator=(const DASHManifestHandler::SegmentEntry &other) {
+    LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::operator=)(other);
+    m_forceRecache = other.m_forceRecache;
+    m_keepAfterSend = other.m_keepAfterSend;
+    m_compressFile = other.m_compressFile;
+    return *this;
+}
+
+DASHManifestHandler::SegmentEntry &DASHManifestHandler::SegmentEntry::operator=(DASHManifestHandler::SegmentEntry &&other) {
+    LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::operator=)(std::move(other));
+    m_forceRecache = other.m_forceRecache;
+    m_keepAfterSend = other.m_keepAfterSend;
+    m_compressFile = other.m_compressFile;
+    return *this;
 }
 
 static bool g_registered = ManifestHandlerFactory::registerManifestHandler("application/dash+xml", new ManifestHandlerConstructorClass<DASHManifestHandler>());
@@ -222,8 +406,6 @@ static LIBMPDPP_NAMESPACE_CLASS(MPD) ingest_manifest(const std::shared_ptr<Objec
          throw std::invalid_argument("Does not look like a DASH Manifest as the media type is invalid. Expected media type: application/dash+xml");
     }
     return LIBMPDPP_NAMESPACE_CLASS(MPD) (new_manifest->first, new_manifest->second.getFetchedUrl());
-
-
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DASHManifestHandler.hh
+++ b/src/mbstf/DASHManifestHandler.hh
@@ -21,6 +21,7 @@
 #include "common.hh"
 #include "ManifestHandler.hh"
 #include "ObjectStore.hh"
+#include "Open5GSYamlIter.hh"
 #include "PullObjectIngester.hh"
 
 MBSTF_NAMESPACE_START
@@ -41,19 +42,59 @@ public:
     virtual ManifestHandler::durn_type getDefaultDeadline();
     virtual bool update(const std::shared_ptr<ObjectStore::Object> &new_manifest);
     virtual std::string nextObjectId();
+    virtual bool compressManifestOnSend() const;
+
     static unsigned int factoryPriority() { return 100; };
+    static bool parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter);
+    static void tidyConfiguration();
 
 private:
+    class SegmentEntry : public LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) {
+    public:
+        SegmentEntry();
+        SegmentEntry(const SegmentEntry &other);
+        SegmentEntry(SegmentEntry &&other);
+        SegmentEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &seg_avail, bool force_recache, bool keep_after_send,
+                     bool compress_entry);
+        SegmentEntry(LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &&seg_avail, bool force_recache, bool keep_after_send,
+                     bool compress_entry);
+        SegmentEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::time_type) &availability_start,
+                     const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::duration_type) &segment_length,
+                     const LIBMPDPP_NAMESPACE_CLASS(URI) &segment_url,
+                     const std::optional<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability::time_type)> &availability_end = std::nullopt,
+                     bool force_recache = false, bool keep_after_send = false, bool compress_entry = false);
+
+        virtual ~SegmentEntry() {};
+
+        SegmentEntry &operator=(const SegmentEntry &other);
+        SegmentEntry &operator=(SegmentEntry &&other);
+
+        bool forceRecache() const { return m_forceRecache; };
+        SegmentEntry &forceRecache(bool force_recache) { m_forceRecache = force_recache; return *this; };
+
+        bool keepAfterSend() const { return m_keepAfterSend; };
+        SegmentEntry &keepAfterSend(bool keep_after_send) { m_keepAfterSend = keep_after_send; return *this; };
+
+        bool compressEntry() const { return m_compressFile; };
+        SegmentEntry &compressEntry(bool compress_file) { m_compressFile = compress_file; return *this; };
+
+    private:
+        bool m_forceRecache;
+        bool m_keepAfterSend;
+        bool m_compressFile;
+    };
+
     std::string generateUUID();
     void addMPDRefreshToExtraPullObjects();
-    void removeExtraPullObjectsEntry(const LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability) &segment);
+    void removeExtraPullObjectsEntry(const SegmentEntry &segment);
+    std::list<SegmentEntry> augmentSegmentAvailabilityList(std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> &&segments, bool force_recache = false, bool keep_after_send = false, bool compress_entry = false);
 
     std::recursive_mutex m_mpdMutex;
     LIBMPDPP_NAMESPACE_CLASS(MPD)  m_mpd;
     std::shared_ptr<ObjectStore::Object> m_manifest;
     bool m_refreshMpd;
     ManifestHandler::time_type m_mpdReceivedTime;
-    std::list<LIBMPDPP_NAMESPACE_CLASS(SegmentAvailability)> m_extraPullObjects;
+    std::list<SegmentEntry> m_extraPullObjects;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/DistributionSession.cc
+++ b/src/mbstf/DistributionSession.cc
@@ -729,12 +729,12 @@ DistributionSession &DistributionSession::distributionSessionReqData(const std::
     m_createReqData = new_create_req_data;
 
     /* Reconfigure the controller using the new CreateReqData */
-    if (m_controller) {
-        m_controller->reconfigure();
-    }
+    //if (m_controller) {
+    //    m_controller->reconfigure();
+    //}
 
     /* Make sure we are in the right state */
-    const auto &old_state = old_dist_session->getDistSessionState();
+    //const auto &old_state = old_dist_session->getDistSessionState();
     const auto &new_state = new_dist_session->getDistSessionState();
     auto new_state_enum = new_state->getValue();
     if (new_state_enum == DistSessionState::VAL_INACTIVE || new_state_enum == DistSessionState::VAL_DEACTIVATING) {

--- a/src/mbstf/ManifestHandler.hh
+++ b/src/mbstf/ManifestHandler.hh
@@ -63,6 +63,10 @@ public:
     virtual durn_type getDefaultDeadline() = 0;
     virtual bool update(const std::shared_ptr<ObjectStore::Object> &new_manifest) = 0;
     virtual void startedFetch(const PullObjectIngester::IngestItem &item) {};
+    virtual bool compressManifestOnSend() const { return false; };
+
+    //static bool parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter);
+    //static void tidyConfiguration();
 
 protected:
    ObjectController *m_controller;

--- a/src/mbstf/ManifestHandlerFactory.cc
+++ b/src/mbstf/ManifestHandlerFactory.cc
@@ -19,6 +19,7 @@
 #include "ObjectStore.hh"
 
 #include "ManifestHandlerFactory.hh"
+#include "MimeContentType.hh"
 
 MBSTF_NAMESPACE_START
 
@@ -30,16 +31,17 @@ namespace {
         };
     } g_factoryCompare;
 
-    static std::map<std::string, std::list<std::unique_ptr<ManifestHandlerConstructor> > > &constructorsByContentType()
+    static std::map<MimeContentType, std::list<std::unique_ptr<ManifestHandlerConstructor> > > &constructorsByContentType()
     {
-         static std::map<std::string, std::list<std::unique_ptr<ManifestHandlerConstructor> > > g_constructorsByContentType;
+         static std::map<MimeContentType, std::list<std::unique_ptr<ManifestHandlerConstructor> > > g_constructorsByContentType;
          return g_constructorsByContentType;
     }
 }
 
-bool ManifestHandlerFactory::registerManifestHandler(const std::string &content_type, ManifestHandlerConstructor *manifest_handler_constructor)
+bool ManifestHandlerFactory::registerManifestHandler(const std::string &content_type_str, ManifestHandlerConstructor *manifest_handler_constructor)
 {
     // Find the prioritised list for the content_type, make new list of one doesn't exist
+    MimeContentType content_type(content_type_str);
     std::list<std::unique_ptr<ManifestHandlerConstructor> > &list = constructorsByContentType()[content_type];
     // Make the value to store in the list (take ownership of manifest_handler_constructor)
     std::unique_ptr<ManifestHandlerConstructor> cc(manifest_handler_constructor);
@@ -51,8 +53,8 @@ bool ManifestHandlerFactory::registerManifestHandler(const std::string &content_
 
 ManifestHandler *ManifestHandlerFactory::makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller, bool pull_distribution)
 {
-    std::string media_type = object->second.mediaType();
-    ogs_debug("Looking for manifest handler for \"%s\" media", media_type.c_str());
+    MimeContentType media_type(object->second.mediaType());
+    ogs_debug("%s", std::format("Looking for manifest handler for \"{}\" media", media_type).c_str());
     // Try manifest handlers for the media type of the object, fallback to any media type (empty string)
     while (true) {
         auto it = constructorsByContentType().find(media_type);
@@ -74,6 +76,25 @@ ManifestHandler *ManifestHandlerFactory::makeManifestHandler(const std::shared_p
         media_type.clear();
     }
     return nullptr;
+}
+
+bool ManifestHandlerFactory::parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter)
+{
+    for (const auto &[mime_type, constructors] : constructorsByContentType()) {
+        for (const auto &constructor : constructors) {
+            if (constructor->parseConfiguration(section_name, iter)) return true;
+        }
+    }
+    return false;
+}
+
+void ManifestHandlerFactory::tidyConfigurations()
+{
+    for (const auto &[mime_type, constructors] : constructorsByContentType()) {
+        for (const auto &constructor : constructors) {
+            constructor->tidyConfiguration();
+        }
+    }
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ManifestHandlerFactory.hh
+++ b/src/mbstf/ManifestHandlerFactory.hh
@@ -14,6 +14,7 @@
 
 #include "common.hh"
 #include "ObjectStore.hh"
+#include "Open5GSYamlIter.hh"
 
 MBSTF_NAMESPACE_START
 
@@ -25,6 +26,8 @@ public:
     virtual unsigned int priority() = 0;
     virtual ManifestHandler *makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller,
                                                  bool pull_distribution) = 0;
+    virtual bool parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter) = 0;
+    virtual void tidyConfiguration() = 0;
 };
 
 template <class H>
@@ -37,6 +40,12 @@ public:
                                                  bool pull_distribution) {
         return new manifest_handler(object, controller, pull_distribution);
     }
+    virtual bool parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter) {
+        return H::parseConfiguration(section_name, iter);
+    }
+    virtual void tidyConfiguration() {
+        H::tidyConfiguration();
+    }
 };
 
 class ManifestHandlerFactory {
@@ -44,6 +53,8 @@ public:
     static bool registerManifestHandler(const std::string &content_type, ManifestHandlerConstructor *manifest_handler_constructor);
     static ManifestHandler *makeManifestHandler(const std::shared_ptr<ObjectStore::Object> &object, ObjectController *controller,
                                                 bool pull_distribution);
+    static bool parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter);
+    static void tidyConfigurations();
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/MimeContentType.cc
+++ b/src/mbstf/MimeContentType.cc
@@ -1,0 +1,320 @@
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: MIME Content Type
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author: David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "ogs-sbi.h"
+
+#include <compare>
+#include <map>
+#include <string>
+
+#include "common.hh"
+#include "CaseInsensitiveTraits.hh"
+
+#include "MimeContentType.hh"
+
+MBSTF_NAMESPACE_START
+
+static std::string _quote(const std::string &str);
+
+MimeContentType::MimeContentType()
+    :m_mimeType()
+    ,m_mimeTypeLower()
+    ,m_typeParams()
+{
+}
+
+MimeContentType::MimeContentType(const std::string &content_type)
+    :m_mimeType()
+    ,m_mimeTypeLower()
+    ,m_typeParams()
+{
+    *this = content_type;
+}
+
+MimeContentType::MimeContentType(const MimeContentType &other)
+    :m_mimeType(other.m_mimeType)
+    ,m_mimeTypeLower(other.m_mimeTypeLower)
+    ,m_typeParams(other.m_typeParams)
+{
+}
+
+MimeContentType::MimeContentType(MimeContentType &&other)
+    :m_mimeType(std::move(other.m_mimeType))
+    ,m_mimeTypeLower(std::move(other.m_mimeTypeLower))
+    ,m_typeParams(std::move(other.m_typeParams))
+{
+}
+
+MimeContentType &MimeContentType::operator=(const std::string &content_type)
+{
+    // Parse media-type according to rfc9110
+    int state = 0;
+    m_mimeType.clear();
+    m_mimeTypeLower.clear();
+    m_typeParams.clear();
+    std::string key;
+    std::string value;
+    static const std::string unquoted_token_chars{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~"};
+    for (auto c : content_type) {
+retry_ct_char:
+        switch (state) {
+        case 0:
+            // preamble whitespace
+            if (!std::isspace(c)) {
+                state = 1;
+                goto retry_ct_char;
+            }
+            break;
+        case 1:
+            // Start of media-type - must be a token char
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                m_mimeType += c;
+                m_mimeTypeLower += std::tolower(c);
+                state = 2;
+            } else {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 2:
+            // Continue media-type - token char or /
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                m_mimeType += c;
+                m_mimeTypeLower += std::tolower(c);
+                state = 2;
+            } else if (c == '/') {
+                m_mimeType += c;
+                m_mimeTypeLower += c;
+                state = 3;
+            } else {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 3:
+            // Start of media-type subtype - must be a token char
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                m_mimeType += c;
+                m_mimeTypeLower += std::tolower(c);
+                state = 4;
+            } else {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 4:
+            // Continue media-type subtype - token char, space or ;
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                m_mimeType += c;
+                m_mimeTypeLower += std::tolower(c);
+            } else if (c == ';') {
+                state = 6;
+            } else if (std::isspace(c)) {
+                state = 5;
+            } else {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 5:
+            // Optional parameters - *(OWS ";" OWS [parameter])
+            if (c == ';') {
+                state = 6;
+            } else if (!std::isspace(c)) {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 6:
+            // Found ";" in parameters - OWS [parameter] *(OWS ";" OWS [parameter])
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                key += c;
+                state = 7;
+            } else if (c != ';' && !std::isspace(c)) {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 7:
+            // Found parameter (key already started) - token "=" (token | quoted-string)
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                key += c;
+            } else if (c == '=') {
+                state = 8;
+            } else {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 8:
+            // parameter-value - (token | quoted-string)
+            if (c == '"') {
+                state = 10;
+            } else if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                state = 9;
+                value += c;
+            } else {
+                throw std::out_of_range("Bad Content-Type value");
+            }
+            break;
+        case 9:
+            // parameter-value token (continued) - token *(OWS ";" OWS [parameter])
+            if (unquoted_token_chars.find_first_of(c) != std::string::npos) {
+                value += c;
+            } else if (c == ';') {
+                m_typeParams[key] = value;
+                key.clear();
+                value.clear();
+                state = 6;
+            } else if (std::isspace(c)) {
+                m_typeParams[key] = value;
+                key.clear();
+                value.clear();
+                state = 5;
+            }
+            break;
+        case 10:
+            // quoted-string parameter value
+            if (c == '"') {
+                m_typeParams[key] = value;
+                key.clear();
+                value.clear();
+                state = 5;
+            } else if (c == '\\') {
+                state = 11;
+            } else {
+                value += c;
+            }
+            break;
+        case 11:
+            // quoted-string parameter value, quoted-pair
+            value += c;
+            state = 10;
+            break;
+        default:
+            throw std::runtime_error("Bad parser state for Content-Type");
+        }
+    }
+    // Complete the paraeter-value token and 
+    if (state == 9) {
+        m_typeParams[key] = value;
+        state = 5;
+    }
+
+    // If we are not in a valid finishing state, then parse error
+    if (state != 4 && state != 5 && state != 6) {
+        throw std::out_of_range("Bad Content-Type value");
+    }
+
+    return *this;
+}
+
+MimeContentType &MimeContentType::operator=(const MimeContentType &other)
+{
+    m_mimeType = other.m_mimeType;
+    m_mimeTypeLower = other.m_mimeTypeLower;
+    m_typeParams = other.m_typeParams;
+    return *this;
+}
+
+MimeContentType &MimeContentType::operator=(MimeContentType &&other)
+{
+    m_mimeType = std::move(other.m_mimeType);
+    m_mimeTypeLower = std::move(other.m_mimeTypeLower);
+    m_typeParams = std::move(other.m_typeParams);
+    return *this;
+}
+
+std::weak_ordering MimeContentType::operator<=>(const MimeContentType &other) const
+{
+    auto result = (m_mimeType <=> other.m_mimeType);
+    if (result < 0) return std::weak_ordering::less;
+    if (result > 0) return std::weak_ordering::greater;
+
+    for (const auto &[key, value] : m_typeParams) {
+        if (other.hasParameter(key)) {
+            auto result = (value <=> other.parameter(key));
+            if (result < 0) return std::weak_ordering::less;
+            if (result > 0) return std::weak_ordering::greater;
+        } else {
+            return std::weak_ordering::greater;
+        }
+    }
+
+    return std::weak_ordering::equivalent;
+}
+
+bool MimeContentType::hasParameter(const std::string &param_key) const
+{
+    return m_typeParams.find(param_key) != m_typeParams.end();
+}
+
+const std::string &MimeContentType::parameter(const std::string &param_key) const
+{
+    auto it = m_typeParams.find(param_key);
+    if (it != m_typeParams.end()) return it->second;
+    throw std::out_of_range(std::format("Parameter {} not found in Content-Type parameters", param_key));
+}
+
+MimeContentType &MimeContentType::parameter(const std::string &param_key, const std::string &param_value)
+{
+    m_typeParams[param_key] = param_value;
+    return *this;
+}
+
+std::size_t MimeContentType::hash() const
+{
+    std::hash<std::string> sh;
+    return sh(m_mimeTypeLower);
+}
+
+MimeContentType::operator std::string() const
+{
+    std::string result(std::string_view(m_mimeType.data(), m_mimeType.size()));
+    for (const auto &[key,value] : m_typeParams) {
+        result += std::format("; {}={}", key, _quote(value));
+    }
+    return result;
+}
+
+static std::string _quote(const std::string &str)
+{
+    std::string result;
+    static const char unquoted_token_chars[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`{|}~";
+    if (str.find_first_not_of(unquoted_token_chars) != std::string::npos) {
+        result += '"';
+        for (char c : str) {
+            if (c == '\\' || c == '"') {
+                result += '\\';
+            }
+            result += c;
+        }
+        result += '"';
+    } else {
+        result = str;
+    }
+    return result;
+}
+
+MBSTF_NAMESPACE_STOP
+
+namespace std {
+
+std::size_t hash<MBSTF_NAMESPACE_NAME(MimeContentType)>::operator()(const MBSTF_NAMESPACE_NAME(MimeContentType) &val) const
+{
+    return val.hash();
+}
+
+}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/mbstf/MimeContentType.hh
+++ b/src/mbstf/MimeContentType.hh
@@ -1,0 +1,100 @@
+#ifndef _MBS_TF_MIME_CONTENT_TYPE_HH_
+#define _MBS_TF_MIME_CONTENT_TYPE_HH_
+/******************************************************************************
+ * 5G-MAG Reference Tools: MBS Transport Function: MIME Content Type
+ ******************************************************************************
+ * Copyright: (C)2025 British Broadcasting Corporation
+ * Author: David Waring <david.waring2@bbc.co.uk>
+ * License: 5G-MAG Public License v1
+ *
+ * Licensed under the License terms and conditions for use, reproduction, and
+ * distribution of 5G-MAG software (the “License”).  You may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ * https://www.5g-mag.com/reference-tools.  Unless required by applicable law or
+ * agreed to in writing, software distributed under the License is distributed on
+ * an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "ogs-sbi.h"
+
+#include <compare>
+#include <format>
+#include <map>
+#include <string>
+
+#include "common.hh"
+#include "CaseInsensitiveTraits.hh"
+
+MBSTF_NAMESPACE_START
+
+class MimeContentType
+{
+public:
+    using cistring = std::basic_string<char, CaseInsensitiveTraits<char>>;
+    MimeContentType();
+    MimeContentType(const std::string &content_type);
+    MimeContentType(const MimeContentType &other);
+    MimeContentType(MimeContentType &&other);
+
+    virtual ~MimeContentType() {};
+
+    MimeContentType &operator=(const std::string &content_type);
+    MimeContentType &operator=(const MimeContentType &other);
+    MimeContentType &operator=(MimeContentType &&other);
+
+    std::weak_ordering operator<=>(const MimeContentType &other) const;
+    bool operator==(const MimeContentType &other) const { return (*this <=> other) == 0; };
+    bool operator!=(const MimeContentType &other) const { return (*this <=> other) != 0; };
+    bool operator<(const MimeContentType &other) const { return (*this <=> other) < 0; };
+    bool operator<=(const MimeContentType &other) const { return (*this <=> other) <= 0; };
+    bool operator>(const MimeContentType &other) const { return (*this <=> other) > 0; };
+    bool operator>=(const MimeContentType &other) const { return (*this <=> other) >= 0; };
+
+    const cistring &mimeType() const { return m_mimeType; };
+    MimeContentType &mimeType(const cistring &mime_type) { m_mimeType = mime_type; return *this; };
+
+    bool hasParameter(const std::string &param_key) const;
+    const std::string &parameter(const std::string &param_key) const;
+    MimeContentType &parameter(const std::string &param_key, const std::string &param_value);
+
+    std::size_t hash() const;
+
+    bool empty() const { return m_mimeType.empty() && m_typeParams.empty(); };
+    MimeContentType &clear() { m_mimeType.clear(); m_typeParams.clear(); return *this; };
+
+    operator std::string() const;
+
+private:
+    cistring m_mimeType;
+    std::string m_mimeTypeLower;
+    std::map<std::string, std::string> m_typeParams;
+};
+
+MBSTF_NAMESPACE_STOP
+
+namespace std {
+    template<>
+    struct formatter<MBSTF_NAMESPACE_NAME(MimeContentType), char> {
+        template <class ParseContext>
+        constexpr ParseContext::iterator parse(ParseContext& ctx) {
+            return ctx.begin();
+        };
+        template <class FmtContext>
+        FmtContext::iterator format(MBSTF_NAMESPACE_NAME(MimeContentType) content_type, FmtContext& ctx) const {
+            return std::format_to(ctx.out(), "{}", static_cast<std::string>(content_type));
+        };
+    };
+
+    template<>
+    struct hash<MBSTF_NAMESPACE_NAME(MimeContentType)> {
+        std::size_t operator()(const MBSTF_NAMESPACE_NAME(MimeContentType) &val) const;
+    };
+}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+#endif

--- a/src/mbstf/ObjectCarouselController.cc
+++ b/src/mbstf/ObjectCarouselController.cc
@@ -52,9 +52,6 @@ using fiveg_mag_reftools::ProblemCause;
 MBSTF_NAMESPACE_START
 
 static void validate_distribution_session(DistributionSession &distribution_session);
-static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, std::string &manifest_url);
-static bool check_if_object_is_active_in_manifest(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
-static void finish_request_in_manifest_handler(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler);
 
 ObjectCarouselController::ObjectCarouselController(DistributionSession &distribution_session)
     :ObjectManifestController(distribution_session)
@@ -62,7 +59,7 @@ ObjectCarouselController::ObjectCarouselController(DistributionSession &distribu
     ogs_debug("ObjectCarouselController validating DistributionSession");
     validate_distribution_session(distribution_session);
     ogs_debug("ObjectCarouselController subscribe to ObjectStore");
-    subscribeToService(objectStore());
+    subscribeToService(*objectStore());
     ogs_debug("ObjectCarouselController active");
 }
 
@@ -85,11 +82,6 @@ void ObjectCarouselController::setObjectPackager()
     updateCarousel();
 }
 
-void ObjectCarouselController::unsetObjectPackager()
-{
-    packager(nullptr);
-}
-
 void ObjectCarouselController::activateObjectPackager() {
     packager()->activate();
     startWorker();
@@ -106,58 +98,16 @@ std::shared_ptr<ObjectCarouselPackager> ObjectCarouselController::getObjectCarou
     return std::dynamic_pointer_cast<ObjectCarouselPackager>(packager());
 }
 
-void ObjectCarouselController::processEvent(Event &event, SubscriptionService &event_service)
+void ObjectCarouselController::objectAddOrUpdateEvent(const std::shared_ptr<ObjectStore::Object> &object)
 {
-    if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
-        event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
-
-        ObjectStore::ObjectChangedEvent &obj_added_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
-        std::string object_id = obj_added_event.objectId();
-        ogs_debug("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
-        try {
-            const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
-            ogs_debug("Object location: %s", object->second.getFetchedUrl().c_str());
-            object->second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
-            if (check_if_object_added_is_manifest(object, getManifestUrl())) {
-                if (manifestHandler()) {
-                    try {
-                        if (!manifestHandler()->update(object)) {
-                            ogs_error("Failed to update Manifest");
-                            unsetObjectListPackager();
-                            event.stopProcessing();
-                            return;
-                        }
-                        startWorker();
-                    } catch (std::exception &ex) {
-                        ogs_error("Invalid Manifest update: %s", ex.what());
-                        unsetObjectListPackager();
-                        event.stopProcessing();
-                        return;
-                    }
-                } else {
-                    std::shared_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
-                    if (!manifest_handler) {
-                        throw std::runtime_error("Could not find suitable manifest handler");
-                    }
-                    manifestHandler(std::move(manifest_handler));
-                }
-            } else if (check_if_object_is_active_in_manifest(object, manifestHandler())) {
-                finish_request_in_manifest_handler(object, manifestHandler());
-                sendToPackager(object_id);
-            }
-        } catch (std::out_of_range &ex) {
-            ogs_error("Object %s is not in the ObjectStore", object_id.c_str());
-        }
-    }
-    ObjectManifestController::processEvent(event, event_service);
+    object->second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
 }
 
-void ObjectCarouselController::sendToPackager(const std::string &object_id)
+void ObjectCarouselController::sendToPackager(const std::shared_ptr<ObjectStore::Object> &object)
 {
     auto packager = getObjectCarouselPackager();
     if (packager) {
         auto manifest_manager = std::dynamic_pointer_cast<ObjectManifestHandler>(manifestHandler());
-        auto &object = objectStore()[object_id];
         ObjectCarouselPackager::PackageItem item(object, manifest_manager);
         packager->add(item);
     }
@@ -210,12 +160,16 @@ void ObjectCarouselController::updateCarousel()
                 }
             }
             if (!found) {
-                /* else (if the object is not added to the packager */
-                const auto &obj_metadata = objectStore().findMetadataByURL(obj.value()->getLocator());
-                if (obj_metadata) {
-                    /* if it is found in the ObjectStore, add it to the packager */
-                    packager->add(ObjectCarouselPackager::PackageItem(objectStore()[obj_metadata->objectId()],
+                /* else (if the object is not added to the packager) */
+                auto object_store = objectStore();
+                if (object_store) {
+                    auto &obj_store = *object_store;
+                    const auto &obj_metadata = obj_store.findMetadataByURL(obj.value()->getLocator());
+                    if (obj_metadata) {
+                        /* if it is found in the ObjectStore, add it to the packager */
+                        packager->add(ObjectCarouselPackager::PackageItem(obj_store[obj_metadata->objectId()],
                                                                       object_manifest_hndlr));
+                    }
                 }
             }
         }
@@ -226,6 +180,21 @@ void ObjectCarouselController::updateCarousel()
         /* this object is no longer in the carousel, so remove it */
         packager->remove(pkg_item);
     }
+}
+
+bool ObjectCarouselController::checkObjectActiveInManifest(const std::shared_ptr<ObjectStore::Object> &object)
+{
+    const auto object_manifest_hndlr = std::dynamic_pointer_cast<const ObjectManifestHandler>(manifestHandler());
+    if (object_manifest_hndlr) {
+        return object_manifest_hndlr->isObjectURLActive(object->second.getOriginalUrl());
+    }
+    return false;
+}
+
+void ObjectCarouselController::finishRequestInManifestHandler(const std::shared_ptr<ObjectStore::Object> &object)
+{
+    auto object_manifest_hndlr = std::dynamic_pointer_cast<ObjectManifestHandler>(manifestHandler());
+    if (object_manifest_hndlr) object_manifest_hndlr->finishRequest(object->second.getOriginalUrl());
 }
 
 namespace {
@@ -242,24 +211,6 @@ static void validate_distribution_session(DistributionSession &distribution_sess
         throw std::logic_error("Expected objDistributionOperatingMode to be set to CAROUSEL.");
     }
     ObjectController::validateDistributionSession(distribution_session);
-}
-
-static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, std::string &manifest_url)
-{
-    auto &metadata = object->second;
-    return (metadata.getOriginalUrl() == manifest_url || metadata.getFetchedUrl() == manifest_url);
-}
-
-static bool check_if_object_is_active_in_manifest(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
-{
-    const auto object_manifest_hndlr = std::dynamic_pointer_cast<const ObjectManifestHandler>(manifest_handler);
-    return object_manifest_hndlr->isObjectURLActive(object->second.getOriginalUrl());
-}
-
-static void finish_request_in_manifest_handler(const std::shared_ptr<ObjectStore::Object> &object, const std::shared_ptr<ManifestHandler> &manifest_handler)
-{
-    auto object_manifest_hndlr = std::dynamic_pointer_cast<ObjectManifestHandler>(manifest_handler);
-    object_manifest_hndlr->finishRequest(object->second.getOriginalUrl());
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectCarouselController.hh
+++ b/src/mbstf/ObjectCarouselController.hh
@@ -47,9 +47,6 @@ public:
 
     static unsigned int factoryPriority() { return 50; };
 
-    // Subscriber virtual methods
-    virtual void processEvent(Event &event, SubscriptionService &event_service);
-
     // Optional: virtual void subscriberRemoved(SubscriptionService &event_service);
     std::string reprString() const {
                 std::ostringstream os;
@@ -57,21 +54,18 @@ public:
                 return os.str();
     }
 
-    void unsetObjectListPackager() {
-        // Reset the shared pointer to release ownership.
-        packager(nullptr);
-    };
-
     virtual void reconfigureObjectPackager();
 
 protected:
     virtual void setObjectPackager();
-    virtual void unsetObjectPackager();
     virtual void activateObjectPackager();
     virtual void deactivateObjectPackager();
+    virtual void objectAddOrUpdateEvent(const std::shared_ptr<ObjectStore::Object> &object);
+    virtual bool checkObjectActiveInManifest(const std::shared_ptr<ObjectStore::Object> &object);
+    virtual void finishRequestInManifestHandler(const std::shared_ptr<ObjectStore::Object> &object);
+    virtual void sendToPackager(const std::shared_ptr<ObjectStore::Object> &object);
 
 private:
-    void sendToPackager(const std::string &object_id);
     void updateCarousel();
 };
 

--- a/src/mbstf/ObjectCarouselPackager.cc
+++ b/src/mbstf/ObjectCarouselPackager.cc
@@ -107,7 +107,7 @@ void ObjectCarouselPackager::PackageItem::startedTransmission(const ObjectCarous
 
 // ObjectCarouselPackager
 
-ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+ObjectCarouselPackager::ObjectCarouselPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                                        const std::list<ObjectCarouselPackager::PackageItem> &objects_to_package,
                                        const SsmPort &ssm_port, uint32_t rate_limit, unsigned short mtu,
                                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
@@ -130,7 +130,7 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
     startScheduler();
 }
 
-ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+ObjectCarouselPackager::ObjectCarouselPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                                        std::list<PackageItem> &&objects_to_package, const SsmPort &ssm_port,
                                        uint32_t rate_limit, unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
@@ -152,7 +152,7 @@ ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, Object
     startScheduler();
 }
 
-ObjectCarouselPackager::ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
+ObjectCarouselPackager::ObjectCarouselPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                                        const SsmPort &ssm_port, uint32_t rate_limit, unsigned short mtu,
                                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, ssm_port, rate_limit, mtu, tunnel_address, tunnel_port)
@@ -326,6 +326,7 @@ void ObjectCarouselPackager::streamsRemoveToi(uint32_t toi)
     std::lock_guard<decltype(m_streamsMutex)::element_type> lock(*m_streamsMutex);
     auto it = m_streams.find(toi);
     if (it != m_streams.end()) {
+        it->second->second.lastSentNow();
         m_streams.erase(it);
         m_packagingUpdateCondVar.notify_all();
     }
@@ -451,7 +452,7 @@ void ObjectCarouselPackager::scheduleCarousel()
                     location = metadata.getFetchedUrl();
                 }
                 if (!file_desc) {
-                    pkg_item.object()->second.fluteFileDescription(new LibFlute::Transmitter::FileDescription(location, pkg_item.object()->first));
+                    metadata.fluteFileDescription(new LibFlute::Transmitter::FileDescription(location, pkg_item.object()->first));
                 } else {
                     /* reset file description information if it's changed */
                     if (file_desc->file_entry().content_location != location) {
@@ -461,6 +462,14 @@ void ObjectCarouselPackager::scheduleCarousel()
                         file_desc->set_content(pkg_item.object()->first);
                     }
                 }
+
+                /* set compression according to the object metadata */
+                if (metadata.compressedSend()) {
+                    file_desc->set_compression(LibFlute::Transmitter::FileDescription::CompressionAlgorithm::COMPRESSION_GZIP);
+                } else {
+                    file_desc->set_compression(LibFlute::Transmitter::FileDescription::CompressionAlgorithm::COMPRESSION_NONE);
+                }
+
                 /* update Cache expiry time */
                 LibFlute::Transmitter::FileDescription::date_time_type default_expiry(LibFlute::Transmitter::FileDescription::date_time_type::clock::now() + 60s);
                 file_desc->set_expiry_time(pkg_item.object()->second.cacheExpires().value_or(std::move(default_expiry)));

--- a/src/mbstf/ObjectCarouselPackager.hh
+++ b/src/mbstf/ObjectCarouselPackager.hh
@@ -81,16 +81,16 @@ public:
     };
 
     ObjectCarouselPackager() = delete;
-    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller,
-                       const std::list<PackageItem> &objects_to_package, const SsmPort &ssm_port,
-                       uint32_t rateLimit, unsigned short mtu,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&objects_to_package,
-                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectCarouselPackager(ObjectStore &object_store, ObjectController &controller, const SsmPort &ssm_port,
-                       uint32_t rateLimit, unsigned short mtu,
-                       const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectCarouselPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
+                           const std::list<PackageItem> &objects_to_package, const SsmPort &ssm_port,
+                           uint32_t rateLimit, unsigned short mtu,
+                           const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectCarouselPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
+                           std::list<PackageItem> &&objects_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
+                           unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectCarouselPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller, const SsmPort &ssm_port,
+                           uint32_t rateLimit, unsigned short mtu,
+                           const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
     virtual ~ObjectCarouselPackager();
 
     bool add(const PackageItem &item);

--- a/src/mbstf/ObjectController.cc
+++ b/src/mbstf/ObjectController.cc
@@ -80,15 +80,16 @@ void ObjectController::processEvent(Event &event, SubscriptionService &event_ser
         std::string object_id = objSendEvent.objectId();
         ogs_info("Object [%s] sent", object_id.c_str());
 
-        const ObjectStore::Metadata &metadata = objectStore().getMetadata(object_id);
+        if (m_objectStore) {
+            const ObjectStore::Metadata &metadata = m_objectStore->getMetadata(object_id);
 
-        if(!metadata.keepAfterSend()) {
-
-            objectStore().deleteObject(object_id);
-        } else {
-            ogs_debug("Keeping object [%s] in object store after sending...", object_id.c_str());
+            if(!metadata.keepAfterSend()) {
+                ogs_debug("Removing object [%s] after sending...", object_id.c_str());
+                m_objectStore->deleteObject(object_id);
+            } else {
+                ogs_debug("Keeping object [%s] in object store after sending...", object_id.c_str());
+            }
         }
-
         if (objSendEvent.queueEmpty()) {
             distributionSession().haveEmptyQueue();
         }
@@ -138,8 +139,10 @@ const std::optional<std::string> &ObjectController::getObjectDistributionBaseUrl
 
 void ObjectController::reconfigureObjectStore()
 {
-    auto &dist_session = distributionSession();
-    m_objectStore->reconfigureMetadatas(dist_session.getObjectIngestBaseUrl(), dist_session.objectDistributionBaseUrl());
+    if (m_objectStore) {
+        auto &dist_session = distributionSession();
+        m_objectStore->reconfigureMetadatas(dist_session.getObjectIngestBaseUrl(), dist_session.objectDistributionBaseUrl());
+    }
 }
 
 void ObjectController::establishInactiveInputs()

--- a/src/mbstf/ObjectController.hh
+++ b/src/mbstf/ObjectController.hh
@@ -42,7 +42,7 @@ public:
         ,m_packager()
         ,m_nextId(1)
         ,m_consecutiveIngestFailures(0)
-    { subscribeTo({"ObjectAdded"}, objectStore()); };
+    { subscribeTo({"ObjectAdded"}, *objectStore()); };
     ObjectController(const ObjectController &) = delete;
     ObjectController(ObjectController &&) = delete;
 
@@ -57,8 +57,8 @@ public:
     ObjectController &operator=(const ObjectController &) = delete;
     ObjectController &operator=(ObjectController &&) = delete;
 
-    const ObjectStore &objectStore() const { return *m_objectStore.get(); };
-    ObjectStore &objectStore() { return *m_objectStore.get(); };
+    const std::shared_ptr<ObjectStore> &objectStore() const { return m_objectStore; };
+    std::shared_ptr<ObjectStore> &objectStore() { return m_objectStore; };
 
     const std::list<std::shared_ptr<PullObjectIngester>> &getPullObjectIngesters() const {return m_pullIngesters;};
 
@@ -101,7 +101,7 @@ protected:
     virtual void initPushObjectIngester() = 0;
     virtual void initPullObjectIngesters() = 0;
     virtual void setObjectPackager() = 0;
-    virtual void unsetObjectPackager() = 0;
+    virtual void unsetObjectPackager() { m_packager.reset(); };
     virtual void activateObjectPackager() = 0;
     virtual void deactivateObjectPackager() = 0;
 

--- a/src/mbstf/ObjectIngester.hh
+++ b/src/mbstf/ObjectIngester.hh
@@ -64,7 +64,7 @@ public:
     };
 
     ObjectIngester() = delete;
-    ObjectIngester(ObjectStore &objectStore, ObjectController &controller)
+    ObjectIngester(const std::shared_ptr<ObjectStore> &objectStore, ObjectController &controller)
         : SubscriptionService(), m_objectStore(objectStore), m_controller(controller), m_workerThread(), m_workerCancel(false) {}
 
     void abort() {
@@ -82,8 +82,8 @@ public:
     bool workerCancelled() const { return m_workerCancel; };
 
 protected:
-    ObjectStore &objectStore() { return m_objectStore; }
-    const ObjectStore &objectStore() const { return m_objectStore; }
+    std::shared_ptr<ObjectStore> &objectStore() { return m_objectStore; }
+    const std::shared_ptr<ObjectStore> &objectStore() const { return m_objectStore; }
     ObjectController &controller() { return m_controller; }
     const ObjectController &controller() const { return m_controller; }
     void startWorker(){m_workerThread = std::thread(workerLoop, this);};
@@ -96,7 +96,7 @@ protected:
 
 private:
     static void workerLoop(ObjectIngester*);
-    ObjectStore &m_objectStore;
+    std::shared_ptr<ObjectStore> m_objectStore;
     ObjectController &m_controller;
     std::thread m_workerThread;
     std::atomic_bool m_workerCancel;

--- a/src/mbstf/ObjectListController.cc
+++ b/src/mbstf/ObjectListController.cc
@@ -62,7 +62,7 @@ ObjectListController::ObjectListController(DistributionSession &distributionSess
         throw std::runtime_error("Invalid Distribution Session");
     }
 
-    subscribeToService(objectStore());
+    subscribeToService(*objectStore());
     subscribeTo({PullObjectIngester::ObjectPullQueueExhaustedEvent::event_name}, *this);
 }
 
@@ -71,16 +71,19 @@ ObjectListController::~ObjectListController()
 }
 
 void ObjectListController::setObjectPackager() {
-    auto ssm_port = distributionSession().getSsmPort();
-    std::optional<std::string> tunnel_addr = distributionSession().getTunnelAddr();
-    uint32_t rate_limit = distributionSession().getRateLimit();
-    in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
-    unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port, GET_MTU_ETHERNET_PAYLOAD) - GTP_HEADER_SIZE;
-    const auto &obj_list = objectStore().getObjects();
-    packager(new ObjectListPackager(objectStore(), *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
-    // Send all objects that are in the ObjectStore
-    for (const auto &[obj_id, object] : obj_list) {
-        sendToPackager(object);
+    auto object_store = objectStore();
+    if (object_store) {
+        auto ssm_port = distributionSession().getSsmPort();
+        std::optional<std::string> tunnel_addr = distributionSession().getTunnelAddr();
+        uint32_t rate_limit = distributionSession().getRateLimit();
+        in_port_t tunnel_port = distributionSession().getTunnelPortNumber();
+        unsigned short mtu = get_tunnelled_path_mtu(ssm_port, tunnel_addr, tunnel_port, GET_MTU_ETHERNET_PAYLOAD) - GTP_HEADER_SIZE;
+        const auto &obj_list = object_store->getObjects();
+        packager(new ObjectListPackager(object_store, *this, ssm_port, rate_limit, mtu, tunnel_addr, tunnel_port));
+        // Send all objects that are in the ObjectStore
+        for (const auto &[obj_id, object] : obj_list) {
+            sendToPackager(object);
+        }
     }
 }
 
@@ -91,10 +94,6 @@ void ObjectListController::sendToPackager(const std::shared_ptr<ObjectStore::Obj
         ObjectListPackager::PackageItem item(object);
         packager->add(item);
     }
-}
-
-void ObjectListController::unsetObjectPackager() {
-    packager(nullptr);
 }
 
 void ObjectListController::activateObjectPackager() {
@@ -120,7 +119,7 @@ void ObjectListController::processEvent(Event &event, SubscriptionService &event
         std::string object_id = obj_changed_event.objectId();
         ogs_info("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
 
-        sendToPackager(objectStore()[object_id]);
+        sendToPackager((*objectStore())[object_id]);
     } else if (event.eventName() == "ObjectPushStart") {
         PushObjectIngester::ObjectPushEvent &obj_push_event = dynamic_cast<PushObjectIngester::ObjectPushEvent&>(event);
         const PushObjectIngester::Request &request(obj_push_event.request());
@@ -189,7 +188,7 @@ void ObjectListController::initPullObjectIngesters()
 
                 }
 
-                const auto *metadata = objectStore().findMetadataByURL(obj_ingest_url);
+                const auto *metadata = objectStore()->findMetadataByURL(obj_ingest_url);
                 if (metadata) {
                     /* refetch existing object */
                     urls.emplace_back(*metadata);

--- a/src/mbstf/ObjectListController.hh
+++ b/src/mbstf/ObjectListController.hh
@@ -67,7 +67,6 @@ protected:
     virtual void initPushObjectIngester();
     virtual void initPullObjectIngesters();
     virtual void setObjectPackager();
-    virtual void unsetObjectPackager();
     virtual void activateObjectPackager();
     virtual void deactivateObjectPackager();
 

--- a/src/mbstf/ObjectListPackager.cc
+++ b/src/mbstf/ObjectListPackager.cc
@@ -80,7 +80,7 @@ ObjectListPackager::PackageItem &ObjectListPackager::PackageItem::operator=(Pack
 
 // ObjectListPackager
 
-ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
+ObjectListPackager::ObjectListPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                                        const std::list<PackageItem> &object_to_package, const SsmPort &ssm_port,
                                        uint32_t rateLimit, unsigned short mtu, const std::optional<std::string> &tunnel_address,
                                        in_port_t tunnel_port)
@@ -96,7 +96,7 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
     startWorker();
 }
 
-ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
+ObjectListPackager::ObjectListPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                                        std::list<PackageItem> &&object_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
                                        unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
@@ -111,7 +111,7 @@ ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectControll
     startWorker();
 }
 
-ObjectListPackager::ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
+ObjectListPackager::ObjectListPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                                        const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
                                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port)
     :ObjectPackager(object_store, controller, ssm_port, rateLimit, mtu, tunnel_address, tunnel_port)
@@ -220,6 +220,7 @@ void ObjectListPackager::doObjectPackage() {
                         }
                         if (m_queuedToi == toi) {
                             m_queued = false;
+                            m_currentObject->second.lastSentNow();
                             m_currentObject.reset();
                             objectSendCompletion(m_queuedObjectId, queue_empty);
                             ogs_info("Transmitted: Object with TOI: %d", toi);
@@ -286,6 +287,12 @@ void ObjectListPackager::doObjectPackage() {
                     file_desc->set_content(objData);
                     ogs_debug("Set FileDescription object data");
                 }
+            }
+
+            if (metadata.compressedSend()) {
+                file_desc->set_compression(LibFlute::Transmitter::FileDescription::CompressionAlgorithm::COMPRESSION_GZIP);
+            } else {
+                file_desc->set_compression(LibFlute::Transmitter::FileDescription::CompressionAlgorithm::COMPRESSION_NONE);
             }
 
             m_queued = true;

--- a/src/mbstf/ObjectListPackager.hh
+++ b/src/mbstf/ObjectListPackager.hh
@@ -65,14 +65,15 @@ public:
     };
 
     ObjectListPackager() = delete;
-    ObjectListPackager(ObjectStore &object_store, ObjectController &controller,
+    ObjectListPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
                        const std::list<PackageItem> &object_to_package, const SsmPort &ssm_port, uint32_t rateLimit,
                        unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectListPackager(ObjectStore &object_store, ObjectController &controller, std::list<PackageItem> &&object_to_package,
-                       const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
+    ObjectListPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller,
+                       std::list<PackageItem> &&object_to_package, const SsmPort &ssm_port, uint32_t rateLimit, unsigned short mtu,
                        const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
-    ObjectListPackager(ObjectStore &object_store, ObjectController &controller, const SsmPort &ssm_port, uint32_t rateLimit,
-                       unsigned short mtu, const std::optional<std::string> &tunnel_address, in_port_t tunnel_port);
+    ObjectListPackager(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller, const SsmPort &ssm_port,
+                       uint32_t rateLimit, unsigned short mtu, const std::optional<std::string> &tunnel_address,
+                       in_port_t tunnel_port);
     virtual ~ObjectListPackager();
 
     bool add(const PackageItem &item);

--- a/src/mbstf/ObjectManifestController.cc
+++ b/src/mbstf/ObjectManifestController.cc
@@ -26,6 +26,8 @@
 #include "common.hh"
 #include "DistributionSession.hh"
 #include "Event.hh"
+#include "ManifestHandler.hh"
+#include "ManifestHandlerFactory.hh"
 #include "ObjectController.hh"
 #include "ObjectManifestHandler.hh"
 #include "ObjectStore.hh"
@@ -44,6 +46,7 @@ MBSTF_NAMESPACE_START
 static bool validate_push_url(DistributionSession &distributionSession, const std::string &url);
 static void validate_pull_acquisition_method(DistributionSession &distributionSession);
 static bool validate_push_acquisition_method(DistributionSession &distributionSession);
+static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, const std::string &manifest_url);
 
 /* ObjectManifestController public methods */
 
@@ -59,7 +62,61 @@ ObjectManifestController::ObjectManifestController(DistributionSession &dist_ses
 
 void ObjectManifestController::processEvent(Event &event, SubscriptionService &event_service)
 {
-    if (event.eventName() == "ObjectPushStart") {
+    if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
+        event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
+
+        ObjectStore::ObjectChangedEvent &obj_changed_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
+        const std::string &object_id = obj_changed_event.objectId();
+        ogs_debug("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
+        try {
+            auto object_store = objectStore();
+            if (object_store) {
+                auto &obj_store = *object_store;
+                const std::shared_ptr<ObjectStore::Object> &object = obj_store[object_id];
+                ogs_debug("Object location: %s", object->second.getFetchedUrl().c_str());
+                objectAddOrUpdateEvent(object);
+                object->second.keepAfterSend(true); /* keep all objects, we'll manually remove if the carousel changes */
+                std::shared_ptr<ManifestHandler> manifest_handler = manifestHandler();
+                if (check_if_object_added_is_manifest(object, getManifestUrl())) {
+                    if (manifest_handler) {
+                        try {
+                            if (!manifest_handler->update(object)) {
+                                ogs_error("Failed to update Manifest");
+                                unsetObjectPackager();
+                                event.stopProcessing();
+                                object->second.keepAfterSend(false);
+                                throw std::runtime_error("Failed to update Manifest");
+                            }
+                            startWorker();
+                            if (includeManifest()) sendToPackager(object);
+                        } catch (std::exception &ex) {
+                            ogs_error("Invalid Manifest update: %s", ex.what());
+                            unsetObjectPackager();
+                            event.stopProcessing();
+                            object->second.keepAfterSend(false);
+                            throw std::runtime_error(ex.what());
+                        }
+                    } else {
+                        manifest_handler.reset(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
+                        if (!manifest_handler) {
+                            object->second.keepAfterSend(false);
+                            throw std::runtime_error("Could not find suitable manifest handler");
+                        }
+                        manifestHandler(std::move(manifest_handler));
+                        if (includeManifest()) {
+                            object->second.compressedSend(manifestHandler()->compressManifestOnSend());
+                            sendToPackager(object);
+                        }
+                    }
+                } else if (checkObjectActiveInManifest(object)) {
+                    finishRequestInManifestHandler(object);
+                    sendToPackager(object);
+                }
+            }
+        } catch (std::out_of_range &ex) {
+            ogs_error("Object %s is not in the ObjectStore", object_id.c_str());
+        }
+    } else if (event.eventName() == PushObjectIngester::ObjectPushEvent::start_event_name) {
         PushObjectIngester::ObjectPushEvent &obj_push_event = dynamic_cast<PushObjectIngester::ObjectPushEvent&>(event);
         const PushObjectIngester::Request &request(obj_push_event.request());
         const std::optional<std::string> &content_type(request.contentType());
@@ -83,7 +140,9 @@ void ObjectManifestController::processEvent(Event &event, SubscriptionService &e
                 auto &ingesters = getPullObjectIngesters();
                 if (!ingesters.empty()) {
                     auto &ingester = ingesters.front();
-                    ingester->fetch(pull_ingest_failed_event.item());
+                    auto &item = pull_ingest_failed_event.item();
+                    item.forceRecache(true); // Force refetch on error
+                    ingester->fetch(item);
                 }
             } catch (std::bad_cast &ex) {
                 // Should never happen, but just incase
@@ -160,11 +219,60 @@ void ObjectManifestController::reconfigurePushObjectIngester()
 void ObjectManifestController::reconfigurePullObjectIngesters()
 {
     std::lock_guard<std::recursive_mutex> lock(this->m_pullObjectIngestersMutex);
-    removeAllPullObjectIngesters();
+    const auto &pull_ingesters = getPullObjectIngesters();
     if (distributionSession().getObjectAcquisitionMethod() == "PULL" &&
         distributionSession().getState() != DistSessionState::VAL_INACTIVE) {
-        initPullObjectIngesters();
+        if (pull_ingesters.empty()) {
+            initPullObjectIngesters();
+        } else {
+            auto pull_ingest_items = getPullAcquisitionIngestList();
+            auto &pull_ingester = pull_ingesters.front();
+            for (auto &item : pull_ingest_items) {
+                pull_ingester->fetch(item);
+            }
+        }
     }
+}
+
+std::list<PullObjectIngester::IngestItem> ObjectManifestController::getPullAcquisitionIngestList()
+{
+    std::list<PullObjectIngester::IngestItem> result;
+    const std::optional<std::string> &object_ingest_base_url = distributionSession().getObjectIngestBaseUrl();
+    const std::optional<std::string> &object_distribution_base_url = distributionSession().objectDistributionBaseUrl();
+
+    auto object_store = objectStore();
+    if (object_store) {
+        auto &pull_urls = distributionSession().getObjectAcquisitionPullUrls();
+        if (pull_urls.has_value()) {
+            for (auto &url : pull_urls.value()) {
+                std::string obj_ingest_url;
+
+                if (url.has_value()) {
+                    const std::string &url_str = url.value();
+                    if (object_ingest_base_url.has_value()) {
+                        if (url_str.starts_with("https:") || url_str.starts_with("http:") || url_str.starts_with("//")) {
+                            ogs_error("Invalid objectAcquisitionPullUrl when objectIngestBaseUrl is set: %s", url.value().c_str());
+                            continue;
+                        } else {
+                            obj_ingest_url = object_ingest_base_url.value();
+                            if (!obj_ingest_url.ends_with("/")) obj_ingest_url += "/";
+                            obj_ingest_url += trim_slashes(url_str);
+                        }
+                    }
+
+                    const auto *metadata = object_store->findMetadataByURL(obj_ingest_url);
+                    if (metadata) {
+                        /* this is a refetch */
+                        result.emplace_back(*metadata);
+                    } else {
+                        /* this is a new URL - always compress manifest for send and keep after sending */
+                        result.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url, std::nullopt /*download_deadline*/, false /*force_recache*/, true /*keep_after_send*/, true /*compressed_send*/);
+                    }
+                }
+            }
+        }
+    }
+    return result;
 }
 
 /* ObjectManifestController protected */
@@ -179,61 +287,33 @@ void ObjectManifestController::startWorker()
 
 void ObjectManifestController::initPullObjectIngesters()
 {
-    const std::optional<std::string> &object_ingest_base_url = distributionSession().getObjectIngestBaseUrl();
-    const std::optional<std::string> &object_distribution_base_url = distributionSession().objectDistributionBaseUrl();
-
-    auto &pull_urls = distributionSession().getObjectAcquisitionPullUrls();
-    if (pull_urls.has_value()) {
-        std::list<PullObjectIngester::IngestItem> urls;
-
-        for (auto &url : pull_urls.value()) {
-            std::string obj_ingest_url;
-
-            if (url.has_value()) {
-                const std::string &url_str = url.value();
-                if (object_ingest_base_url.has_value()) {
-                    if (url_str.starts_with("https:") || url_str.starts_with("http:") || url_str.starts_with("//")) {
-                        ogs_error("Invalid objectAcquisitionPullUrl when objectIngestBaseUrl is set: %s", url.value().c_str());
-                        continue;
-                    } else {
-                        obj_ingest_url = object_ingest_base_url.value();
-                        if (!obj_ingest_url.ends_with("/")) obj_ingest_url += "/";
-                        obj_ingest_url += trim_slashes(url_str);
-                    }
-
-                }
-
-                const auto *metadata = objectStore().findMetadataByURL(obj_ingest_url);
-                if (metadata) {
-                    /* this is a refetch */
-                    urls.emplace_back(*metadata);
-                } else {
-                    /* this is a new URL */
-                    urls.emplace_back(nextObjectId(), obj_ingest_url, url_str, object_ingest_base_url, object_distribution_base_url);
-                }
-            }
-        }
-
-        addPullObjectIngester(new PullObjectIngester(objectStore(), *this, urls));
+    auto object_store = objectStore();
+    if (object_store) {
+        auto pull_ingest_items = getPullAcquisitionIngestList();
+        addPullObjectIngester(new PullObjectIngester(object_store, *this, pull_ingest_items));
     }
 }
 
 void ObjectManifestController::initPushObjectIngester()
 {
-    const std::string objIngestBaseUrl;
+    if (objectStore()) {
+        const std::string objIngestBaseUrl;
 
-    PushObjectIngester *push_ingester = new PushObjectIngester(objectStore(), *this);
+        PushObjectIngester *push_ingester = new PushObjectIngester(objectStore(), *this);
 
-    distributionSession().setObjectIngestBaseUrl(push_ingester->getIngestServerPrefix());
-    subscribeTo({"ObjectPushStart"}, *push_ingester);
-    pushObjectIngester(push_ingester);
+        distributionSession().setObjectIngestBaseUrl(push_ingester->getIngestServerPrefix());
+        subscribeTo({"ObjectPushStart"}, *push_ingester);
+        pushObjectIngester(push_ingester);
+    }
 }
 
 ObjectManifestController &ObjectManifestController::manifestHandler(std::shared_ptr<ManifestHandler> &&manifest_handler)
 {
     std::lock_guard guard(m_manifestHandlerMutex);
     m_manifestHandler = std::move(manifest_handler);
-    subscribeTo({ObjectManifestHandler::ObjectManifestChangeEvent::event_name}, *m_manifestHandler);
+    if (m_manifestHandler) {
+        subscribeTo({ObjectManifestHandler::ObjectManifestChangeEvent::event_name}, *m_manifestHandler);
+    }
     m_manifestHandlerChange.notify_all();
     return *this;
 }
@@ -307,8 +387,10 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
         // Get the next ingest items
         try {
             std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
-            next_ingest_items = controller->manifestHandler()->nextIngestItems();
-            default_deadline = controller->manifestHandler()->getDefaultDeadline();
+            if (controller->m_manifestHandler) {
+                next_ingest_items = controller->m_manifestHandler->nextIngestItems();
+                default_deadline = controller->m_manifestHandler->getDefaultDeadline();
+            }
         } catch ( std::domain_error &err) {
             ogs_error("While fetching next manifest ingest item: %s", err.what());
         }
@@ -319,11 +401,12 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
 
         std::list<PullObjectIngester::IngestItem> urls;
 
-        {
+        auto object_store = controller->objectStore();
+        if (object_store) {
             std::lock_guard<std::recursive_mutex> lock(controller->m_pullObjectIngestersMutex);
             auto &ingesters = controller->getPullObjectIngesters();
             while (ingesters.size() < next_ingest_items.second.size()) {
-                controller->addPullObjectIngester(new PullObjectIngester(controller->objectStore(), *controller, urls));
+                controller->addPullObjectIngester(new PullObjectIngester(object_store, *controller, urls));
             }
         }
 
@@ -367,7 +450,13 @@ void ObjectManifestController::workerLoop(ObjectManifestController *controller)
 
                 {
                     std::lock_guard<std::recursive_mutex> lock(controller->m_manifestHandlerMutex);
-                    controller->manifestHandler()->startedFetch(ingest_item);
+                    if (controller->m_manifestHandler) {
+                        controller->m_manifestHandler->startedFetch(ingest_item);
+                    } else {
+                        // Manifest handler has disappeared, end scheduled pull
+                        controller->m_scheduledPullRunning = false;
+                        break;
+                    }
                 }
 
                 if (!(*ingester_it)->fetch(ingest_item)) {
@@ -440,6 +529,17 @@ static bool validate_push_url(DistributionSession &distributionSession, const st
     }
 
     return true;
+}
+
+static bool check_if_object_added_is_manifest(const std::shared_ptr<ObjectStore::Object> &object, const std::string &manifest_url)
+{
+    auto &metadata = object->second;
+    if (metadata.getOriginalUrl() == manifest_url || metadata.getFetchedUrl() == manifest_url) {
+        metadata.keepAfterSend(true);
+        return true;
+    }
+    return false;
+
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectManifestController.hh
+++ b/src/mbstf/ObjectManifestController.hh
@@ -64,10 +64,15 @@ protected:
     ObjectManifestController &manifestHandler(std::shared_ptr<ManifestHandler> &&manifest_handler);
     const std::shared_ptr<ManifestHandler> &manifestHandler() const;
     virtual std::string nextObjectId();
-
+    virtual void objectAddOrUpdateEvent(const std::shared_ptr<ObjectStore::Object> &object) {};
+    virtual bool includeManifest() { return false; };
+    virtual bool checkObjectActiveInManifest(const std::shared_ptr<ObjectStore::Object> &object) { return true; };
+    virtual void finishRequestInManifestHandler(const std::shared_ptr<ObjectStore::Object> &object) {};
+    virtual void sendToPackager(const std::shared_ptr<ObjectStore::Object> &object) = 0;
 
 private:
     static void workerLoop(ObjectManifestController *controller);
+    std::list<PullObjectIngester::IngestItem> getPullAcquisitionIngestList();
     std::string generateUUID();
 
     std::string m_manifestUrl;

--- a/src/mbstf/ObjectManifestHandler.cc
+++ b/src/mbstf/ObjectManifestHandler.cc
@@ -34,6 +34,7 @@
 #include "DistributionSession.hh"
 #include "ManifestHandler.hh"
 #include "ManifestHandlerFactory.hh"
+#include "MimeContentType.hh"
 #include "ObjectController.hh"
 #include "ObjectStore.hh"
 #include "PullObjectIngester.hh"
@@ -124,7 +125,7 @@ std::pair<ManifestHandler::time_type, ManifestHandler::ingest_list> ObjectManife
         /* find the metadata entry for this object in the ObjectStore */
         auto &object_store = m_controller->objectStore();
         auto obj_locator = obj.value()->getLocator();
-        auto obj_metadata_ptr = object_store.findMetadataByURL(obj_locator);
+        auto obj_metadata_ptr = object_store->findMetadataByURL(obj_locator);
 
         auto it = m_objectMetadataCache.find(obj.value().get());
         if (it != m_objectMetadataCache.end() && !it->second.beenRequested) {
@@ -186,9 +187,9 @@ bool ObjectManifestHandler::update(const std::shared_ptr<ObjectStore::Object> &n
         if (new_it == new_objects.end()) {
             /* object removed from carousel */
             auto &object_store = m_controller->objectStore();
-            auto *metadata = object_store.findMetadataByURL(old_it->value()->getLocator());
+            auto *metadata = object_store->findMetadataByURL(old_it->value()->getLocator());
             if (metadata) {
-                object_store.removeObject(metadata->objectId());
+                object_store->removeObject(metadata->objectId());
             }
             m_objectMetadataCache.erase(old_it->value().get());
             to_del.push_back(*old_it);
@@ -324,7 +325,7 @@ void ObjectManifestHandler::finishRequest(const std::string &url)
             auto obj_meta_it = m_objectMetadataCache.find(obj.value().get());
             if (obj_meta_it != m_objectMetadataCache.end()) {
                 obj_meta_it->second.beenRequested = false;
-                auto obj_metadata_ptr = object_store.findMetadataByURL(obj_locator);
+                auto obj_metadata_ptr = object_store->findMetadataByURL(obj_locator);
                 auto &keep_updated_interval = obj.value()->getKeepUpdatedInterval();
                 std::optional<datetime_type> next_fetch_time;
                 if (obj_metadata_ptr) {
@@ -375,11 +376,12 @@ static bool g_registered3 = ManifestHandlerFactory::registerManifestHandler("app
 static ObjectManifest ingest_manifest(const std::shared_ptr<ObjectStore::Object> &new_manifest)
 {
     auto &new_metadata = new_manifest->second;
-    ogs_debug("%s", std::format("ingest_manifest: mediaType() = {}", new_metadata.mediaType()).c_str());
-    if (new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json" &&
-        new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json;version=Rel17" &&
-        new_metadata.mediaType() != "application/3gpp-mbs-object-manifest+json;version=\"Rel17\""){
-         throw std::invalid_argument("Does not look like an ObjectManifest as the media type is invalid. Expected media type: application/3gpp-mbs-object-manifest+json;version=\"Rel17\"");
+    static const MimeContentType mime_type_obj_manifest("application/3gpp-mbs-object-manifest+json");
+    MimeContentType new_mime_type(new_metadata.mediaType());
+    ogs_debug("%s", std::format("ingest_manifest: mediaType() = {}", new_mime_type).c_str());
+    if (mime_type_obj_manifest != new_mime_type ||
+        (new_mime_type.hasParameter("version") && new_mime_type.parameter("version") != "Rel17")) {
+        throw std::invalid_argument("Does not look like an ObjectManifest as the media type is invalid. Expected media type: application/3gpp-mbs-object-manifest+json;version=\"Rel17\"");
     }
 
     try {

--- a/src/mbstf/ObjectManifestHandler.hh
+++ b/src/mbstf/ObjectManifestHandler.hh
@@ -21,6 +21,7 @@
 #include "Event.hh"
 #include "ManifestHandler.hh"
 #include "ObjectStore.hh"
+#include "Open5GSYamlIter.hh"
 #include "PullObjectIngester.hh"
 #include "SubscriptionService.hh"
 #include "openapi/model/ObjectManifest.h"
@@ -70,6 +71,9 @@ public:
     double getRepetitionIntervalForUrl(const std::string &url) const;
     bool isObjectURLActive(const std::string &url) const;
     void finishRequest(const std::string &url);
+
+    static bool parseConfiguration(const std::string &section_name, Open5GSYamlIter &iter) { return false; };
+    static void tidyConfiguration() {};
 
 private:
     struct ObjectMetadataCache {

--- a/src/mbstf/ObjectPackager.hh
+++ b/src/mbstf/ObjectPackager.hh
@@ -126,7 +126,7 @@ public:
     ObjectPackager(ObjectPackager &&) = delete;
     ObjectPackager(const ObjectPackager &) = delete;
 
-    ObjectPackager(ObjectStore &objectStore, ObjectController &controller, const SsmPort &ssm_port = SsmPort(), uint32_t rateLimit = 0, unsigned short mtu = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
+    ObjectPackager(const std::shared_ptr<ObjectStore> &objectStore, ObjectController &controller, const SsmPort &ssm_port = SsmPort(), uint32_t rateLimit = 0, unsigned short mtu = 0, const std::optional<std::string> &tunnel_address = std::nullopt, in_port_t tunnel_port = 0 )
         :m_transmitterMutex(new decltype(m_transmitterMutex)::element_type)
         ,m_transmitter(nullptr), m_io(), m_queuedToi(0), m_queued(false), m_deactivating(false), m_queuedObjectId()
         ,m_objectStore(objectStore), m_controller(controller), m_ssmPort(ssm_port), m_rateLimit(rateLimit), m_mtu(mtu)
@@ -159,8 +159,8 @@ public:
     virtual void flushQueue() {};
 
 protected:
-    const ObjectStore &objectStore() const { return m_objectStore; };
-    ObjectStore &objectStore() { return m_objectStore; };
+    const std::shared_ptr<ObjectStore> &objectStore() const { return m_objectStore; };
+    std::shared_ptr<ObjectStore> &objectStore() { return m_objectStore; };
     const ObjectController &controller() const { return m_controller; };
     ObjectController &controller() { return m_controller; };
     const SsmPort &ssmPort() const { return m_ssmPort; };
@@ -182,7 +182,7 @@ protected:
 
 private:
     static void workerLoop(ObjectPackager*);
-    ObjectStore &m_objectStore;
+    std::shared_ptr<ObjectStore> m_objectStore;
     ObjectController &m_controller;
     SsmPort m_ssmPort;
     uint32_t m_rateLimit;

--- a/src/mbstf/ObjectStore.cc
+++ b/src/mbstf/ObjectStore.cc
@@ -43,12 +43,14 @@ ObjectStore::Metadata::Metadata()
     ,m_fetchedUrl()
     ,m_acquisitionId()
     ,m_keepAfterSend(false)
+    ,m_compressedSend(false)
     ,m_objIngestBaseUrl()
     ,m_objDistributionBaseUrl()
     ,m_cacheExpires(std::nullopt)
     ,m_receivedTime(std::chrono::system_clock::now())
     ,m_created(std::chrono::system_clock::now())
     ,m_modified(std::chrono::system_clock::now())
+    ,m_lastSentTime(std::chrono::system_clock::duration(0)) // set to epoch initially
     ,m_fileDescription()
 {
 }
@@ -65,12 +67,14 @@ ObjectStore::Metadata::Metadata(const std::string &object_id, const std::string 
     ,m_fetchedUrl(fetched_url)
     ,m_acquisitionId(acquisition_id)
     ,m_keepAfterSend(false)
+    ,m_compressedSend(false)
     ,m_objIngestBaseUrl(obj_ingest_base_url)
     ,m_objDistributionBaseUrl(obj_distribution_base_url)
     ,m_cacheExpires(cache_expires)
     ,m_receivedTime(std::chrono::system_clock::now())
     ,m_created(std::chrono::system_clock::now())
     ,m_modified(last_modified)
+    ,m_lastSentTime(std::chrono::system_clock::duration(0)) // set to epoch initially
     ,m_fileDescription()
 {
 }
@@ -82,12 +86,14 @@ ObjectStore::Metadata::Metadata(const Metadata &other)
     ,m_fetchedUrl(other.m_fetchedUrl)
     ,m_acquisitionId(other.m_acquisitionId)
     ,m_keepAfterSend(other.m_keepAfterSend)
+    ,m_compressedSend(other.m_compressedSend)
     ,m_objIngestBaseUrl(other.m_objIngestBaseUrl)
     ,m_objDistributionBaseUrl(other.m_objDistributionBaseUrl)
     ,m_cacheExpires(other.m_cacheExpires)
     ,m_receivedTime(other.m_receivedTime)
     ,m_created(other.m_created)
     ,m_modified(other.m_modified)
+    ,m_lastSentTime(other.m_lastSentTime)
     ,m_fileDescription(other.m_fileDescription)
 {
 }
@@ -98,13 +104,15 @@ ObjectStore::Metadata::Metadata(Metadata &&other)
     ,m_originalUrl(std::move(other.m_originalUrl))
     ,m_fetchedUrl(std::move(other.m_fetchedUrl))
     ,m_acquisitionId(std::move(other.m_acquisitionId))
-    ,m_keepAfterSend(std::move(other.m_keepAfterSend))
+    ,m_keepAfterSend(other.m_keepAfterSend)
+    ,m_compressedSend(other.m_compressedSend)
     ,m_objIngestBaseUrl(std::move(other.m_objIngestBaseUrl))
     ,m_objDistributionBaseUrl(std::move(other.m_objDistributionBaseUrl))
     ,m_cacheExpires(std::move(other.m_cacheExpires))
     ,m_receivedTime(std::move(other.m_receivedTime))
     ,m_created(std::move(other.m_created))
     ,m_modified(std::move(other.m_modified))
+    ,m_lastSentTime(std::move(other.m_lastSentTime))
     ,m_fileDescription(std::move(other.m_fileDescription))
 {
 }
@@ -117,12 +125,14 @@ ObjectStore::Metadata &ObjectStore::Metadata::operator=(const ObjectStore::Metad
     m_fetchedUrl = other.m_fetchedUrl;
     m_acquisitionId = other.m_acquisitionId;
     m_keepAfterSend = other.m_keepAfterSend;
+    m_compressedSend = other.m_compressedSend;
     m_objIngestBaseUrl = other.m_objIngestBaseUrl;
     m_objDistributionBaseUrl = other.m_objDistributionBaseUrl;
     m_cacheExpires = other.m_cacheExpires;
     m_receivedTime = other.m_receivedTime;
     m_created = other.m_created;
     m_modified = other.m_modified;
+    m_lastSentTime = other.m_lastSentTime;
     m_fileDescription = other.m_fileDescription;
 
     return *this;
@@ -135,13 +145,15 @@ ObjectStore::Metadata &ObjectStore::Metadata::operator=(ObjectStore::Metadata &&
     m_originalUrl = std::move(other.m_originalUrl);
     m_fetchedUrl = std::move(other.m_fetchedUrl);
     m_acquisitionId = std::move(other.m_acquisitionId);
-    m_keepAfterSend = std::move(other.m_keepAfterSend);
+    m_keepAfterSend = other.m_keepAfterSend;
+    m_compressedSend = other.m_compressedSend;
     m_objIngestBaseUrl = std::move(other.m_objIngestBaseUrl);
     m_objDistributionBaseUrl = std::move(other.m_objDistributionBaseUrl);
     m_cacheExpires = std::move(other.m_cacheExpires);
     m_receivedTime = std::move(other.m_receivedTime);
     m_created = std::move(other.m_created);
     m_modified = std::move(other.m_modified);
+    m_lastSentTime = std::move(other.m_lastSentTime);
     m_fileDescription = std::move(other.m_fileDescription);
 
     return *this;
@@ -150,6 +162,7 @@ ObjectStore::Metadata &ObjectStore::Metadata::operator=(ObjectStore::Metadata &&
 bool ObjectStore::Metadata::operator==(const ObjectStore::Metadata& other) const
 {
     return m_keepAfterSend == other.m_keepAfterSend &&
+           m_compressedSend == other.m_compressedSend &&
            m_cacheExpires == other.m_cacheExpires &&
            m_receivedTime == other.m_receivedTime &&
            m_created == other.m_created &&

--- a/src/mbstf/ObjectStore.hh
+++ b/src/mbstf/ObjectStore.hh
@@ -216,6 +216,9 @@ public:
         Metadata &keepAfterSend(bool keep_after_send) {m_keepAfterSend = keep_after_send; return *this;};
         bool keepAfterSend() const { return m_keepAfterSend;};
 
+        bool compressedSend() const { return m_compressedSend; };
+        Metadata &compressedSend(bool compress_send) { m_compressedSend = compress_send; return *this; };
+
         const std::optional<std::string> &objIngestBaseUrl() const { return m_objIngestBaseUrl;};
         Metadata &objIngestBaseUrl(const std::optional<std::string> &obj_ingest_base_url) {
             m_objIngestBaseUrl = obj_ingest_base_url;
@@ -264,6 +267,11 @@ public:
             return *this;
         };
 
+        const datetime_type &lastSent() const { return m_lastSentTime; };
+        Metadata &lastSent(const datetime_type &val) { m_lastSentTime = val; return *this; };
+        Metadata &lastSent(datetime_type &&val) { m_lastSentTime = std::move(val); return *this; };
+        Metadata &lastSentNow() { m_lastSentTime = datetime_type::clock::now(); return *this; };
+
     private:
         std::string m_objectId;
         std::string m_mediaType;
@@ -271,6 +279,7 @@ public:
         std::string m_fetchedUrl;
         std::string m_acquisitionId;
         bool m_keepAfterSend;
+        bool m_compressedSend;
         std::optional<std::string> m_objIngestBaseUrl;
         std::optional<std::string> m_objDistributionBaseUrl;
         std::optional<std::string> m_entityTag;
@@ -278,6 +287,7 @@ public:
         datetime_type m_receivedTime;
         datetime_type m_created;
         datetime_type m_modified;
+        datetime_type m_lastSentTime;
         std::shared_ptr<LibFlute::Transmitter::FileDescription> m_fileDescription;
     };
 

--- a/src/mbstf/ObjectStreamingController.cc
+++ b/src/mbstf/ObjectStreamingController.cc
@@ -50,14 +50,12 @@ using fiveg_mag_reftools::ProblemCause;
 MBSTF_NAMESPACE_START
 
 static void validate_distribution_session(DistributionSession &distributionSession);
-static bool check_if_object_added_is_manifest(const std::string &object_id, ObjectStore &object_store,
-                                              const std::string &manifest_url);
 
 ObjectStreamingController::ObjectStreamingController(DistributionSession &distributionSession)
     :ObjectManifestController(distributionSession)
 {
     validate_distribution_session(distributionSession);
-    subscribeToService(objectStore());
+    subscribeToService(*objectStore());
     //setObjectListPackager();
     //startWorker();
 }
@@ -78,15 +76,13 @@ void ObjectStreamingController::setObjectPackager()
     auto pkgr = getObjectListPackager();
     subscribeToService(*pkgr);
     startWorker();
-    const auto &obj_list = objectStore().getObjects();
-    for (const auto &[obj_id, object] : obj_list) {
-        sendToPackager(object);
+    auto object_store = objectStore();
+    if (object_store) {
+        const auto &obj_list = object_store->getObjects();
+        for (const auto &[obj_id, object] : obj_list) {
+            sendToPackager(object);
+        }
     }
-}
-
-void ObjectStreamingController::unsetObjectPackager()
-{
-    packager(nullptr);
 }
 
 void ObjectStreamingController::activateObjectPackager() {
@@ -103,44 +99,6 @@ void ObjectStreamingController::deactivateObjectPackager() {
 std::shared_ptr<ObjectListPackager> ObjectStreamingController::getObjectListPackager() const
 {
     return std::dynamic_pointer_cast<ObjectListPackager>(packager());
-}
-
-void ObjectStreamingController::processEvent(Event &event, SubscriptionService &event_service)
-{
-    if (event.eventName() == ObjectStore::ObjectAddedEvent::event_name ||
-        event.eventName() == ObjectStore::ObjectUpdatedEvent::event_name) {
-        ObjectStore::ObjectChangedEvent &obj_changed_event = dynamic_cast<ObjectStore::ObjectChangedEvent&>(event);
-        const std::string &object_id = obj_changed_event.objectId();
-        ogs_info("%s with ID: %s", event.eventName().c_str(), object_id.c_str());
-        const std::shared_ptr<ObjectStore::Object> &object = objectStore()[object_id];
-        if(check_if_object_added_is_manifest(object_id, objectStore(), getManifestUrl())) {
-            if(manifestHandler()) {
-                try {
-                    if(!manifestHandler()->update(object)) {
-                        ogs_error("Failed to update Manifest");
-                        unsetObjectListPackager();
-                        event.stopProcessing();
-                        return;
-                    }
-                    startWorker();
-                    sendToPackager(object);
-                } catch (std::exception &ex) {
-                    ogs_error("Invalid Manifest update: %s", ex.what());
-                    unsetObjectListPackager();
-                    event.stopProcessing();
-                    return;
-                }
-
-            } else {
-                std::unique_ptr<ManifestHandler> manifest_handler(ManifestHandlerFactory::makeManifestHandler(object, this, distributionSession().getObjectAcquisitionMethod() == "PULL"));
-                manifestHandler(std::move(manifest_handler));
-                sendToPackager(object);
-            }
-        } else {
-            sendToPackager(object);
-        }
-    }
-    ObjectManifestController::processEvent(event, event_service);
 }
 
 void ObjectStreamingController::sendToPackager(const std::shared_ptr<ObjectStore::Object> &object)
@@ -187,17 +145,6 @@ static void validate_distribution_session(DistributionSession &distribution_sess
         throw std::logic_error("Expected objDistributionOperatingMode to be set to STREAMING.");
     }
     ObjectController::validateDistributionSession(distribution_session);
-}
-
-static bool check_if_object_added_is_manifest(const std::string &object_id, ObjectStore &object_store,
-                                              const std::string &manifest_url) {
-    ObjectStore::Metadata &metadata = object_store.getMetadata(object_id);
-    if(metadata.getOriginalUrl() == manifest_url || metadata.getFetchedUrl() == manifest_url) {
-        metadata.keepAfterSend(true);
-        return true;
-    }
-    return false;
-
 }
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/ObjectStreamingController.hh
+++ b/src/mbstf/ObjectStreamingController.hh
@@ -49,9 +49,6 @@ public:
 
     static unsigned int factoryPriority() { return 50; };
 
-    // Subscriber virtual methods
-    virtual void processEvent(Event &event, SubscriptionService &event_service);
-
     // Optional: virtual void subscriberRemoved(SubscriptionService &event_service);
     std::string reprString() const {
                 std::ostringstream os;
@@ -59,24 +56,16 @@ public:
                 return os.str();
     }
 
-    void unsetObjectListPackager() {
-        // Reset the shared pointer to release ownership.
-        packager(nullptr);
-    };
-
     virtual void reconfigureObjectPackager();
 
 protected:
     virtual void setObjectPackager();
-    virtual void unsetObjectPackager();
     virtual void activateObjectPackager();
     virtual void deactivateObjectPackager();
+    virtual bool includeManifest() { return true; };
+    virtual void sendToPackager(const std::shared_ptr<ObjectStore::Object> &object);
 
 private:
-    void sendToPackager(const std::shared_ptr<ObjectStore::Object> &object);
-    //std::string generateUUID();
-    //std::shared_ptr<ObjectListPackager> m_objectListPackager;
-//    std::thread m_ingestSchedulingThread;
 };
 
 MBSTF_NAMESPACE_STOP

--- a/src/mbstf/PullObjectIngester.cc
+++ b/src/mbstf/PullObjectIngester.cc
@@ -38,23 +38,30 @@ MBSTF_NAMESPACE_START
 /***** PullObjectIngester::IngestItem methods *****/
 
 PullObjectIngester::IngestItem::IngestItem(const ObjectStore::Metadata &object_meta,
-                                           const std::optional<time_type> &download_deadline)
+                                           const std::optional<time_type> &download_deadline, bool force_recache,
+                                           bool keep_after_send, bool compress_send)
     :m_objectId(object_meta.objectId())
     ,m_url(object_meta.getFetchedUrl())
     ,m_acquisitionId(object_meta.acquisitionId())
     ,m_objIngestBaseUrl(object_meta.objIngestBaseUrl())
     ,m_objDistributionBaseUrl(object_meta.objDistributionBaseUrl())
     ,m_deadline(download_deadline)
+    ,m_forceRecache(force_recache)
+    ,m_markAsKeepAfterSend(keep_after_send)
+    ,m_markAsCompressedSend(compress_send)
 {
 }
 
-PullObjectIngester::IngestItem::IngestItem(const std::string &object_id, const std::string &url, const std::string &acquisition_id, const std::optional<std::string> &obj_ingest_base_url,  const std::optional<std::string> &obj_distribution_base_url, const std::optional<time_type> &download_deadline)
+PullObjectIngester::IngestItem::IngestItem(const std::string &object_id, const std::string &url, const std::string &acquisition_id, const std::optional<std::string> &obj_ingest_base_url,  const std::optional<std::string> &obj_distribution_base_url, const std::optional<time_type> &download_deadline, bool force_recache, bool keep_after_send, bool compress_send)
     :m_objectId(object_id)
     ,m_url(url)
     ,m_acquisitionId(acquisition_id)
     ,m_objIngestBaseUrl(obj_ingest_base_url)
     ,m_objDistributionBaseUrl(obj_distribution_base_url)
     ,m_deadline(download_deadline)
+    ,m_forceRecache(force_recache)
+    ,m_markAsKeepAfterSend(keep_after_send)
+    ,m_markAsCompressedSend(compress_send)
 {
 }
 
@@ -65,6 +72,9 @@ PullObjectIngester::IngestItem::IngestItem(const IngestItem &other)
     ,m_objIngestBaseUrl(other.m_objIngestBaseUrl)
     ,m_objDistributionBaseUrl(other.m_objDistributionBaseUrl)
     ,m_deadline(other.m_deadline)
+    ,m_forceRecache(other.m_forceRecache)
+    ,m_markAsKeepAfterSend(other.m_markAsKeepAfterSend)
+    ,m_markAsCompressedSend(other.m_markAsCompressedSend)
 {
 }
 
@@ -75,6 +85,9 @@ PullObjectIngester::IngestItem::IngestItem(IngestItem &&other)
     ,m_objIngestBaseUrl(std::move(other.m_objIngestBaseUrl))
     ,m_objDistributionBaseUrl(std::move(other.m_objDistributionBaseUrl))
     ,m_deadline(std::move(other.m_deadline))
+    ,m_forceRecache(other.m_forceRecache)
+    ,m_markAsKeepAfterSend(other.m_markAsKeepAfterSend)
+    ,m_markAsCompressedSend(other.m_markAsCompressedSend)
 {
 }
 
@@ -91,7 +104,7 @@ PullObjectIngester::~PullObjectIngester() {
     abort();
 }
 
-bool PullObjectIngester::fetch(const std::string &object_id, const std::optional<time_type> &download_deadline)
+bool PullObjectIngester::fetch(const std::string &object_id, const std::optional<time_type> &download_deadline, bool force_recache, bool keep_after_send, bool compress_send)
 {
     std::lock_guard<std::recursive_mutex> lock(*m_ingestItemsMutex);
 
@@ -102,13 +115,16 @@ bool PullObjectIngester::fetch(const std::string &object_id, const std::optional
             if (download_deadline.has_value()) {
                 it->deadline(download_deadline.value());
             }
+            it->forceRecache(it->forceRecache() || force_recache);
+            it->markAsKeepAfterSend(it->markAsKeepAfterSend() || keep_after_send);
+            it->markAsCompressedSend(it->markAsCompressedSend() || compress_send);
             break;
         }
     }
 
     // otherwise we need a new fetch based on the ObjectStore entry
     if (it == m_fetchList.end()) {
-        m_fetchList.emplace_back(objectStore().getMetadata(object_id), download_deadline);
+        m_fetchList.emplace_back(objectStore()->getMetadata(object_id).keepAfterSend(keep_after_send).compressedSend(compress_send), download_deadline, force_recache);
     }
 
     sortListByPolicy();
@@ -118,38 +134,16 @@ bool PullObjectIngester::fetch(const std::string &object_id, const std::optional
 }
 
 bool PullObjectIngester::fetch(const IngestItem &item) {
-    std::lock_guard<std::recursive_mutex> lock(*m_ingestItemsMutex);
-    try {
-        objectStore().getMetadata(item.objectId());
-        return fetch(item.objectId(), item.deadline());
-    } catch (const std::out_of_range &ex) {
-        // No previous version, this isn't a refresh, but may still be a re-request for an existing list item
-        decltype(m_fetchList)::iterator it;
-        for (it = m_fetchList.begin(); it != m_fetchList.end(); ++it) {
-            if (it->objectId() == item.objectId()) {
-                if (item.deadline().has_value()) {
-                    it->deadline(item.deadline().value());
-                }
-                break;
-            }
-        }
-
-        // otherwise we need a new fetch based on the ObjectStore entry
-        if (it == m_fetchList.end()) {
-            m_fetchList.push_back(item);
-        }
-
-        sortListByPolicy();
-        m_ingestItemsCondVar.notify_all();
-    }
-    return true;
+    return fetch(std::move(IngestItem(item)));
 }
 
 bool PullObjectIngester::fetch(IngestItem &&item) {
     std::lock_guard<std::recursive_mutex> lock(*m_ingestItemsMutex);
     try {
-        objectStore().getMetadata(item.objectId());
-        return fetch(item.objectId(), item.deadline());
+        auto &metadata = objectStore()->getMetadata(item.objectId());
+        if (!metadata.keepAfterSend()) metadata.keepAfterSend(item.markAsKeepAfterSend());
+        metadata.compressedSend(item.markAsCompressedSend());
+        return fetch(item.objectId(), item.deadline(), item.forceRecache(), item.markAsKeepAfterSend(), item.markAsCompressedSend());
     } catch (const std::out_of_range &ex) {
         // No previous version, this isn't a refresh, but may still be a re-request for an existing list item
         decltype(m_fetchList)::iterator it;
@@ -158,6 +152,9 @@ bool PullObjectIngester::fetch(IngestItem &&item) {
                 if (item.deadline().has_value()) {
                     it->deadline(item.deadline().value());
                 }
+                it->forceRecache(it->forceRecache() || item.forceRecache());
+                it->markAsKeepAfterSend(it->markAsKeepAfterSend() || item.markAsKeepAfterSend());
+                it->markAsCompressedSend(it->markAsCompressedSend() || item.markAsCompressedSend());
                 break;
             }
         }
@@ -199,8 +196,20 @@ void PullObjectIngester::doObjectIngest() {
             m_ingestItemsMutex->unlock(); // temp unlock while we fetch
             ObjectStore::Metadata *old_meta = nullptr;
             try {
-                auto &meta = objectStore().getMetadata(item.objectId());
+                auto &meta = objectStore()->getMetadata(item.objectId());
                 old_meta = &meta;
+                if (!item.forceRecache() && meta.hasExpiryTime() && meta.ExpiryTime() > ObjectStore::datetime_type::clock::now()) {
+                    // Existing store item is still fresh
+                    ogs_debug("Reusing cached object for %s instead of fetching again", item.url().c_str());
+                    ObjectStore::Metadata metadata(meta);
+                    try {
+                        this->objectStore()->updateMetadata(meta.objectId(), std::move(metadata), true);
+                    } catch (std::runtime_error &ex) {
+                        ogs_warn("While reusing cached object %s: %s", item.url().c_str(), ex.what());
+                        emitObjectPullIngestFailedEvent(item, item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
+                    }
+                    return;
+                }
                 auto &file_desc = meta.fluteFileDescription();
                 if (file_desc) {
                     ogs_debug("Refetching %s (TOI %u)...", item.url().c_str(), file_desc->toi());
@@ -237,12 +246,17 @@ void PullObjectIngester::doObjectIngest() {
                 ObjectStore::Metadata metadata(item.objectId(), m_curl->getContentType(), item.url(), fetched_url, item.acquisitionId(), m_curl->getLastModified(), item.objIngestBaseUrl(), item.objDistributionBaseUrl());
                 /* re-get metadata from ObjectStore as it may have changed */
                 try {
-                    auto &meta = objectStore().getMetadata(item.objectId());
+                    auto &meta = objectStore()->getMetadata(item.objectId());
                     old_meta = &meta;
                 } catch (const std::out_of_range &ex) {
                     old_meta = nullptr;
                 }
-                if (old_meta) metadata.fluteFileDescription(old_meta->fluteFileDescription());
+                if (old_meta) {
+                    metadata.fluteFileDescription(old_meta->fluteFileDescription());
+                    metadata.keepAfterSend(old_meta->keepAfterSend() || item.markAsKeepAfterSend());
+                } else {
+                    metadata.keepAfterSend(item.markAsKeepAfterSend());
+                }
                 unsigned long max_age = m_curl->getCacheControlMaxAge();
                 unsigned long current_age = m_curl->getAge();
                 metadata.cacheExpires(max_age ? std::chrono::system_clock::now() + std::chrono::seconds(max_age) - std::chrono::seconds(current_age) : std::chrono::system_clock::now() + std::chrono::seconds(ObjectStore::Metadata::cacheExpiry()));
@@ -253,18 +267,30 @@ void PullObjectIngester::doObjectIngest() {
                 auto response_code = m_curl->getResponseCode();
                 if (response_code >= 200 && response_code <= 299) {
                     /* received object - store it */
-                    this->objectStore().addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
+                    try {
+                        this->objectStore()->addObject(item.objectId(), std::move(m_curl->getData()), std::move(metadata), true);
+                    } catch (std::runtime_error &ex) {
+                        // Add to ObjectStore failed, send error
+                        ogs_warn("While adding a new object: %s", ex.what());
+                        emitObjectPullIngestFailedEvent(item, item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
+                    }
                 } else if (response_code == 304) {
                     /* Not Modified - just update metadata */
                     if (old_meta) {
                         metadata.mediaType(old_meta->mediaType()); // 304 may not have Content-Type due to no content
-                        this->objectStore().updateMetadata(item.objectId(), std::move(metadata), true);
+                        try {
+                            this->objectStore()->updateMetadata(item.objectId(), std::move(metadata), true);
+                        } catch (std::runtime_error &ex) {
+                            // Update in ObjectStore failed, send error
+                            ogs_warn("While updating object metadata: %s", ex.what());
+                            emitObjectPullIngestFailedEvent(item, item.url(), ObjectIngester::IngestFailedEvent::GENERAL_ERROR);
+                        }
                     }
                 } else {
                     /* error response - do we throw the object away? */
                     ogs_debug("Fetch error %i", response_code);
                     emitObjectPullIngestFailedEvent(item, fetched_url, (response_code >= 400 && response_code <= 499)?ObjectIngester::IngestFailedEvent::CLIENT_ERROR:ObjectIngester::IngestFailedEvent::SERVER_ERROR);
-                    this->objectStore().updateError(item.objectId(), response_code, item.url(), false);
+                    this->objectStore()->updateError(item.objectId(), response_code, item.url(), false);
                 }
             } else if (bytesReceived == -1) {
                 ogs_error("Request timed out.");

--- a/src/mbstf/PullObjectIngester.hh
+++ b/src/mbstf/PullObjectIngester.hh
@@ -44,11 +44,13 @@ public:
     public:
 
         IngestItem() = delete;
-        IngestItem(const ObjectStore::Metadata &object_meta, const std::optional<time_type> &download_deadline = std::nullopt);
+        IngestItem(const ObjectStore::Metadata &object_meta, const std::optional<time_type> &download_deadline = std::nullopt,
+                   bool force_recache = false, bool keep_after_send = false, bool compress_send = false);
         IngestItem(const std::string &object_id, const std::string &url, const std::string &acquisition_id,
                    const std::optional<std::string> &obj_ingest_base_url = std::nullopt,
                    const std::optional<std::string> &obj_distribution_base_url = std::nullopt,
-                   const std::optional<time_type> &download_deadline = std::nullopt);
+                   const std::optional<time_type> &download_deadline = std::nullopt,
+                   bool force_recache = false, bool keep_after_send = false, bool compressed_send = false);
         IngestItem(const IngestItem &other);
         IngestItem(IngestItem &&other);
         virtual ~IngestItem() {};
@@ -77,6 +79,15 @@ public:
         IngestItem &deadline(const time_type &dl_deadline) { m_deadline = time_type(dl_deadline); return *this; };
         IngestItem &deadline(time_type &&dl_deadline) { m_deadline = std::move(dl_deadline); return *this; };
 
+        bool forceRecache() const { return m_forceRecache; };
+        IngestItem &forceRecache(bool force_recache) { m_forceRecache = force_recache; return *this; };
+
+        bool markAsKeepAfterSend() const { return m_markAsKeepAfterSend; };
+        IngestItem &markAsKeepAfterSend(bool keep_after_send) { m_markAsKeepAfterSend = keep_after_send; return *this; };
+
+        bool markAsCompressedSend() const { return m_markAsCompressedSend; };
+        IngestItem &markAsCompressedSend(bool compress_send) { m_markAsCompressedSend = compress_send; return *this; };
+
     private:
         std::string m_objectId;
         std::string m_url;
@@ -84,6 +95,9 @@ public:
         std::optional<std::string> m_objIngestBaseUrl;
         std::optional<std::string> m_objDistributionBaseUrl;
         std::optional<time_type> m_deadline;
+        bool m_forceRecache;
+        bool m_markAsKeepAfterSend;
+        bool m_markAsCompressedSend;
     };
 
     class PullIngestFailedEvent : public ObjectIngester::IngestFailedEvent {
@@ -97,6 +111,7 @@ public:
         PullIngestFailedEvent &operator=(const PullIngestFailedEvent &other) = delete;
         PullIngestFailedEvent &operator=(PullIngestFailedEvent &&other) = delete;
 
+        PullObjectIngester::IngestItem &item() { return m_item; };
         const PullObjectIngester::IngestItem &item() const { return m_item; };
 
         virtual Event clone() const { return PullIngestFailedEvent(*this); };
@@ -108,25 +123,31 @@ public:
     };
 
     PullObjectIngester() = delete;
-    PullObjectIngester(ObjectStore& object_store, ObjectController &controller, const std::list<IngestItem> &id_to_url_map)
-      :ObjectIngester(object_store, controller)
-      ,m_fetchList(id_to_url_map)
-      ,m_ingestItemsMutex (new std::recursive_mutex)
+    PullObjectIngester(const std::shared_ptr<ObjectStore>& object_store, ObjectController &controller,
+                       const std::list<IngestItem> &id_to_url_map)
+        :ObjectIngester(object_store, controller)
+        ,m_fetchList(id_to_url_map)
+        ,m_ingestItemsMutex (new std::recursive_mutex)
+    {
+        sortListByPolicy();
+        startWorker();
+    };
 
-    { sortListByPolicy(); startWorker(); };
-
-    PullObjectIngester(ObjectStore& object_store, ObjectController &controller, std::list<IngestItem> &&id_to_url_map)
-      :ObjectIngester(object_store, controller)
-      ,m_fetchList(std::move(id_to_url_map))
-      ,m_ingestItemsMutex (new std::recursive_mutex)
-
-    { sortListByPolicy(); startWorker();};
+    PullObjectIngester(const std::shared_ptr<ObjectStore>& object_store, ObjectController &controller, std::list<IngestItem> &&id_to_url_map)
+        :ObjectIngester(object_store, controller)
+        ,m_fetchList(std::move(id_to_url_map))
+        ,m_ingestItemsMutex (new std::recursive_mutex)
+    {
+        sortListByPolicy();
+        startWorker();
+    };
 
     virtual ~PullObjectIngester();
 
     bool fetch(const IngestItem &item);
     bool fetch(IngestItem &&item);
-    bool fetch(const std::string &object_id, const std::optional<time_type> &download_deadline);
+    bool fetch(const std::string &object_id, const std::optional<time_type> &download_deadline, bool force_recache,
+               bool keep_after_send, bool send_compressed);
 
     std::shared_ptr<Curl> curl() {return m_curl;};
     //static int client_notify_cb(int status, ogs_sbi_response_t *response, void *data);

--- a/src/mbstf/PushObjectIngester.cc
+++ b/src/mbstf/PushObjectIngester.cc
@@ -151,7 +151,7 @@ void PushObjectIngester::Request::processRequest()
         m_objectId = m_pushObjectIngester.controller().nextObjectId();
     }
 
-    m_pushObjectIngester.objectStore().addObject(m_objectId, std::move(body), std::move(metadata));
+    m_pushObjectIngester.objectStore()->addObject(m_objectId, std::move(body), std::move(metadata), true);
     m_statusCode = 200;
 }
 
@@ -169,7 +169,12 @@ void PushObjectIngester::Request::requestHandler(struct MHD_Connection *connecti
     if (m_method != "PUSH" && m_method != "PUT" && m_method != "POST") {
         setError(405, "Method Not Allowed");
     } else {
-        processRequest();
+        try {
+            processRequest();
+        } catch (std::runtime_error &ex) {
+            ogs_warn("Failed to accept pushed object: %s", ex.what());
+            setError(400, "Bad Request");
+        }
     }
 
     if (m_statusCode >= 400 && m_statusCode <= 499) {
@@ -209,17 +214,17 @@ std::string PushObjectIngester::Request::reprString() const
 
 PushObjectIngester::ObjectPushEvent *PushObjectIngester::ObjectPushEvent::makeStartEvent(const std::shared_ptr<Request> &request)
 {
-    return new PushObjectIngester::ObjectPushEvent("ObjectPushStart", request);
+    return new PushObjectIngester::ObjectPushEvent(PushObjectIngester::ObjectPushEvent::start_event_name, request);
 }
 
 PushObjectIngester::ObjectPushEvent *PushObjectIngester::ObjectPushEvent::makeBlockReceivedEvent(const std::shared_ptr<Request> &request)
 {
-    return new PushObjectIngester::ObjectPushEvent("ObjectPushBlockReceived", request);
+    return new PushObjectIngester::ObjectPushEvent(PushObjectIngester::ObjectPushEvent::block_received_event_name, request);
 }
 
 PushObjectIngester::ObjectPushEvent *PushObjectIngester::ObjectPushEvent::makeTrailersReceivedEvent(const std::shared_ptr<Request> &request)
 {
-    return new PushObjectIngester::ObjectPushEvent("ObjectPushTrailersReceived", request);
+    return new PushObjectIngester::ObjectPushEvent(PushObjectIngester::ObjectPushEvent::trailers_received_event_name, request);
 }
 
 PushObjectIngester::ObjectPushEvent::~ObjectPushEvent()

--- a/src/mbstf/PushObjectIngester.hh
+++ b/src/mbstf/PushObjectIngester.hh
@@ -126,6 +126,9 @@ public:
 
     class ObjectPushEvent : public Event {
     public:
+        constexpr static const char *start_event_name = "ObjectPushStart";
+        constexpr static const char *block_received_event_name = "ObjectPushBlockReceived";
+        constexpr static const char *trailers_received_event_name = "ObjectPushTrailersReceived";
         enum ObjectPushEventType {
             ObjectPushStart,
             ObjectPushBlockReceived,
@@ -165,17 +168,19 @@ public:
         std::shared_ptr<Request> m_request;
     };
 
-    PushObjectIngester(ObjectStore& object_store, ObjectController &controller)
-      :ObjectIngester(object_store, controller)
-      ,m_mhdDaemon(nullptr)
-      ,m_sockaddr()
-      ,m_activeRequests()
-      ,m_IPAddress()
-      ,m_domain()
-      ,m_urlPrefix()
-      ,m_port(0)
-      ,m_mtx()
-    { startWorker(); };
+    PushObjectIngester(const std::shared_ptr<ObjectStore> &object_store, ObjectController &controller)
+        :ObjectIngester(object_store, controller)
+        ,m_mhdDaemon(nullptr)
+        ,m_sockaddr()
+        ,m_activeRequests()
+        ,m_IPAddress()
+        ,m_domain()
+        ,m_urlPrefix()
+        ,m_port(0)
+        ,m_mtx()
+    {
+        startWorker();
+    };
 
     bool start();
     bool stop();

--- a/src/mbstf/mbstf.yaml.in
+++ b/src/mbstf/mbstf.yaml.in
@@ -175,6 +175,43 @@ sbi:
 #      'service-names' is always included in the URI query parameter.
 #    * That is, 'no_service_names' has no effect.
 #
+#
+
+# <Global MBSTF streaming options>
+#   manifestHandler:
+#      manifestRepetitionRate: 10s
+#
+# o This specifies the rate at which the manifest will be repeated in the stream if it is not overridden by the configuration for
+#   a specific manifest handler.
+#   The format is an integer followed by an optional unit (seconds assumed if no units).
+#   The units are:
+#     ms - Milliseconds
+#     s  - Seconds
+#     m  - Minutes
+#     h  - Hours
+#     d  - Days
+#     w  - Weeks
+#
+#   For example, to set the repetition to 10 seconds you could use any of the following:
+#     manifestRepetitionRate: 10
+#     manifestRepetitionRate: 10s
+#     manifestRepetitionRate: 10000ms
+#
+# o If this is omitted from the configuration then the manifest will not be repeated automatically
+#
+# <DASH Manifest Handler streaming options>
+#   dashManifestHandler:
+#     compressMPDOnSend: true
+#     mpdRepetitionRate: 2500ms
+#
+# o The compressMPDOnSend option, when set to true, will cause the MBSTF to send the MPD in the stream compressed with GZIP.
+#   When false or unset the MPD will be sent in plain text.
+#
+# o The mpdRepetitionRate option overrides the global MBSTF streaming manifestRepetitionRate option and takes the same format.
+#   If the MPD specifies an update period less than the repetition period then that will be used as the resend time. If the MPD
+#   update period is greater than the repetition period then the MPD will be repeated at the given interval until the update
+#   period elapses, at which point the MPD will be refetched and sent.
+#
 mbstf:
     sbi:
       - addr: 127.0.0.59
@@ -194,7 +231,11 @@ mbstf:
     serverResponseCacheControl:
       - distMaxAge: 60
         ObjectMaxAge: 60
-
+    manifestHandler:
+      manifestRepetitionRate: 10s
+    dashManifestHandler:
+      compressMPDOnSend: true
+      mpdRepetitionRate: 2000ms
 
 # nrf:
 #

--- a/src/mbstf/meson.build
+++ b/src/mbstf/meson.build
@@ -113,6 +113,8 @@ libmbstf_dist_sources = files('''
     MBSTFEventHandler.cc
     MBSTFEventHandler.hh
     MBSTFNetworkFunction.hh
+    MimeContentType.cc
+    MimeContentType.hh
     NfServer.cc
     NfServer.hh
     ObjectCarouselController.cc


### PR DESCRIPTION
Closes #66
Closes #70 
Closes #44?

This PR is quite extensive but as an overview it provides the following:
- Adds configuration options for manifest repetition times (#66)
- Adds better checking for the MIME type of received manifests (#70)
- Handles unknown manifest types by reporting an ingest error and returning the Distribution Session to the INACTIVE state (both STREAMING and CAROUSEL modes) (#70).
- Enables GZip compression of the MPD object in the FLUTE session for DASH streams (#66).
- Improves efficiency around fetching objects via HTTP (better use of the `ObjectStore` cache).
- Repeats manifests and ancillary files in DASH streams according to the configured repetition parameters or when an update of the MPD is noticed at the MPD `minimumUpdatePeriod` refresh time.
  - MPD updates at `minimumUpdatePeriod` will force a refresh with the origin server, even if the MPD is still viable in the `ObjectStore` cache.
- I think this also fixes the double MPD fetches and transmissions (#44).